### PR TITLE
add a timeout of 10minutes

### DIFF
--- a/example-deployment/deploy.sh
+++ b/example-deployment/deploy.sh
@@ -38,7 +38,7 @@ cd $(dirname $0)
 
 kubectl apply -f k8s/keycloak.yaml
 echo 'waiting for keycloak to be ready...'
-kubectl wait --for=condition=available deployment/keycloak
+kubectl wait --for=condition=available deployment/keycloak --timeout=2m
 
 echo 'creating jwt configmap...'
 function try() {


### PR DESCRIPTION
Signed-off-by: Boon Han <charayaphan.nakorn.boon.han@gmail.com>


Add a timeout of 10 minutes to the example-deployment deploy script. The default value is 30 seconds, which is not always sufficient for keycloak to launch.

