### PR TITLE
dashboard: add react-mosaic-component and minimal route

### DIFF
--- a/packages/dashboard/package-lock.json
+++ b/packages/dashboard/package-lock.json
@@ -1489,6 +1489,33 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "@blueprintjs/core": {
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.41.0.tgz",
+      "integrity": "sha512-iKH/+eTzDGw8jAGCb7NvcIjpj3AIoou9wRogezOjHHylt3Ks34alkmSBIytPwj+JxBK67c31d0y0F/ppWqSvUQ==",
+      "requires": {
+        "@blueprintjs/icons": "^3.25.1",
+        "@types/dom4": "^2.0.1",
+        "classnames": "^2.2",
+        "dom4": "^2.1.5",
+        "normalize.css": "^8.0.1",
+        "popper.js": "^1.16.1",
+        "react-lifecycles-compat": "^3.0.4",
+        "react-popper": "^1.3.7",
+        "react-transition-group": "^2.9.0",
+        "resize-observer-polyfill": "^1.5.1",
+        "tslib": "~1.13.0"
+      }
+    },
+    "@blueprintjs/icons": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-3.25.1.tgz",
+      "integrity": "sha512-AppGf5IyjjKa/Zlre4pHWbDnsI7nefurXKku8Yf/B14bDAB2a8lzP6HCoTowAW4fHryTwE5Pzp9zEJYvofkUEg==",
+      "requires": {
+        "classnames": "^2.2",
+        "tslib": "~1.13.0"
+      }
+    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -1619,6 +1646,15 @@
       "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
       "requires": {
         "@hapi/hoek": "^8.3.0"
+      }
+    },
+    "@hypnosphi/create-react-context": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
+      "integrity": "sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==",
+      "requires": {
+        "gud": "^1.0.0",
+        "warning": "^4.0.3"
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -2282,6 +2318,21 @@
         }
       }
     },
+    "@react-dnd/asap": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-4.0.0.tgz",
+      "integrity": "sha512-0XhqJSc6pPoNnf8DhdsPHtUhRzZALVzYMTzRwV4VI6DJNJ/5xxfL9OQUwb8IH5/2x7lSf7nAZrnzUD+16VyOVQ=="
+    },
+    "@react-dnd/invariant": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-2.0.0.tgz",
+      "integrity": "sha512-xL4RCQBCBDJ+GRwKTFhGUW8GXa4yoDfJrPbLblc3U09ciS+9ZJXJ3Qrcs/x2IODOdIE5kQxvMmE2UKyqUictUw=="
+    },
+    "@react-dnd/shallowequal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz",
+      "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg=="
+    },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
@@ -2668,6 +2719,11 @@
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
       "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
     },
+    "@types/dom4": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dom4/-/dom4-2.0.1.tgz",
+      "integrity": "sha512-kSkVAvWmMZiCYtvqjqQEwOmvKwcH+V4uiv3qPQ8pAh1Xl39xggGEo8gHUqV4waYGHezdFw0rKBR8Jt0CrQSDZA=="
+    },
     "@types/enzyme": {
       "version": "3.10.6",
       "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.6.tgz",
@@ -2725,6 +2781,15 @@
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.7.tgz",
       "integrity": "sha512-2xtoL22/3Mv6a70i4+4RB7VgbDDORoWwjcqeNysojZA0R7NK17RbY5Gof/2QiFfJgX+KkWghbwJ+d/2SB8Ndzg=="
+    },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
     },
     "@types/html-minifier-terser": {
       "version": "5.1.1",
@@ -6045,6 +6110,21 @@
         "path-type": "^4.0.0"
       }
     },
+    "dnd-core": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-10.0.2.tgz",
+      "integrity": "sha512-PrxEjxF0+6Y1n1n1Z9hSWZ1tvnDXv9syL+BccV1r1RC08uWNsyetf8AnWmUF3NgYPwy0HKQJwTqGkZK+1NlaFA==",
+      "requires": {
+        "@react-dnd/asap": "^4.0.0",
+        "@react-dnd/invariant": "^2.0.0",
+        "redux": "^4.0.4"
+      }
+    },
+    "dnd-multi-backend": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-multi-backend/-/dnd-multi-backend-5.0.1.tgz",
+      "integrity": "sha512-BAOj6fIeGfZPA1LreehaV8mUD7Ww0EpaKqSDRrZ5mZXLWLIxFPPT3bIvpJhHUCt0+lTrOqkXu11Hudh+gHXNUA=="
+    },
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -6089,6 +6169,14 @@
         "utila": "~0.4"
       }
     },
