### PR TITLE
Modify bootstrap file to automatically add dashboard client scope

### DIFF
--- a/example-deployment/keycloak-tools/bootstrap-keycloak.js
+++ b/example-deployment/keycloak-tools/bootstrap-keycloak.js
@@ -107,20 +107,20 @@ function authHeaders(token) {
       },
       {
         name: 'dashboard',
-	protocol: 'openid-connect',
-	description: 'dashboard scope',
-	protocolMappers: [
-	  {
-	    config: {
-	      "access.token.claim": "true",
-	      "id.token.claim": "false",
-	      "included.client.audience": "dashboard"
-	    },
-	    name: 'rmf-audience',
- 	    protocol: 'openid-connect',
+	      protocol: 'openid-connect',
+	      description: 'dashboard scope',
+	      protocolMappers: [
+	      {
+	        config: {
+	          "access.token.claim": "true",
+	          "id.token.claim": "false",
+	          "included.client.audience": "dashboard"
+	      },
+	      name: 'rmf-audience',
+ 	      protocol: 'openid-connect',
   	    protocolMapper: 'oidc-audience-mapper'
-	  }
-	]
+	    }
+	    ]
       },
     );
 
@@ -130,8 +130,8 @@ function authHeaders(token) {
       headers: authHeaders(token),
     });
 
