### PR TITLE
Fix reporting auth problem

### DIFF
--- a/example-deployment/k8s/fluentd-configmap.yaml
+++ b/example-deployment/k8s/fluentd-configmap.yaml
@@ -112,6 +112,11 @@ data:
       <buffer>
         flush_interval 10s
       </buffer>
+      <auth>
+        method basic
+        username "#{ENV['FLUENTD_USER']}"
+        password "#{ENV['FLUENTD_PASSWORD']}"
+      </auth>
     </match>
 
   reporting-server-all-logs.conf: |-
@@ -127,4 +132,9 @@ data:
       <buffer>
         flush_interval 10s
       </buffer>
+      <auth>
+        method basic
+        username "#{ENV['FLUENTD_USER']}"
+        password "#{ENV['FLUENTD_PASSWORD']}"
+      </auth>
     </match>

--- a/example-deployment/k8s/fluentd.yaml
+++ b/example-deployment/k8s/fluentd.yaml
@@ -82,6 +82,10 @@ spec:
           value: "minio"
         - name: MINIO_SECRET_KEY
           value: "minio123"
+        - name: FLUENTD_USER
+          value: "fluentd"
+        - name: FLUENTD_PASSWORD
+          value: "fluentd123"
       terminationGracePeriodSeconds: 30
       volumes:
       - name: fluentd-config

--- a/example-deployment/k8s/reporting-server.yaml
+++ b/example-deployment/k8s/reporting-server.yaml
@@ -105,6 +105,11 @@ spec:
           env:
             - name: RMF_REPORT_REST_SERVER_CONFIG
               value: /reporting-server-config/reporting_server_config.py
+            # FIXME: This should be on k8s secrets.
+            - name: FLUENTD_USER
+              value: "fluentd"
+            - name: FLUENTD_PASSWORD
+              value: "fluentd123"
           volumeMounts:
             - mountPath: /jwt-configmap
               name: jwt-pub-key

--- a/example-deployment/reporting_server_config.py
+++ b/example-deployment/reporting_server_config.py
@@ -9,6 +9,7 @@ config[
     "db_url"
 ] = "postgres://reporting-server:reporting-server@reporting-server-db/reporting-server"
 config["public_url"] = "https://example.com/logserver/api/v1"
