### PR TITLE
example-deployment:Add fluentd and MinIO to kubernetes cluster

### DIFF
--- a/example-deployment/README.md
+++ b/example-deployment/README.md
@@ -22,6 +22,8 @@ others:
 * keycloak
 * nginx
 * postgres
+* minio
+* fluentd
 
 **NOTE: If you are using this example as a starting point for your own deployment, you must make sure that you have the proper license to use the softwares used in this example.**
 
@@ -246,45 +248,8 @@ deploy it
 .bin/minikube kubectl -- apply -f k8s/dashboard.yaml
 ```
 
-## [MinIO](https://github.com/minio/minio)
-MinIO is a High-Performance Object Storage released under Apache License v2.0. MinIO has several uses but in our case, we will use MinIO to store logs.
-
-``` bash
-# connected to internet
-docker pull minio/minio:RELEASE.2021-03-10T05-11-33Z
-
-# connected to airgap network
-docker save minio/minio:RELEASE.2021-03-10T05-11-33Z | bash -c 'eval $(.bin/minikube docker-env) && docker load'
-
-.bin/minikube kubectl -- apply -f k8s/minio.yaml
-```
-
-## FluentD
-
-Fluentd is an open source data collector for unified logging layer. Fluentd allows you to unify data collection and consumption for a better use and understanding of data.
-### Fluentd Manifests
-
-Manifests from the official fluentd [github repo](https://github.com/fluent/fluentd-kubernetes-daemonset).
-
-### Fluentd Docker
-
-Official docker image of [fluentd](https://hub.docker.com/r/fluent/fluentd/). <br/> We adjusted `fluentd` to send logs to a local storage server called MinIO.
-
-``` bash
-# connected to internet
-docker pull fluent/fluentd-kubernetes-daemonset:v1.12.2-debian-s3-1.0
-
-# connected to airgap network
-docker save fluent/fluentd-kubernetes-daemonset:v1.12.2-debian-s3-1.0 | bash -c 'eval $(.bin/minikube docker-env) && docker load'
-```
-
-### Fluentd Configmap
-
-We have 4 files in our `fluentd-configmap.yaml` :
-* `fluent.conf`: Our main config which includes all configurations we want to run.
-* `pods-fluent.conf`: `tail` config that sources all pod logs on the `kubernetes` host in the cluster.
-* `minio-fluent.conf`: `match` config to capture all logs and send them to MinIO. Every chunck of logs should have 5mb. </br>
-* `minio-fluent-dev.conf`: `match` config to capture all logs and send them to MinIO. Every chunck of logs should have 2kb for development purposes. </br>
+Capture all logs and send them to MinIO. Every chunck of logs should have 5mb. 
+* `minio-fluent-dev.conf`: `match` config to capture all logs and send them to MinIO. Every chunck of logs should have 2kb for development purposes.
 
 Let's deploy our `configmap`:
 
@@ -294,7 +259,9 @@ Let's deploy our `configmap`:
 
 ### Fluentd Daemonset
 
-Let's deploy the `daemonset`, on the kubernetes folder run:
+Let's deploy the `daemonset`,
+
+This requires internet connection, see [Deploying in an airgapped network](#deploying-in-an-airgapped-network) if you are in an airgap network.
 
 ``` bash
 .bin/minikube kubectl -- apply -f k8s/fluentd.yaml
@@ -332,17 +299,21 @@ Sit back and relax, everything will be done for you!
 
 There are certain parts that requires an internet connection to fetch the docker images and source codes, in order to deploy from within an airgapped network, you can use obtain the images first, then push them directly to minikube. For example
 
-when you have internet, run this to get the keycloak image
+when you have internet, run this to get the keycloak, MinIO and Fluentd images
 ```bash
 docker pull quay.io/keycloak/keycloak:12.0.4
+docker pull minio/minio:RELEASE.2021-03-10T05-11-33Z
+docker pull fluent/fluentd-kubernetes-daemonset:v1.12.2-debian-s3-1.0
 ```
 
-now, connect to the airgapped network and push the image to minikube
+now, connect to the airgapped network and push the images to minikube
 ```bash
 docker save quay.io/keycloak/keycloak:12.0.4 | bash -c 'eval $(.bin/minikube docker-env) && docker load'
+docker save minio/minio:RELEASE.2021-03-10T05-11-33Z | bash -c 'eval $(.bin/minikube docker-env) && docker load'
+docker save fluent/fluentd-kubernetes-daemonset:v1.12.2-debian-s3-1.0 | bash -c 'eval $(.bin/minikube docker-env) && docker load'
 ```
 
-now you can deploy keycloak without require access to the internet
+now you can deploy keycloak, MinIO and Fluentd without require access to the internet
 
 If connection to the internet from the same PC is not possible, you can use `docker save` to save the image into a tarball, then transfer it to the minikube PC through whatever method possible (thumbdrives, cds etc) and use `docker load` to load the image. Then you can use `.bin/minikube load` to push it into minikube.
 