+    "dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "dom-serializer": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
@@ -6109,6 +6197,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
+    "dom4": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/dom4/-/dom4-2.1.6.tgz",
+      "integrity": "sha512-JkCVGnN4ofKGbjf5Uvc8mmxaATIErKQKSgACdBXpsQ3fY6DlIpAyWfiBSrGkttATssbDCp3psiAKWXk5gmjycA=="
     },
     "domain-browser": {
       "version": "1.2.0",
@@ -8204,6 +8297,11 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "optional": true
     },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+    },
     "gzip-size": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
@@ -8775,6 +8873,11 @@
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/immer/-/immer-7.0.9.tgz",
       "integrity": "sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A=="
+    },
+    "immutability-helper": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-3.1.1.tgz",
+      "integrity": "sha512-Q0QaXjPjwIju/28TsugCHNEASwoCcJSyJV3uO1sOIQGI0jKgm9f41Lvz0DZj3n46cNCyAZTsEYoY4C2bVRUzyQ=="
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -11682,6 +11785,11 @@
         "sort-keys": "^1.0.0"
       }
     },
+    "normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
+    },
     "npm-bundled": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
@@ -12328,6 +12436,11 @@
       "requires": {
         "ts-pnp": "^1.1.6"
       }
+    },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "portfinder": {
       "version": "1.0.28",
@@ -22070,6 +22183,52 @@
         }
       }
     },
+    "react-dnd": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-10.0.2.tgz",
+      "integrity": "sha512-SC2Ymvntynhoqtf5zaFhZscm9xenCoMofilxPdlwUlaelAzmbl9fw82C4ZJ//+lNm3kWAKXjGDZg2/aWjKEAtg==",
+      "requires": {
+        "@react-dnd/shallowequal": "^2.0.0",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "dnd-core": "^10.0.2",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
+    "react-dnd-html5-backend": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-10.0.2.tgz",
+      "integrity": "sha512-ny17gUdInZ6PIGXdzfwPhoztRdNVVvjoJMdG80hkDBamJBeUPuNF2Wv4D3uoQJLjXssX1+i9PhBqc7EpogClwQ==",
+      "requires": {
+        "dnd-core": "^10.0.2"
+      }
+    },
+    "react-dnd-multi-backend": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-multi-backend/-/react-dnd-multi-backend-5.0.1.tgz",
+      "integrity": "sha512-E45T5xVl4CLt9QFV9ZMjWCGLyF16+B6B6FgbeZE9J5o0rvLHaCqyAJTelRDXtbSiSBPaDlN1STO86jkiD31AHA==",
+      "requires": {
+        "dnd-multi-backend": "^5.0.1",
+        "prop-types": "^15.7.2",
+        "react-dnd-preview": "^5.0.1"
+      }
+    },
+    "react-dnd-preview": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-preview/-/react-dnd-preview-5.0.1.tgz",
+      "integrity": "sha512-wwUgk8jWuO4WMOoa+GviHoZyYAiXer6vsSW2aEhpz0gsde08O+4cI+j7DG7q9vYlBnljNutdQ1WjDV0VskZ4jQ==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
+    "react-dnd-touch-backend": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/react-dnd-touch-backend/-/react-dnd-touch-backend-10.0.2.tgz",
+      "integrity": "sha512-+lW/Ern0dKyHToD0oP+Wc/ZD6l7qJazosLqbjzL7OnPlig6WxdlrHkJylOLkeAdZj41fIJJ551Lb57pIL0CcPw==",
+      "requires": {
+        "@react-dnd/invariant": "^2.0.0",
+        "dnd-core": "^10.0.2"
+      }
+    },
     "react-error-overlay": {
       "version": "6.0.8",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.8.tgz",
@@ -22116,6 +22275,48 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/react-leaflet-control/-/react-leaflet-control-2.1.2.tgz",
       "integrity": "sha512-xdheoLuLEeDGZ6/FKsnKjMYxC9BlyxsK5L5S27Dd6Z+FYP4jIa1Ekhu7UDgTV7GGSw+Yjjf8uofoheylxggB6w=="
+    },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-mosaic-component": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-mosaic-component/-/react-mosaic-component-4.1.1.tgz",
+      "integrity": "sha512-HVlLvfYQ/AKmoKvw95Orx3Qyc7SNuS/QlAy+SkAVit1g9ipzXBGYoBg7RMXP5sF5w47CgYxA+1gT+fYRVf73jA==",
+      "requires": {
+        "classnames": "^2.2.6",
+        "immutability-helper": "^3.0.1",
+        "lodash": "^4.17.11",
+        "prop-types": "^15.7.2",
+        "react-dnd": "^10.0.2",
+        "react-dnd-html5-backend": "^10.0.2",
+        "react-dnd-multi-backend": "^5.0.0",
+        "react-dnd-touch-backend": "^10.0.2",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
+      }
+    },
+    "react-popper": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.11.tgz",
+      "integrity": "sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "@hypnosphi/create-react-context": "^0.3.1",
+        "deep-equal": "^1.1.1",
+        "popper.js": "^1.14.4",
+        "prop-types": "^15.6.1",
+        "typed-styles": "^0.0.7",
+        "warning": "^4.0.2"
+      }
     },
     "react-refresh": {
       "version": "0.8.3",
@@ -22302,6 +22503,17 @@
         }
       }
     },
