### PR TITLE
send only when websocket is ready

### DIFF
--- a/packages/dashboard/src/components/app.tsx
+++ b/packages/dashboard/src/components/app.tsx
@@ -44,7 +44,7 @@ export default function App(): JSX.Element | null {
   const [authInitialized, setAuthInitialized] = React.useState(!!appConfig.authenticator.user);
   const [authenticator, setAuthenticator] = React.useState(appConfig.authenticator);
   const [user, setUser] = React.useState<User | null>(appConfig.authenticator.user || null);
-  const [ws, setWs] = React.useState<WebSocket | undefined>(undefined);
+  const [ws, setWs] = React.useState<WebSocket>(new WebSocket(appConfig.trajServerUrl));
   const appRoutes = [DASHBOARD_ROUTE, TASKS_ROUTE];
   const [tabValue, setTabValue] = React.useState<TabValue | null>(() =>
     locationToTabValue(window.location.pathname),

--- a/packages/dashboard/src/components/app.tsx
+++ b/packages/dashboard/src/components/app.tsx
@@ -44,6 +44,7 @@ export default function App(): JSX.Element | null {
   const [authInitialized, setAuthInitialized] = React.useState(!!appConfig.authenticator.user);
   const [authenticator, setAuthenticator] = React.useState(appConfig.authenticator);
   const [user, setUser] = React.useState<User | null>(appConfig.authenticator.user || null);
+  const [ws, setWs] = React.useState<WebSocket | undefined>(undefined);
   const appRoutes = [DASHBOARD_ROUTE, TASKS_ROUTE];
   const [tabValue, setTabValue] = React.useState<TabValue | null>(() =>
     locationToTabValue(window.location.pathname),
@@ -56,6 +57,10 @@ export default function App(): JSX.Element | null {
 
   const onTokenExpired = () => setAuthenticator(appConfig.authenticator);
   authenticator.on('tokenRefresh', onTokenExpired);
+
+  React.useEffect(() => {
+    setWs(new WebSocket(appConfig.trajServerUrl));
+  }, [setWs]);
 
   React.useEffect(() => {
     if (user) {
@@ -96,7 +101,7 @@ export default function App(): JSX.Element | null {
       <ResourcesContext.Provider value={resourceManager.current}>
         <AuthenticatorContext.Provider value={authenticator}>
           <UserContext.Provider value={user}>
-            <TrajectorySocketContext.Provider value={new WebSocket(appConfig.trajServerUrl)}>
+            <TrajectorySocketContext.Provider value={ws}>
               <ThemeProvider theme={theme}>
                 <BrowserRouter>
                   <Switch>

--- a/packages/dashboard/src/components/schedule-visualizer/index.tsx
+++ b/packages/dashboard/src/components/schedule-visualizer/index.tsx
@@ -274,10 +274,9 @@ export default function ScheduleVisualizer(props: ScheduleVisualizerProps): Reac
     }
   }, [curMapFloorLayer, trajectories]);
 
-  const negoTrajs = React.useMemo(
-    () => (negotiationTrajStore[curLevelName] ? negotiationTrajStore[curLevelName].values : []),
-    [negotiationTrajStore, curLevelName],
-  );
+  const negoTrajs = negotiationTrajStore[curLevelName]
+    ? negotiationTrajStore[curLevelName].values
+    : [];
 
   return (
     <LMap

--- a/packages/dashboard/src/managers/trajectory-socket-manager.ts
+++ b/packages/dashboard/src/managers/trajectory-socket-manager.ts
@@ -32,7 +32,7 @@ export default class TrajectorySocketManager extends EventEmitter<Events> {
     if (!webSocket) throw Error('Websocket not initialized!');
     // response should come in the order that requests are sent, this should allow multiple messages
     // in-flight while processing the responses in the order they are sent.
-    webSocket.send(payload);
+    if (webSocket.readyState === WebSocket.OPEN) webSocket.send(payload);
     // waits for the earlier response to be processed.
     if (this._ongoingRequest) {
       await this._ongoingRequest;

--- a/packages/dashboard/src/managers/trajectory-socket-manager.ts
+++ b/packages/dashboard/src/managers/trajectory-socket-manager.ts
@@ -32,7 +32,7 @@ export default class TrajectorySocketManager extends EventEmitter<Events> {
     if (!webSocket) throw Error('Websocket not initialized!');
     // response should come in the order that requests are sent, this should allow multiple messages
     // in-flight while processing the responses in the order they are sent.
-    if (webSocket.readyState === WebSocket.OPEN) webSocket.send(payload);
+    webSocket.send(payload);
     // waits for the earlier response to be processed.
     if (this._ongoingRequest) {
       await this._ongoingRequest;


### PR DESCRIPTION
Signed-off-by: ChawinTan <chawin15@gmail.com>

## What's new

See linked issue for the screen shot of the error that happens when toggling between panels. In short, the websocket seems to try to connect to the server again when toggling between panels. 

The fix is to check if websocket is ready before sending.

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

## Self-checks

- [x] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [x] I tried testing edge cases
- [x] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