--- a/example-deployment/k8s/fluentd-configmap.yaml
+++ b/example-deployment/k8s/fluentd-configmap.yaml
@@ -40,8 +40,8 @@ data:
       <buffer time>
         @type file
         path /var/log/fluent/s3
-        timekey 1m                # Flush the accumulated chunks every hour
-        timekey_wait 1s             # Wait for 60 seconds before flushing
+        timekey 1m                # Flush the accumulated chunks every 1 min
+        timekey_wait 1s             # Wait for 1 seconds before flushing
         timekey_use_utc true        # Use this option if you prefer UTC timestamps
         chunk_limit_size 2k       # The maximum size of each chunk
       </buffer>

--- a/example-deployment/k8s/fluentd-configmap.yaml
+++ b/example-deployment/k8s/fluentd-configmap.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentd-config
+data:
+  fluent.conf: |-
+    ################################################################
+    # This source gets all logs from local docker host
+    @include pods-fluent.conf
+    @include minio-fluent-dev.conf
+    # Use this configuration for production
+    # @include minio-fluent.conf
+  # This is for running fluentd in the cloud
+  pods-fluent.conf: |-
+    <source>
+      @type tail
+      read_from_head true
+      tag minio.s3.*
+      path /var/log/containers/*.log
+      pos_file /var/log/fluent/fluentd-all-containers.log.pos
+      exclude_path ["/var/log/containers/fluent*"]
+      <parse>
+        @type kubernetes
+        @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"
+        time_format %Y-%m-%dT%H:%M:%S.%NZ
+      </parse>
+    </source>
+
+  minio-fluent-dev.conf: |-
+    <match minio.s3.**>
+      @type s3
+      aws_key_id "#{ENV['MINIO_ACCESS_KEY']}" # The access key for Minio
+      aws_sec_key "#{ENV['MINIO_SECRET_KEY']}" # The secret key for Minio
+      s3_bucket test         # The bucket to store the log data
+      s3_endpoint http://minio-service:9000/  # The endpoint URL
+      # s3_region us-east-1           # See the region settings of your Minio server
+      path logs/                    # This prefix is added to each file
+      force_path_style true         # This prevents AWS SDK from breaking endpoint URL
+      time_slice_format %Y%m%d%H%M  # This timestamp is added to each file name
+      <buffer time>
+        @type file
+        path /var/log/fluent/s3
+        timekey 1m                # Flush the accumulated chunks every hour
+        timekey_wait 1s             # Wait for 60 seconds before flushing
+        timekey_use_utc true        # Use this option if you prefer UTC timestamps
+        chunk_limit_size 2k       # The maximum size of each chunk
+      </buffer>
+    </match>
+
+  minio-fluent.conf: |-
+    <match minio.s3.**>
+      @type s3
+      aws_key_id "#{ENV['MINIO_ACCESS_KEY']}" # The access key for Minio
+      aws_sec_key "#{ENV['MINIO_SECRET_KEY']}" # The secret key for Minio
+      s3_bucket test         # The bucket to store the log data
+      s3_endpoint http://minio-service:9000/  # The endpoint URL
+      # s3_region us-east-1           # See the region settings of your Minio server
+      path logs/                    # This prefix is added to each file
+      force_path_style true         # This prevents AWS SDK from breaking endpoint URL
+      time_slice_format %Y%m%d%H%M  # This timestamp is added to each file name
+      <buffer time>
+        @type file
+        path /var/log/fluent/s3
+        timekey 60m                # Flush the accumulated chunks every hour
+        timekey_wait 1m             # Wait for 60 seconds before flushing
+        timekey_use_utc true        # Use this option if you prefer UTC timestamps
+        chunk_limit_size 5mb       # The maximum size of each chunk
+      </buffer>
+    </match>

--- a/example-deployment/k8s/fluentd-configmap.yaml
+++ b/example-deployment/k8s/fluentd-configmap.yaml
@@ -7,9 +7,9 @@ data:
     ################################################################
     # This source gets all logs from local docker host
     @include pods-fluent.conf
-    @include minio-fluent-dev.conf
+    # @include minio-fluent-dev.conf
     # Use this configuration for production
-    # @include minio-fluent.conf
+    @include minio-fluent.conf
   # This is for running fluentd in the cloud
   pods-fluent.conf: |-
     <source>

--- a/example-deployment/k8s/fluentd.yaml
+++ b/example-deployment/k8s/fluentd.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd
+---
+# to set permission and groups 
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fluentd
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fluentd
+roleRef:
+  kind: ClusterRole
+  name: fluentd
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: fluentd
+  namespace: default
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluentd
+  namespace: default
+  labels:
+    k8s-app: fluentd-logging
+    version: v1
+spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-logging
+      version: v1
+  template:
+    metadata:
+      labels:
+        k8s-app: fluentd-logging
+        version: v1
+    spec:
+      serviceAccount: fluentd
+      serviceAccountName: fluentd
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: fluentd
+        imagePullPolicy: "Always"
+        image: fluent/fluentd-kubernetes-daemonset:v1.12.2-debian-s3-1.0
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: fluentd-config
+          mountPath: /fluentd/etc
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        env:
+        # FIXME: This should be on k8s secrets.
+        # MinIO access key and secret key
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: fluentd-config
+        configMap:
+          name: fluentd-config
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers

--- a/example-deployment/k8s/fluentd.yaml
+++ b/example-deployment/k8s/fluentd.yaml
@@ -60,7 +60,6 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd
-        imagePullPolicy: "Always"
         image: fluent/fluentd-kubernetes-daemonset:v1.12.2-debian-s3-1.0
         resources:
           limits:

--- a/example-deployment/k8s/minio.yaml
+++ b/example-deployment/k8s/minio.yaml
@@ -1,3 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # This name uniquely identifies the service
+  name: minio-service
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    # Looks for labels `app:minio` in the namespace and applies the spec
+    app: minio
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  # This name uniquely identifies the PVC. This is used in deployment.
+  name: minio-pv-claim
+spec:
+  # Read more about access modes here: http://kubernetes.io/docs/user-guide/persistent-volumes/#access-modes
+  accessModes:
+    # The volume is mounted as read-write by a single node
+    - ReadWriteOnce
+  resources:
+    # This is the request for storage. Should be available in the cluster.
+    requests:
+      storage: 10Gi
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -64,38 +97,7 @@ spec:
           initialDelaySeconds: 120
           periodSeconds: 20
 ---
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  # This name uniquely identifies the PVC. This is used in deployment.
-  name: minio-pv-claim
-spec:
-  # Read more about access modes here: http://kubernetes.io/docs/user-guide/persistent-volumes/#access-modes
-  accessModes:
-    # The volume is mounted as read-write by a single node
-    - ReadWriteOnce
-  resources:
-    # This is the request for storage. Should be available in the cluster.
-    requests:
-      storage: 10Gi
----
 
-apiVersion: v1
-kind: Service
-metadata:
-  # This name uniquely identifies the service
-  name: minio-service
-spec:
-  type: LoadBalancer
-  ports:
-    - port: 9000
-      targetPort: 9000
-      protocol: TCP
-  selector:
-    # Looks for labels `app:minio` in the namespace and applies the spec
-    app: minio
-
----
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/example-deployment/k8s/minio.yaml
+++ b/example-deployment/k8s/minio.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  # This name uniquely identifies the Deployment
+  name: minio
+spec:
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  strategy:
+    # Specifies the strategy used to replace old Pods by new ones
+    # Refer: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        # This label is used as a selector in Service definition
+        app: minio
+    spec:
+      # Volumes used by this deployment
+      volumes:
+      - name: data
+        # This volume is based on PVC
+        persistentVolumeClaim:
+          # Name of the PVC created earlier
+          claimName: minio-pv-claim
+      containers:
+      - name: minio
+        # Volume mounts for this container
+        volumeMounts:
+        # Volume 'data' is mounted to path '/data'
+        - name: data 
+          mountPath: "/data"
+        # Pulls the lastest Minio image from Docker Hub
+        image: minio/minio:RELEASE.2021-03-10T05-11-33Z
+        args:
+        - server
+        - /data
+        env:
+        # FIXME: This should be on k8s secrets.
+        # MinIO access key and secret key
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        ports:
+        - containerPort: 9000
+        # Readiness probe detects situations when MinIO server instance
+        # is not ready to accept traffic. Kubernetes doesn't forward
+        # traffic to the pod while readiness checks fail.
+        readinessProbe:
+          httpGet:
+            path: /minio/health/ready
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  # This name uniquely identifies the PVC. This is used in deployment.
+  name: minio-pv-claim
+spec:
+  # Read more about access modes here: http://kubernetes.io/docs/user-guide/persistent-volumes/#access-modes
+  accessModes:
+    # The volume is mounted as read-write by a single node
+    - ReadWriteOnce
+  resources:
+    # This is the request for storage. Should be available in the cluster.
+    requests:
+      storage: 10Gi
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  # This name uniquely identifies the service
+  name: minio-service
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    # Looks for labels `app:minio` in the namespace and applies the spec
+    app: minio

--- a/example-deployment/k8s/minio.yaml
+++ b/example-deployment/k8s/minio.yaml
@@ -94,3 +94,26 @@ spec:
   selector:
     # Looks for labels `app:minio` in the namespace and applies the spec
     app: minio
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minio-ingress
+  labels:
+    app: minio
+spec:
+  tls:
+    - hosts:
+      - example.com
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - path: /minio
+            pathType: Prefix
+            backend:
+              service:
+                name: minio-service
+                port:
+                  number: 9000


### PR DESCRIPTION
## What's new
Related to #281

* Updated Readme with installation instructions of Fluentd and Minio
* Created a Fluentd configmap file for Fluentd and a deploy file.
* Created a MinIO deploy file with an ingress on `example.com/minio`
* Fluentd collects all logs and sends those logs to MinIO where are stored in chunks of 5mb. 

![image](https://user-images.githubusercontent.com/11761240/114312894-4eb8d100-9ac2-11eb-9168-bc6e2355ca31.png)

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

## Self-checks

- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