-    const client_array = JSON.parse(resp.body);
-    const dashboard_id = client_array.filter(function(item){
+    const clientArray = JSON.parse(resp.body);
+    const dashboardId = clientArray.filter(function(item){
 	    return item.clientId === "dashboard";
     })[0].id
 
@@ -141,14 +141,14 @@ function authHeaders(token) {
       headers: authHeaders(token),
     });
 
-    const client_scopes_array = JSON.parse(resp.body);
-    const client_scope_id = client_scopes_array.filter(function(item){
+    const clientScopesArray = JSON.parse(resp.body);
+    const clientScopeId = clientScopesArray.filter(function(item){
 	    return item.name == "dashboard";
     })[0].id
 
     // set client with client scope
     await request(
-      `${baseUrl}/admin/realms/rmf-web/clients/${dashboard_id}/default-client-scopes/${client_scope_id}`,
+      `${baseUrl}/admin/realms/rmf-web/clients/${dashboardId}/default-client-scopes/${clientScopeId}`,
       {
         method: 'PUT',
         headers: authHeaders(token),

--- a/example-deployment/keycloak-tools/bootstrap-keycloak.js
+++ b/example-deployment/keycloak-tools/bootstrap-keycloak.js
@@ -132,7 +132,7 @@ function authHeaders(token) {
 
     const client_array = JSON.parse(resp.body);
     const dashboard_id = client_array.filter(function(item){
-	    return item.clientId == "dashboard";
+	    return item.clientId === "dashboard";
     })[0].id
 
     // get client scope id 

--- a/example-deployment/keycloak-tools/bootstrap-keycloak.js
+++ b/example-deployment/keycloak-tools/bootstrap-keycloak.js
@@ -31,9 +31,9 @@ function authHeaders(token) {
       },
       {
         clientId: 'dashboard',
-        rootUrl: 'https://openrobotics.demo.open-rmf.org',
-        redirectUris: ['https://openrobotics.demo.open-rmf.org/*'],
-        webOrigins: ['https://openrobotics.demo.open-rmf.org'],
+        rootUrl: 'https://example.com',
+        redirectUris: ['https://example.com/*'],
+        webOrigins: ['https://example.com'],
         publicClient: true,
       },
     );
@@ -46,9 +46,9 @@ function authHeaders(token) {
       },
       {
         clientId: 'reporting',
-        rootUrl: 'https://openrobotics.demo.open-rmf.org',
-        redirectUris: ['https://openrobotics.demo.open-rmf.org/*'],
-        webOrigins: ['https://openrobotics.demo.open-rmf.org'],
+        rootUrl: 'https://example.com',
+        redirectUris: ['https://example.com/*'],
+        webOrigins: ['https://example.com'],
         publicClient: true,
       },
     );

--- a/example-deployment/keycloak-tools/bootstrap-keycloak.js
+++ b/example-deployment/keycloak-tools/bootstrap-keycloak.js
@@ -31,9 +31,9 @@ function authHeaders(token) {
       },
       {
         clientId: 'dashboard',
-        rootUrl: 'https://example.com',
-        redirectUris: ['https://example.com/*'],
-        webOrigins: ['https://example.com'],
+        rootUrl: 'https://openrobotics.demo.open-rmf.org',
+        redirectUris: ['https://openrobotics.demo.open-rmf.org/*'],
+        webOrigins: ['https://openrobotics.demo.open-rmf.org'],
         publicClient: true,
       },
     );
@@ -46,9 +46,9 @@ function authHeaders(token) {
       },
       {
         clientId: 'reporting',
-        rootUrl: 'https://example.com',
-        redirectUris: ['https://example.com/*'],
-        webOrigins: ['https://example.com'],
+        rootUrl: 'https://openrobotics.demo.open-rmf.org',
+        redirectUris: ['https://openrobotics.demo.open-rmf.org/*'],
+        webOrigins: ['https://openrobotics.demo.open-rmf.org'],
         publicClient: true,
       },
     );
@@ -97,7 +97,69 @@ function authHeaders(token) {
         eventsListeners: ['jsonlog_event_listener'],
       },
     );
+
+    // create audience client scope
+    await request(
+      `${baseUrl}/admin/realms/rmf-web/client-scopes`,
+      {
+        method: 'POST',
+        headers: authHeaders(token),
+      },
+      {
+        name: 'dashboard',
+	protocol: 'openid-connect',
+	description: 'dashboard scope',
+	protocolMappers: [
+	  {
+	    config: {
+	      "access.token.claim": "true",
+	      "id.token.claim": "false",
+	      "included.client.audience": "dashboard"
+	    },
+	    name: 'rmf-audience',
+ 	    protocol: 'openid-connect',
+  	    protocolMapper: 'oidc-audience-mapper'
+	  }
+	]
+      },
+    );
+
+    // get dashboard id ( not clientid )
+    resp = await request(`${baseUrl}/admin/realms/rmf-web/clients`, {
+      method: 'GET',
+      headers: authHeaders(token),
+    });
+
+    const client_array = JSON.parse(resp.body);
+    const dashboard_id = client_array.filter(function(item){
+	    return item.clientId == "dashboard";
+    })[0].id
+
+    // get client scope id 
+    resp = await request(`${baseUrl}/admin/realms/rmf-web/client-scopes`, {
+      method: 'GET',
+      headers: authHeaders(token),
+    });
+
+    const client_scopes_array = JSON.parse(resp.body);
+    const client_scope_id = client_scopes_array.filter(function(item){
+	    return item.name == "dashboard";
+    })[0].id
+    console.log(client_scope_id)
+
+    // set client with client scope
+    await request(
+      `${baseUrl}/admin/realms/rmf-web/clients/${dashboard_id}/default-client-scopes/${client_scope_id}`,
+      {
+        method: 'PUT',
+        headers: authHeaders(token),
+      }
+    );
+   
+
   } catch (e) {
     process.exitCode = 1;
   }
 })();
+
+

--- a/example-deployment/keycloak-tools/bootstrap-keycloak.js
+++ b/example-deployment/keycloak-tools/bootstrap-keycloak.js
@@ -145,7 +145,6 @@ function authHeaders(token) {
     const client_scope_id = client_scopes_array.filter(function(item){
 	    return item.name == "dashboard";
     })[0].id
-    console.log(client_scope_id)
 
     // set client with client scope
     await request(


### PR DESCRIPTION
This PR modifies the deploy.sh script to automatically add the correct client scope and adds it to the dashboard client, so that keycloak authentication works properly. 

Tested on a clean build based on [this commit](https://github.com/open-rmf/rmf/commit/4b25f29e3c08418bf379250a028203ee17f9d12d) of `rmf.repos.` 