### PR TITLE
dashboard:fix:error running last version of rmf

### DIFF
--- a/packages/dashboard/rmf-launcher.ts
+++ b/packages/dashboard/rmf-launcher.ts
@@ -77,7 +77,7 @@ export class LocalLauncher {
     }
 
     const headless = !process.env.ROMI_DASHBOARD_NO_HEADLESS;
-    const officeDemoArgs = ['launch', 'rmf_demos', 'office.launch.xml'];
+    const officeDemoArgs = ['launch', 'demos', 'office.launch.xml'];
     if (headless) {
       officeDemoArgs.push('headless:=true');
     }


### PR DESCRIPTION
Signed-off-by: Matias Bavera <matiasbavera@gmail.com>

## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

I had this error running the last version of rmf-demos:

``` bash
[start:rmf] Package 'rmf_demos' not found: "package 'rmf_demos' not found, searching: ['/home/ekumen/rmf_demos_ws/install/demos', '/home/ekumen/rmf_demos_ws/install/visualizer', '/home/ekumen/rmf_demos_ws/install/traffic_editor_assets', '/home/ekumen/rmf_demos_ws/install/traffic_editor', '/home/ekumen/rmf_demos_ws/install/test_maps', '/home/ekumen/rmf_demos_ws/install/rviz2_plugin', '/home/ekumen/rmf_demos_ws/install/ros_ign', '/home/ekumen/rmf_demos_ws/install/ros_ign_gazebo_demos', '/home/ekumen/rmf_demos_ws/install/ros_ign_image', '/home/ekumen/rmf_demos_ws/install/ros_ign_gazebo', '/home/ekumen/rmf_demos_ws/install/ros_ign_bridge', '/home/ekumen/rmf_demos_ws/install/rmf_workcell_msgs', '/home/ekumen/rmf_demos_ws/install/rmf_task_ros2', '/home/ekumen/rmf_demos_ws/install/rmf_schedule_visualizer', '/home/ekumen/rmf_demos_ws/install/rmf_fleet_adapter', '/home/ekumen/rmf_demos_ws/install/rmf_traffic_ros2', '/home/ekumen/rmf_demos_ws/install/rmf_rviz_plugin', '/home/ekumen/rmf_demos_ws/install/rmf_battery', '/home/ekumen/rmf_demos_ws/install/fleet_state_visualizer', '/home/ekumen/rmf_demos_ws/install/rmf_traffic_msgs', '/home/ekumen/rmf_demos_ws/install/rmf_demo_tasks', '/home/ekumen/rmf_demos_ws/install/rmf_demo_panel', '/home/ekumen/rmf_demos_ws/install/rmf_task_msgs', '/home/ekumen/rmf_demos_ws/install/building_systems_visualizer', '/home/ekumen/rmf_demos_ws/install/rmf_schedule_visualizer_msgs', '/home/ekumen/rmf_demos_ws/install/rmf_ignition_plugins', '/home/ekumen/rmf_demos_ws/install/rmf_demo_assets', '/home/ekumen/rmf_demos_ws/install/rmf_gazebo_plugins', '/home/ekumen/rmf_demos_ws/install/rmf_plugins_common', '/home/ekumen/rmf_demos_ws/install/building_ignition_plugins', '/home/ekumen/rmf_demos_ws/install/building_gazebo_plugins', '/home/ekumen/rmf_demos_ws/install/building_sim_common', '/home/ekumen/rmf_demos_ws/install/rmf_lift_msgs', '/home/ekumen/rmf_demos_ws/install/rmf_ingestor_msgs', '/home/ekumen/rmf_demos_ws/install/rmf_fleet_msgs', '/home/ekumen/rmf_demos_ws/install/rmf_door_msgs', '/home/ekumen/rmf_demos_ws/install/rmf_dispenser_msgs', '/home/ekumen/rmf_demos_ws/install/rmf_demos_dashboard_resources', '/home/ekumen/rmf_demos_ws/install/rmf_demo_maps', '/home/ekumen/rmf_demos_ws/install/rmf_cmake_uncrustify', '/home/ekumen/rmf_demos_ws/install/rmf_charger_msgs', '/home/ekumen/rmf_demos_ws/install/building_map_tools', '/home/ekumen/rmf_demos_ws/install/building_map_msgs', '/home/ekumen/rmf_demos_ws/install/ament_cmake_catch2', '/opt/ros/foxy']"
```

So, I replaced `rmf_demos` with `demos` as the new `rmf-demos` documentation says. https://github.com/osrf/rmf_demos#office-world

And that fixed the problem.