+    "react-transition-group": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "requires": {
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      }
+    },
     "reactour": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/reactour/-/reactour-1.18.0.tgz",
@@ -22426,6 +22638,15 @@
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
+      }
+    },
+    "redux": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
       }
     },
     "regenerate": {
@@ -22693,6 +22914,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.15.0",
@@ -30103,6 +30329,11 @@
         }
       }
     },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -30621,6 +30852,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typed-styles": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
+      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -33,6 +33,8 @@
     ]
   },
   "dependencies": {
+    "@blueprintjs/core": "^3.41.0",
+    "@blueprintjs/icons": "^3.25.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.30",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
@@ -64,6 +66,7 @@
     "react-hotkeys": "^2.0.0",
     "react-leaflet": "^2.7.0",
     "react-leaflet-control": "^2.1.1",
+    "react-mosaic-component": "^4.1.1",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^4.0.1",

--- a/packages/dashboard/src/components/app.tsx
+++ b/packages/dashboard/src/components/app.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import 'typeface-roboto';
 import appConfig from '../app-config';
 import ResourceManager from '../managers/resource-manager';
-import { DASHBOARD_ROUTE, LOGIN_ROUTE } from '../util/url';
+import { DASHBOARD_ROUTE, LOGIN_ROUTE, MOSAIC_ROUTE } from '../util/url';
 import { AppBase } from './app-base';
 import { ResourcesContext, AppConfigContext } from './app-contexts';
 import './app.css';
@@ -15,6 +15,7 @@ import { User } from './auth/user';
 import Dashboard from './dashboard/dashboard';
 import NotFoundPage from './error-pages/page-not-found';
 import { RmfApp } from './rmf-app';
+import LayoutManager from './layout-manager/layout-manager';
 
 const theme = createMuiTheme({
   palette: {
@@ -38,7 +39,7 @@ export default function App(): JSX.Element | null {
   const authenticator = appConfig.authenticator;
   const [authInitialized, setAuthInitialized] = React.useState(!!authenticator.user);
   const [user, setUser] = React.useState<User | null>(authenticator.user || null);
-  const appRoutes = [DASHBOARD_ROUTE];
+  const appRoutes = [DASHBOARD_ROUTE, MOSAIC_ROUTE];
 
   React.useEffect(() => {
     if (user) {
@@ -92,6 +93,9 @@ export default function App(): JSX.Element | null {
                       <Switch>
                         <PrivateRoute exact path={DASHBOARD_ROUTE}>
                           <Dashboard />
+                        </PrivateRoute>
+                        <PrivateRoute exact path={MOSAIC_ROUTE}>
+                          <LayoutManager />
                         </PrivateRoute>
                       </Switch>
                     </AppIntrinsics>

--- a/packages/dashboard/src/components/layout-manager/building-map-window.tsx
+++ b/packages/dashboard/src/components/layout-manager/building-map-window.tsx
@@ -1,0 +1,42 @@
+import { MosaicWindow, MosaicBranch } from 'react-mosaic-component';
+import 'react-mosaic-component/react-mosaic-component.css';
+import * as RomiCore from '@osrf/romi-js-core-interfaces';
+import React from 'react';
+import { BuildingMapContext } from '../rmf-app';
+import ScheduleVisualizer from '../schedule-visualizer';
+import { NegotiationTrajectoryResponse } from '../../managers/negotiation-status-manager';
+
+export interface BuildingMapWindowProps extends React.HTMLProps<HTMLDivElement> {
+  path: MosaicBranch[];
+}
+
+export default function BuildingMapWindow(props: BuildingMapWindowProps): React.ReactElement {
+  const buildingMap = React.useContext(BuildingMapContext);
+
+  const [negotiationTrajStore] = React.useState<Record<string, NegotiationTrajectoryResponse>>({});
+
+  const mapFloorSort = React.useCallback(
+    (levels: RomiCore.Level[]) =>
+      levels.sort((a, b) => a.elevation - b.elevation).map((x) => x.name),
+    [],
+  );
+
+  return (
+    <MosaicWindow<string>
+      path={props.path}
+      className="layout-manager-theme"
+      title="Map"
+      toolbarControls={[]}
+    >
+      {buildingMap && (
+        <>
+          <ScheduleVisualizer
+            buildingMap={buildingMap}
+            mapFloorSort={mapFloorSort}
+            negotiationTrajStore={negotiationTrajStore}
+          ></ScheduleVisualizer>
+        </>
+      )}
+    </MosaicWindow>
+  );
+}

--- a/packages/dashboard/src/components/layout-manager/layout-manager.css
+++ b/packages/dashboard/src/components/layout-manager/layout-manager.css
@@ -1,0 +1,6 @@
+#layout_manager {
+  width: 100%;
+  height: 100%;
+  margin: 0px;
+  padding: 0px;
+}

--- a/packages/dashboard/src/components/layout-manager/layout-manager.css
+++ b/packages/dashboard/src/components/layout-manager/layout-manager.css
@@ -1,6 +1,0 @@
-#layout_manager {
-  width: 100%;
-  height: 100%;
-  margin: 0px;
-  padding: 0px;
-}

--- a/packages/dashboard/src/components/layout-manager/layout-manager.tsx
+++ b/packages/dashboard/src/components/layout-manager/layout-manager.tsx
@@ -1,11 +1,20 @@
 import { Mosaic, MosaicWindow, MosaicBranch } from 'react-mosaic-component';
 import 'react-mosaic-component/react-mosaic-component.css';
-import './layout-manager.css';
+import { makeStyles } from '@material-ui/core';
 import Debug from 'debug';
 import React from 'react';
 import BuildingMapWindow from './building-map-window';
 
 const debug = Debug('LayoutManager');
+
+const useStyles = makeStyles({
+  layoutManager: {
+    width: '100%',
+    height: '100%',
+    margin: '0px',
+    padding: '0px',
+  },
+});
 
 export default function LayoutManager(_props: {}): React.ReactElement {
   debug('render');
@@ -26,8 +35,9 @@ export default function LayoutManager(_props: {}): React.ReactElement {
     }
   }
 
+  const classes = useStyles();
   return (
-    <div id="layout_manager">
+    <div className={classes.layoutManager}>
       <Mosaic<string>
         renderTile={(id, path) => create_tile(id, path)}
         resize={{ minimumPaneSizePercentage: 5 }}

--- a/packages/dashboard/src/components/layout-manager/layout-manager.tsx
+++ b/packages/dashboard/src/components/layout-manager/layout-manager.tsx
@@ -1,0 +1,48 @@
+import { Mosaic, MosaicWindow, MosaicBranch } from 'react-mosaic-component';
+import 'react-mosaic-component/react-mosaic-component.css';
+import './layout-manager.css';
+import Debug from 'debug';
+import React from 'react';
+import BuildingMapWindow from './building-map-window';
+
+const debug = Debug('LayoutManager');
+
+export default function LayoutManager(_props: {}): React.ReactElement {
+  debug('render');
+
+  function create_tile(id: string, path: MosaicBranch[]): JSX.Element {
+    if (id === 'map_2d') return <BuildingMapWindow path={path} />;
+    else {
+      return (
+        <MosaicWindow<string>
+          path={path}
+          className="layout-manager-theme"
+          title={id}
+          toolbarControls={[]}
+        >
+          <div>panel id: {id}</div>
+        </MosaicWindow>
+      );
+    }
+  }
+
+  return (
+    <div id="layout_manager">
+      <Mosaic<string>
+        renderTile={(id, path) => create_tile(id, path)}
+        resize={{ minimumPaneSizePercentage: 5 }}
+        initialValue={{
+          direction: 'row',
+          first: 'map_2d',
+          second: {
+            direction: 'column',
+            first: 'placeholder_A',
+            second: 'placeholder_B',
+            splitPercentage: 40,
+          },
+          splitPercentage: 70,
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/dashboard/src/util/url.ts
+++ b/packages/dashboard/src/util/url.ts
@@ -40,3 +40,4 @@ export function getUrl(path: string): string {
 
 export const DASHBOARD_ROUTE = BASE_PATH;
 export const LOGIN_ROUTE = normalizePath(`${BASE_PATH}/login`);
+export const MOSAIC_ROUTE = normalizePath(`${BASE_PATH}/mosaic`);


### PR DESCRIPTION
## What's new

This feature adds the `react-mosaic-component` package (and some dependencies), as well as a minimal working example on the `/mosaic` route which shows the building map in a panel, as well as two placeholder panels that can be resized and moved around.

At first I had a few more placeholder panels that had sample data, but I thought it would be easier for review small PR's, so this first one is just the "layout manager framework" PR. We can create panels one-by-one in additional PR's once we iterate on this enough to get it in.

## Self-checks

- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [X] I tried testing edge cases
- [X] I tested the behavior of the components that interact with the backend, with an e2e test