+config["basic_auth"] = True
 config["log_level"] = "INFO"
 config["jwt_public_key"] = "/jwt-configmap/jwt-pub-key.pub"
 config[

--- a/packages/reporting-server/dependencies/__init__.py
+++ b/packages/reporting-server/dependencies/__init__.py
@@ -1,2 +1,3 @@
 from .auth import auth_scheme, authenticator
+from .basic_auth import basic_auth_scheme
 from .logging import logger

--- a/packages/reporting-server/dependencies/basic_auth.py
+++ b/packages/reporting-server/dependencies/basic_auth.py
@@ -4,7 +4,7 @@ from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from rest_server.app_config import app_config
 from rest_server.authenticator import AuthenticationError, BasicAuthenticator
 
-if app_config.jwt_public_key:
+if app_config.basic_auth:
     authenticator = BasicAuthenticator()
 
     security = HTTPBasic()

--- a/packages/reporting-server/dependencies/basic_auth.py
+++ b/packages/reporting-server/dependencies/basic_auth.py
@@ -1,0 +1,24 @@
+from dependencies.logging import logger
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from rest_server.app_config import app_config
+from rest_server.authenticator import AuthenticationError, BasicAuthenticator
+
+if app_config.jwt_public_key:
+    authenticator = BasicAuthenticator()
+
+    security = HTTPBasic()
+
+    def basic_auth_scheme(credentials: HTTPBasicCredentials = Depends(security)):
+        try:
+            authenticator.verify_credentials(credentials)
+        except AuthenticationError as e:
+            raise HTTPException(401, str(e)) from e
+
+
+else:
+    logger.warning("basic authentication is disabled")
+    authenticator = None
+
+    def basic_auth_scheme():
+        return None  # no authentication

--- a/packages/reporting-server/dependencies/basic_auth.py
+++ b/packages/reporting-server/dependencies/basic_auth.py
@@ -2,23 +2,21 @@ from dependencies.logging import logger
 from fastapi import Depends, HTTPException
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from rest_server.app_config import app_config
-from rest_server.authenticator import AuthenticationError, BasicAuthenticator
+from rest_server.authenticator import AuthenticationError, verify_basic_credentials
 
 if app_config.basic_auth:
-    authenticator = BasicAuthenticator()
 
     security = HTTPBasic()
 
     def basic_auth_scheme(credentials: HTTPBasicCredentials = Depends(security)):
         try:
-            authenticator.verify_credentials(credentials)
+            verify_basic_credentials(credentials)
         except AuthenticationError as e:
             raise HTTPException(401, str(e)) from e
 
 
 else:
     logger.warning("basic authentication is disabled")
-    authenticator = None
 
     def basic_auth_scheme():
         return None  # no authentication

--- a/packages/reporting-server/rest_server/app.py
+++ b/packages/reporting-server/rest_server/app.py
@@ -5,7 +5,7 @@ import logging
 import os
 import sys
 
-from dependencies import auth_scheme, logger
+from dependencies import auth_scheme, basic_auth_scheme, logger
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from rest_server.routers import log_router, report_router
@@ -24,9 +24,7 @@ else:
 
 logger.info("started app")
 
-app = FastAPI(
-    dependencies=[Depends(auth_scheme)],
-)
+app = FastAPI()
 
 app.add_middleware(
     CORSMiddleware,
@@ -36,8 +34,15 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.include_router(log_router, prefix="/log", tags=["log"])
-app.include_router(report_router, prefix="/report", tags=["report"])
+app.include_router(
+    log_router, prefix="/log", tags=["log"], dependencies=[Depends(basic_auth_scheme)]
+)
+app.include_router(
+    report_router,
+    prefix="/report",
+    tags=["report"],
+    dependencies=[Depends(auth_scheme)],
+)
 
 register_tortoise(
     app,

--- a/packages/reporting-server/rest_server/app_config.py
+++ b/packages/reporting-server/rest_server/app_config.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 @dataclass
 class AppConfig:
+    basic_auth: bool
     host: str
     port: int
     db_url: str

--- a/packages/reporting-server/rest_server/authenticator.py
+++ b/packages/reporting-server/rest_server/authenticator.py
@@ -45,7 +45,7 @@ class BasicAuthenticator:
                 credentials.username, os.environ["FLUENTD_USER"]
             )
             correct_password = secrets.compare_digest(
-                credentials.password, os.environ["FLUENTD_USER"]
+                credentials.password, os.environ["FLUENTD_PASSWORD"]
             )
         except Exception as e:
             raise AuthenticationError(str(e)) from e

--- a/packages/reporting-server/rest_server/authenticator.py
+++ b/packages/reporting-server/rest_server/authenticator.py
@@ -1,4 +1,8 @@
+import os
+import secrets
+
 import jwt
+from fastapi.security import HTTPBasicCredentials
 
 from .app_config import app_config
 
@@ -27,3 +31,26 @@ class JwtAuthenticator:
             )
         except jwt.InvalidTokenError as e:
             raise AuthenticationError(str(e)) from e
+
+
+class BasicAuthenticator:
+    """
+    Authenticates with a Basic authentication method, the client must send an auth params with
+    a "user" and "password".
+    """
+
+    def verify_credentials(self, credentials: HTTPBasicCredentials):
+        try:
+            correct_username = secrets.compare_digest(
+                credentials.username, os.environ["FLUENTD_USER"]
+            )
+            correct_password = secrets.compare_digest(
+                credentials.password, os.environ["FLUENTD_USER"]
+            )
+        except Exception as e:
+            raise AuthenticationError(str(e)) from e
+
+        if not (correct_username and correct_password):
+            raise AuthenticationError("Incorrect email or password")
+
+        return credentials.username

--- a/packages/reporting-server/rest_server/authenticator.py
+++ b/packages/reporting-server/rest_server/authenticator.py
@@ -33,24 +33,18 @@ class JwtAuthenticator:
             raise AuthenticationError(str(e)) from e
 
 
-class BasicAuthenticator:
-    """
-    Authenticates with a Basic authentication method, the client must send an auth params with
-    a "user" and "password".
-    """
+def verify_basic_credentials(credentials: HTTPBasicCredentials):
+    try:
+        correct_username = secrets.compare_digest(
+            credentials.username, os.environ["FLUENTD_USER"]
+        )
+        correct_password = secrets.compare_digest(
+            credentials.password, os.environ["FLUENTD_PASSWORD"]
+        )
+    except Exception as e:
+        raise AuthenticationError(str(e)) from e
 
-    def verify_credentials(self, credentials: HTTPBasicCredentials):
-        try:
-            correct_username = secrets.compare_digest(
-                credentials.username, os.environ["FLUENTD_USER"]
-            )
-            correct_password = secrets.compare_digest(
-                credentials.password, os.environ["FLUENTD_PASSWORD"]
-            )
-        except Exception as e:
-            raise AuthenticationError(str(e)) from e
+    if not (correct_username and correct_password):
+        raise AuthenticationError("Incorrect email or password")
 
-        if not (correct_username and correct_password):
-            raise AuthenticationError("Incorrect email or password")
-
-        return credentials.username
+    return credentials.username

--- a/packages/reporting-server/rest_server/default_config.py
+++ b/packages/reporting-server/rest_server/default_config.py
@@ -12,6 +12,8 @@ config = {
     "log_level": "INFO",  # https://docs.python.org/3.8/library/logging.html#levels
     # path to a PEM encoded RSA public key which is used to verify JWT tokens, if the path is relative, it is based on the working dir.
     "jwt_public_key": None,
+    # requires basic auth for fluentd endpoints
+    "basic_auth": False,
     # url to the oidc endpoint, used to authenticate rest requests, it should point to the well known endpoint, e.g.
     # http://localhost:8080/auth/realms/rmf-web/.well-known/openid-configuration.
     # NOTE: This is ONLY used for documentation purposes, the "jwt_public_key" will be the

--- a/packages/reporting/src/components/report-dashboard.tsx
+++ b/packages/reporting/src/components/report-dashboard.tsx
@@ -16,6 +16,9 @@ import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 
 import { ReportContainer, Reports } from './report-list';
 import { ExpandableMultilevelMenuProps, MultiLevelMenu } from 'react-components';
+import { Menu, MenuItem } from '@material-ui/core';
+import { AuthenticatorContext } from './auth-contexts';
+import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 
 const drawerWidth = 240;
 
@@ -74,6 +77,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     }),
     marginLeft: 0,
   },
