### PR TITLE
dashboard: custom dropdown for clean and delivery waypoints

### DIFF
--- a/packages/dashboard/src/components/tasks/task-page.tsx
+++ b/packages/dashboard/src/components/tasks/task-page.tsx
@@ -20,7 +20,9 @@ export function TaskPage() {
   const classes = useStyles();
   const { tasksApi = null } = React.useContext(RmfIngressContext) || {};
   const places = React.useContext(PlacesContext);
-  const placeNames = places.map((p) => p.vertex.name);
+
+  // Note: This is replaced by filetered waypoints below
+  // const placeNames = places.map((p) => p.vertex.name);
 
   const clean_zones = Object.values(places).reduce<string[]>((place, it) => {
     for (const param of it.vertex.params){

--- a/packages/dashboard/src/components/tasks/task-page.tsx
+++ b/packages/dashboard/src/components/tasks/task-page.tsx
@@ -22,6 +22,34 @@ export function TaskPage() {
   const places = React.useContext(PlacesContext);
   const placeNames = places.map((p) => p.vertex.name);
 
+  const clean_zones = Object.values(places).reduce<string[]>((place, it) => {
+    for (const param of it.vertex.params){
+      if (param.name === "is_cleaning_zone" && param.value_bool){
+        place.push(it.vertex.name);
+        break;
+      }
+    }
+    return place
+  }, []);
+
+  // TODO should retain workcell name, and parse it to TaskPanel
+  const delivery_places = Object.values(places).reduce<string[]>((place, it) => {
+    const param_names = it.vertex.params.map((param) => param.name);
+    if (param_names.includes("pickup_dispenser") || param_names.includes("dropoff_ingestor"))
+      place.push(it.vertex.name);
+    return place
+  }, []);
+
+  // TODO This is custom to the throwaway demo. We are not showing any
+  // charging waypoints and cleaning waypoints on loop request. dock_name is valid
+  // for charging and cleaning waypoints
+  const loop_places = Object.values(places).reduce<string[]>((place, it) => {
+    const param_names = it.vertex.params.map((param) => param.name);
+    if (!param_names.includes('dock_name'))
+      place.push(it.vertex.name);
+    return place
+  }, []);
+
   const fetchTasks = React.useCallback<TaskPanelProps['fetchTasks']>(
     async (limit: number, offset: number) => {
       if (!tasksApi) {
@@ -42,7 +70,7 @@ export function TaskPage() {
         undefined,
         limit,
         offset,
-        'state,-priority,-start_time',
+        '-priority,-start_time',
       );
       const taskProgresses: TaskProgress[] = resp.data.items;
       const task_summaries = taskProgresses.map((t) => t.task_summary);
@@ -90,9 +118,9 @@ export function TaskPage() {
     <TaskPanel
       className={classes.taskPanel}
       fetchTasks={fetchTasks}
-      cleaningZones={placeNames}
-      loopWaypoints={placeNames}
-      deliveryWaypoints={placeNames}
+      cleaningZones={clean_zones}
+      loopWaypoints={loop_places}
+      deliveryWaypoints={delivery_places}
       submitTasks={submitTasks}
       cancelTask={cancelTask}
     />


### PR DESCRIPTION
This is part of this mega ticket: https://github.com/open-rmf/rmf-web/issues/352

In short, instead of showing all valid places on the graph, this will only show places that are relevant to the delivery and clean task. As Shown here:

![Screenshot from 2021-06-02 09-47-42](https://user-images.githubusercontent.com/32189404/120413207-70c82480-c38a-11eb-8146-a1f1d323c4ff.png)             |  ![Screenshot from 2021-06-02 09-47-03](https://user-images.githubusercontent.com/32189404/120413211-71f95180-c38a-11eb-8031-6ab19d2384ab.png)
:-------------------------:|:-------------------------:


### To Test
Dependencies:
 - rmf_traffic_editor: `feature/populate-vertex-params`   https://github.com/open-rmf/rmf_traffic_editor/pull/351
 - rmf_demos: `feature/cleanup-map-configs` https://github.com/open-rmf/rmf_demos/pull/52

Then run airport world (as it consists both delivery and clean tasks) and the `rmf-web` dashboard
```
ros2 launch rmf_demos airport_terminal.launch.xml
```

### Caveat
 - Currently there's a hack going on due to converting `building_map_msgs/Params` to `Record<string, Place>` type, will need to fix this soon
 - With the obtained parameters, the user doesn't need to manually fill in the `Dispenser` and `Ingestor` names (blanks as seen above). Will soon need to implement this feature.