### PR TITLE
reporting:server: Fix all-logs report are sorted by date desc

### DIFF
--- a/packages/react-components/lib/reports/log-management/custom-lookup-filter.tsx
+++ b/packages/react-components/lib/reports/log-management/custom-lookup-filter.tsx
@@ -23,7 +23,7 @@ const MenuProps = {
 
 export interface CustomLookupFilterParserProps {
   // Prop RowData from material-table is not exported so unknown
-  columnDef: Column<{ level: string; message: string; timestamp: string }>;
+  columnDef: Column<{ level: string; message: string; created: string }>;
   onFilterChanged: (rowId: string, value: string | number | unknown) => void;
 }
 

--- a/packages/react-components/lib/reports/log-management/log-table.tsx
+++ b/packages/react-components/lib/reports/log-management/log-table.tsx
@@ -5,7 +5,7 @@ import { makeStyles, Typography } from '@material-ui/core';
 import moment from 'moment';
 import { materialTableIcons } from '../../material-table-icons';
 
-export type LogRowsType = { level: string; message: string; timestamp: string }[];
+export type LogRowsType = { level: string; message: string; created: string }[];
 
 export interface LogTableProps {
   rows: LogRowsType | [];
@@ -88,7 +88,7 @@ export const LogTable = (props: LogTableProps): React.ReactElement => {
           lookup: logLevels as Column<{
             level: string;
             message: string;
-            timestamp: string;
+            created: string;
           }>['lookup'],
           filterComponent: (props) => <CustomLookupFilterParser {...props} />,
           render: (rowData) => {
@@ -114,7 +114,7 @@ export const LogTable = (props: LogTableProps): React.ReactElement => {
         },
         {
           title: <Typography>Timestamp</Typography>,
-          field: 'timestamp',
+          field: 'created',
           type: 'datetime',
           filtering: false,
           align: 'center',
@@ -122,7 +122,7 @@ export const LogTable = (props: LogTableProps): React.ReactElement => {
           render: (rowData) => {
             return (
               <Typography className={classes.cellContent} data-testid={'log-table-date'}>
-                {moment(rowData.timestamp).format('lll')}
+                {moment(rowData.created).format('lll')}
               </Typography>
             );
           },

--- a/packages/react-components/stories/logging.stories.tsx
+++ b/packages/react-components/stories/logging.stories.tsx
@@ -24,7 +24,7 @@ const getLogs = () => {
     rows.push({
       message: 'Test' + i,
       level: 'Debug',
-      timestamp: randomDate(new Date(2012, 0, 1), new Date()).toISOString(),
+      created: randomDate(new Date(2012, 0, 1), new Date()).toISOString(),
     });
   }
   return rows;
@@ -56,12 +56,12 @@ export const SimpleLogTable: Story = (args) => {
     npm ERR! A complete log of this run can be found in:
     npm ERR!     /home/ekumen/.npm/_logs/2021-01-18T21_20_07_480Z-debug.log`,
     level: 'Error',
-    timestamp: timestamp,
+    created: timestamp,
   });
   logs.unshift({
     message: `long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long msg`,
     level: 'Debug',
-    timestamp: timestamp,
+    created: timestamp,
   });
 
   return <LogTable rows={logs} {...args} />;

--- a/packages/react-components/tests/reports/log-management/log-table.spec.tsx
+++ b/packages/react-components/tests/reports/log-management/log-table.spec.tsx
@@ -19,7 +19,7 @@ for (let i = 0; i < 110; i++) {
   rows.push({
     message: 'Test' + i,
     level: getRandomLogLevel().toUpperCase(),
-    timestamp: timestamp,
+    created: timestamp,
   });
 }
 
@@ -86,7 +86,7 @@ describe('Applies styles to labels correctly', () => {
     styleRows.push({
       message: 'Test' + i,
       level: logLevels[i].toUpperCase(),
-      timestamp: timestamp,
+      created: timestamp,
     });
   }
 

--- a/packages/reporting-server/rest_server/repositories/report/raw_log.py
+++ b/packages/reporting-server/rest_server/repositories/report/raw_log.py
@@ -28,5 +28,5 @@ async def get_all_raw_logs(
         query["level__iexact"] = log_level
 
     return await RawLog_Pydantic.from_queryset(
-        RawLog.filter(**query).offset(offset).limit(limit)
+        RawLog.filter(**query).offset(offset).limit(limit).order_by("-created")
     )

--- a/packages/reporting/src/stories/reports/reporter-side-bar.stories.tsx
+++ b/packages/reporting/src/stories/reports/reporter-side-bar.stories.tsx
@@ -24,7 +24,7 @@ const getLogs = () => {
     rows.push({
       message: 'Test' + i,
       level: 'Debug',
-      timestamp: randomDate(new Date(2012, 0, 1), new Date()).toISOString(),
+      created: randomDate(new Date(2012, 0, 1), new Date()).toISOString(),
     });
   }
   return rows;


### PR DESCRIPTION
Signed-off-by: Matias Bavera <matiasbavera@gmail.com>

## What's new
All-logs report are now sorted by date desc.

![image](https://user-images.githubusercontent.com/11761240/116763746-9a3d0b80-a9ec-11eb-9e14-b57ec833052e.png)


<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

## Self-checks

- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
