### PR TITLE
use onChange instead of onblur

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22373,6 +22373,11 @@
 			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.1.4.tgz",
 			"integrity": "sha512-WOEpRNz8Oo2SEU4eYQ279jEKFSjpFPa9Vi2U/K0DGwP9wOQ8wYkJcNSd5Qbv1L8OFvyKDCbWekjftXaU5mbmtg=="
 		},
+		"react-customizable-progressbar": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/react-customizable-progressbar/-/react-customizable-progressbar-1.0.3.tgz",
+			"integrity": "sha512-aqkZoexIfXXiQgFvo1++7GaxAKAQCb/zj5lRMj6oniZjn9CSIhowr3dSnGnvvvygvegVcPGEYK8shPV5MZasSQ=="
+		},
 		"react-dev-utils": {
 			"version": "11.0.4",
 			"resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.4.tgz",

--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -229,8 +229,8 @@ function LoopTaskForm({ taskDesc, loopWaypoints, onChange }: LoopTaskFormProps) 
             label="Loops"
             margin="normal"
             value={numOfLoops}
-            onChange={(ev) => setNumOfLoops(ev.target.value)}
-            onBlur={(ev) => {
+            onChange={(ev) => {
+              setNumOfLoops(ev.target.value);
               onChange({
                 ...taskDesc,
                 num_loops: parseInt(ev.target.value) || 1,


### PR DESCRIPTION
Signed-off-by: ChawinTan <chawin15@gmail.com>

## What's new

Related to: #364 

`onBlur` api does not behave the same way in firefox and chrome. Clicking on the submit button triggers the onblur api in chrome but does not in firefox. 

In order to be more consistent, the number of loops would be set during `onChange` instead.

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

## Self-checks

- [x] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