+  toolbarTitle: {
+    flexGrow: 1,
+  },
 }));
 
 export interface ReportDashboardProps {
@@ -87,6 +93,7 @@ export const ReportDashboard = (props: ReportDashboardProps) => {
   const theme = useTheme();
   const [open, setOpen] = React.useState(true);
   const [currentReport, setCurrentReport] = React.useState(Reports.queryAllLogs);
+  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
 
   const setReport = React.useCallback(
     (report: Reports) => {
@@ -102,6 +109,16 @@ export const ReportDashboard = (props: ReportDashboardProps) => {
   const handleDrawerClose = () => {
     setOpen(false);
   };
+
+  const authenticator = React.useContext(AuthenticatorContext);
+
+  async function handleLogout(): Promise<void> {
+    try {
+      await authenticator.logout();
+    } catch (e) {
+      console.error(`error logging out: ${e.message}`);
+    }
+  }
 
   return (
     <div className={classes.root}>
@@ -122,9 +139,39 @@ export const ReportDashboard = (props: ReportDashboardProps) => {
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" noWrap>
+          <Typography variant="h6" className={classes.toolbarTitle}>
             Reports
           </Typography>
+          {authenticator.user && (
+            <>
+              <IconButton
+                id="user-btn"
+                aria-label={'user-btn'}
+                color="inherit"
+                onClick={(event) => setAnchorEl(event.currentTarget)}
+              >
+                <AccountCircleIcon />
+              </IconButton>
+              <Menu
+                anchorEl={anchorEl}
+                getContentAnchorEl={null}
+                anchorOrigin={{
+                  vertical: 'bottom',
+                  horizontal: 'right',
+                }}
+                transformOrigin={{
+                  vertical: 'top',
+                  horizontal: 'right',
+                }}
+                open={!!anchorEl}
+                onClose={() => setAnchorEl(null)}
+              >
+                <MenuItem id="logout-btn" onClick={handleLogout}>
+                  Logout
+                </MenuItem>
+              </Menu>
+            </>
+          )}
         </Toolbar>
       </AppBar>
       <Drawer

--- a/packages/reporting/src/components/reports/all-logs-report.tsx
+++ b/packages/reporting/src/components/reports/all-logs-report.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import axios from 'axios';
 import { LogManagement, LogQueryPayload, LogRowsType } from 'react-components';
 import appConfig from '../../app-config';
+import { AuthenticatorContext } from '../auth-contexts';
 
 const AllLogsReport = () => {
+  const authenticator = React.useContext(AuthenticatorContext);
   const getLogs = async (params: LogQueryPayload): Promise<LogRowsType> => {
     try {
       const response = await axios.get(`${appConfig.reportingServerUrl}/report/raw_logs/`, {
@@ -13,6 +15,9 @@ const AllLogsReport = () => {
           logLabel: params.logLabel,
           logLevel: params.logLevel,
           offset: params.offset,
+        },
+        headers: {
+          Authorization: 'Bearer ' + authenticator.token,
         },
       });
       return response.data as LogRowsType;

--- a/packages/reporting/src/components/reports/dispenser-state-report.tsx
+++ b/packages/reporting/src/components/reports/dispenser-state-report.tsx
@@ -1,28 +1,21 @@
 import React from 'react';
-import axios from 'axios';
 import {
   DefaultReportQueryPayload,
   DispenserStateReport,
   DispenserStateRowsType,
 } from 'react-components';
 import appConfig from '../../app-config';
+import { AuthenticatorContext } from '../auth-contexts';
+import { getLogData } from './utils';
 
 const DispenserStateReportConfig = () => {
+  const authenticator = React.useContext(AuthenticatorContext);
   const getLogs = async (params: DefaultReportQueryPayload): Promise<DispenserStateRowsType> => {
-    try {
-      const response = await axios.get(`${appConfig.reportingServerUrl}/report/dispenser_state/`, {
-        params: {
-          toLogDate: params.toLogDate ? params.toLogDate.format() : null,
-          fromLogDate: params.fromLogDate ? params.fromLogDate.format() : null,
-          offset: params.offset,
-          limit: params.limit,
-        },
-      });
-      return response.data as DispenserStateRowsType;
-    } catch (error) {
-      console.error(error);
-      return [];
-    }
+    return (await getLogData(
+      `${appConfig.reportingServerUrl}/report/dispenser_state/`,
+      params,
+      authenticator.token,
+    )) as DispenserStateRowsType;
   };
 
   return <DispenserStateReport getLogs={getLogs} />;

--- a/packages/reporting/src/components/reports/door-state-report.tsx
+++ b/packages/reporting/src/components/reports/door-state-report.tsx
@@ -1,24 +1,17 @@
 import React from 'react';
-import axios from 'axios';
 import { DefaultReportQueryPayload, DoorStateReport, DoorStateRowsType } from 'react-components';
 import appConfig from '../../app-config';
+import { AuthenticatorContext } from '../auth-contexts';
+import { getLogData } from './utils';
 
 const DoorStateReportConfig = () => {
+  const authenticator = React.useContext(AuthenticatorContext);
   const getLogs = async (params: DefaultReportQueryPayload): Promise<DoorStateRowsType> => {
-    try {
-      const response = await axios.get(`${appConfig.reportingServerUrl}/report/door_state/`, {
-        params: {
-          toLogDate: params.toLogDate ? params.toLogDate.format() : null,
-          fromLogDate: params.fromLogDate ? params.fromLogDate.format() : null,
-          offset: params.offset,
-          limit: params.limit,
-        },
-      });
-      return response.data as DoorStateRowsType;
-    } catch (error) {
-      console.error(error);
-      return [];
-    }
+    return (await getLogData(
+      `${appConfig.reportingServerUrl}/report/door_state/`,
+      params,
+      authenticator.token,
+    )) as DoorStateRowsType;
   };
 
   return <DoorStateReport getLogs={getLogs} />;

--- a/packages/reporting/src/components/reports/fleet-state-report.tsx
+++ b/packages/reporting/src/components/reports/fleet-state-report.tsx
@@ -1,24 +1,17 @@
 import React from 'react';
-import axios from 'axios';
 import { DefaultReportQueryPayload, FleetStateReport, FleetStateRowsType } from 'react-components';
 import appConfig from '../../app-config';
+import { AuthenticatorContext } from '../auth-contexts';
+import { getLogData } from './utils';
 
 const FleetStateReportConfig = () => {
+  const authenticator = React.useContext(AuthenticatorContext);
   const getLogs = async (params: DefaultReportQueryPayload): Promise<FleetStateRowsType> => {
-    try {
-      const response = await axios.get(`${appConfig.reportingServerUrl}/report/fleet_state/`, {
-        params: {
-          toLogDate: params.toLogDate ? params.toLogDate.format() : null,
-          fromLogDate: params.fromLogDate ? params.fromLogDate.format() : null,
-          offset: params.offset,
-          limit: params.limit,
-        },
-      });
-      return response.data as FleetStateRowsType;
-    } catch (error) {
-      console.error(error);
-      return [];
-    }
+    return (await getLogData(
+      `${appConfig.reportingServerUrl}/report/fleet_state/`,
+      params,
+      authenticator.token,
+    )) as FleetStateRowsType;
   };
 
   return <FleetStateReport getLogs={getLogs} />;

--- a/packages/reporting/src/components/reports/health-report.tsx
+++ b/packages/reporting/src/components/reports/health-report.tsx
@@ -1,24 +1,17 @@
 import React from 'react';
-import axios from 'axios';
 import { DefaultReportQueryPayload, HealthReport, HealthRowsType } from 'react-components';
 import appConfig from '../../app-config';
+import { AuthenticatorContext } from '../auth-contexts';
+import { getLogData } from './utils';
 
 const HealthReportConfig = () => {
+  const authenticator = React.useContext(AuthenticatorContext);
   const getLogs = async (params: DefaultReportQueryPayload): Promise<HealthRowsType> => {
-    try {
-      const response = await axios.get(`${appConfig.reportingServerUrl}/report/health/`, {
-        params: {
-          toLogDate: params.toLogDate ? params.toLogDate.format() : null,
-          fromLogDate: params.fromLogDate ? params.fromLogDate.format() : null,
-          offset: params.offset,
-          limit: params.limit,
-        },
-      });
-      return response.data as HealthRowsType;
-    } catch (error) {
-      console.error(error);
-      return [];
-    }
+    return (await getLogData(
+      `${appConfig.reportingServerUrl}/report/health/`,
+      params,
+      authenticator.token,
+    )) as HealthRowsType;
   };
 
   return <HealthReport getLogs={getLogs} />;

--- a/packages/reporting/src/components/reports/ingestor-state-report.tsx
+++ b/packages/reporting/src/components/reports/ingestor-state-report.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import axios from 'axios';
 import {
   DefaultReportQueryPayload,
   IngestorStateReport,

--- a/packages/reporting/src/components/reports/ingestor-state-report.tsx
+++ b/packages/reporting/src/components/reports/ingestor-state-report.tsx
@@ -6,23 +6,17 @@ import {
   IngestorStateRowsType,
 } from 'react-components';
 import appConfig from '../../app-config';
+import { AuthenticatorContext } from '../auth-contexts';
+import { getLogData } from './utils';
 
 const IngestorStateReportConfig = () => {
+  const authenticator = React.useContext(AuthenticatorContext);
   const getLogs = async (params: DefaultReportQueryPayload): Promise<IngestorStateRowsType> => {
-    try {
-      const response = await axios.get(`${appConfig.reportingServerUrl}/report/ingestor_state/`, {
-        params: {
-          toLogDate: params.toLogDate ? params.toLogDate.format() : null,
-          fromLogDate: params.fromLogDate ? params.fromLogDate.format() : null,
-          offset: params.offset,
-          limit: params.limit,
-        },
-      });
-      return response.data as IngestorStateRowsType;
-    } catch (error) {
-      console.error(error);
-      return [];
-    }
+    return (await getLogData(
+      `${appConfig.reportingServerUrl}/report/ingestor/`,
+      params,
+      authenticator.token,
+    )) as IngestorStateRowsType;
   };
 
   return <IngestorStateReport getLogs={getLogs} />;

--- a/packages/reporting/src/components/reports/lift-state-report.tsx
+++ b/packages/reporting/src/components/reports/lift-state-report.tsx
@@ -1,24 +1,17 @@
 import React from 'react';
-import axios from 'axios';
 import { DefaultReportQueryPayload, LiftStateReport, LiftStateRowsType } from 'react-components';
 import appConfig from '../../app-config';
+import { getLogData } from './utils';
+import { AuthenticatorContext } from '../auth-contexts';
 
 const LiftStateReportConfig = () => {
+  const authenticator = React.useContext(AuthenticatorContext);
   const getLogs = async (params: DefaultReportQueryPayload): Promise<LiftStateRowsType> => {
-    try {
-      const response = await axios.get(`${appConfig.reportingServerUrl}/report/lift_state/`, {
-        params: {
-          toLogDate: params.toLogDate ? params.toLogDate.format() : null,
-          fromLogDate: params.fromLogDate ? params.fromLogDate.format() : null,
-          offset: params.offset,
-          limit: params.limit,
-        },
-      });
-      return response.data as LiftStateRowsType;
-    } catch (error) {
-      console.error(error);
-      return [];
-    }
+    return (await getLogData(
+      `${appConfig.reportingServerUrl}/report/lift_state/`,
+      params,
+      authenticator.token,
+    )) as LiftStateRowsType;
   };
 
   return <LiftStateReport getLogs={getLogs} />;

--- a/packages/reporting/src/components/reports/utils.ts
+++ b/packages/reporting/src/components/reports/utils.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+import { DefaultReportQueryPayload } from 'react-components';
+
+export const getLogData = async (
+  url: string,
+  params: DefaultReportQueryPayload,
+  token: string | undefined | null,
+) => {
+  try {
+    const response = await axios.get(url, {
+      params: {
+        toLogDate: params.toLogDate ? params.toLogDate.format() : null,
+        fromLogDate: params.fromLogDate ? params.fromLogDate.format() : null,
+        offset: params.offset,
+        limit: params.limit,
+      },
+      headers: {
+        Authorization: 'Bearer ' + token,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+};


### PR DESCRIPTION
## What's new

FluentD only supports Basic auth, so the two endpoints that FluentD uses to send data to the reporting server has BasicAuth, the rest of the endpoints (that are accessible from the UI) are working with tokens.

* Created a new BasicAutorization class. I'm using secrets as suggested here (https://fastapi.tiangolo.com/advanced/security/http-basic-auth/#fix-it-with-secretscompare_digest).
* Added tokens to reports

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

## Self-checks

- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
