### PR TITLE
perf(dashboad): fix some performance regression in schedule visualizer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25691,6 +25691,40 @@
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
+		"source-map-explorer": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/source-map-explorer/-/source-map-explorer-2.5.2.tgz",
+			"integrity": "sha512-gBwOyCcHPHcdLbgw6Y6kgoH1uLKL6hN3zz0xJcNI2lpnElZliIlmSYAjUVwAWnc7+HscoTyh1ScR7ITtFuEnxg==",
+			"requires": {
+				"btoa": "^1.2.1",
+				"chalk": "^4.1.0",
+				"convert-source-map": "^1.7.0",
+				"ejs": "^3.1.5",
+				"escape-html": "^1.0.3",
+				"glob": "^7.1.6",
+				"gzip-size": "^6.0.0",
+				"lodash": "^4.17.20",
+				"open": "^7.3.1",
+				"source-map": "^0.7.3",
+				"temp": "^0.9.4",
+				"yargs": "^16.2.0"
+			},
+			"dependencies": {
+				"gzip-size": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+					"integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+					"requires": {
+						"duplexer": "^0.1.2"
+					}
+				},
+				"source-map": {
+					"version": "0.7.3",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+				}
+			}
+		},
 		"source-map-resolve": {
 			"version": "0.5.3",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
@@ -26545,6 +26579,25 @@
 				"isobject": "^4.0.0",
 				"lodash": "^4.17.21",
 				"memoizerific": "^1.11.3"
+			}
+		},
+		"temp": {
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+			"integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
+			"requires": {
+				"mkdirp": "^0.5.1",
+				"rimraf": "~2.6.2"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
 			}
 		},
 		"temp-dir": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "analyze": "source-map-explorer 'build/static/js/*.js'",
     "start": "concurrently npm:start:rmf-server npm:start:rmf npm:start:react",
     "start:clinic": "RMF_DASHBOARD_DEMO_MAP=clinic.launch.xml npm start",
     "start:react": "react-scripts start",
@@ -83,6 +84,7 @@
     "reactour": "^1.18.0",
     "rmf-auth": "*",
     "rmf-models": "*",
+    "source-map-explorer": "^2.5.2",
     "styled-components": "^4.4.1",
     "ts-node": "^9.1.1",
     "typescript": "4.2.4"

--- a/packages/dashboard/src/components/dashboard/dashboard.tsx
+++ b/packages/dashboard/src/components/dashboard/dashboard.tsx
@@ -97,6 +97,8 @@ function robotKey(fleet: string, robot: RmfModels.RobotState): string {
   return `${fleet}-${robot.name}`;
 }
 
+const initialStack = [OmniPanelViewIndex.MainMenu];
+
 export default function Dashboard(_props: {}): React.ReactElement {
   debug('render');
 
@@ -112,7 +114,7 @@ export default function Dashboard(_props: {}): React.ReactElement {
   );
 
   const [viewStack, viewStackDispatch] = useStackNavigator<OmniPanelViewIndex>(
-    [OmniPanelViewIndex.MainMenu],
+    initialStack,
     OmniPanelViewIndex.MainMenu,
   );
   const currentView = viewStack[viewStack.length - 1];

--- a/packages/dashboard/src/components/dashboard/dashboard.tsx
+++ b/packages/dashboard/src/components/dashboard/dashboard.tsx
@@ -32,6 +32,7 @@ import {
   RmfIngressContext,
 } from '../rmf-app';
 import ScheduleVisualizer, { ScheduleVisualizerProps } from '../schedule-visualizer';
+import { RobotsOverlayProps } from '../schedule-visualizer/robots-overlay';
 import { SpotlightValue } from '../spotlight-value';
 import MainMenu from './main-menu';
 import NegotiationsPanel from './negotiations-panel';
@@ -93,8 +94,8 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function robotKey(fleet: string, robot: RmfModels.RobotState): string {
-  return `${fleet}-${robot.name}`;
+function robotKey(fleet: string, robotName: string): string {
+  return `${fleet}-${robotName}`;
 }
 
 const initialStack = [OmniPanelViewIndex.MainMenu];
@@ -213,8 +214,8 @@ export default function Dashboard(_props: {}): React.ReactElement {
     fleetNames.current = newFleetNames;
   }
   const robotAccordionRefs = React.useMemo(() => defaultDict(createSpotlightRef), []);
-  const handleRobotMarkerClick = React.useCallback(
-    (fleet: string, robot: RmfModels.RobotState) => {
+  const handleRobotMarkerClick = React.useCallback<Required<RobotsOverlayProps>['onRobotClick']>(
+    (_ev, fleet, robot) => {
       setShowOmniPanel(true);
       viewStackDispatch.push(OmniPanelViewIndex.Robots);
       robotAccordionRefs[robotKey(fleet, robot)].spotlight();
@@ -351,8 +352,8 @@ export default function Dashboard(_props: {}): React.ReactElement {
                 const toLower = robot.name;
                 return toLower.includes(filter) ? (
                   <RobotAccordion
-                    key={robotKey(fleet.name, robot)}
-                    ref={robotAccordionRefs[robotKey(fleet.name, robot)].ref}
+                    key={robotKey(fleet.name, robot.name)}
+                    ref={robotAccordionRefs[robotKey(fleet.name, robot.name)].ref}
                     robot={robot}
                     fleetName={fleet.name}
                     data-component="RobotAccordion"

--- a/packages/dashboard/src/components/dashboard/tour/tour-map.tsx
+++ b/packages/dashboard/src/components/dashboard/tour/tour-map.tsx
@@ -23,9 +23,9 @@ const useStyles = makeStyles(() => ({
 }));
 
 export interface TourMapProps {
-  buildingMap: Readonly<RmfModels.BuildingMap>;
-  fleets: Readonly<RmfModels.FleetState[]>;
-  mapFloorLayerSorted: Readonly<string[]>;
+  buildingMap: RmfModels.BuildingMap;
+  fleets: RmfModels.FleetState[];
+  mapFloorLayerSorted: string[];
 }
 
 export default function TourMap(props: TourMapProps): React.ReactElement {

--- a/packages/dashboard/src/components/schedule-visualizer/dispensers-overlay.tsx
+++ b/packages/dashboard/src/components/schedule-visualizer/dispensers-overlay.tsx
@@ -43,16 +43,24 @@ export const DispensersOverlay = (props: DispensersOverlayProps): React.ReactEle
     );
   }, [dispenserResourcesContext, currentFloorName]);
 
+  const dispenserLocations = React.useMemo(
+    () =>
+      dispenserInCurLevel.map(
+        (dispenser) => [dispenser.location.x, dispenser.location.y] as [number, number],
+      ),
+    [dispenserInCurLevel],
+  );
+
   return (
     <SVGOverlay {...otherProps}>
       <svg viewBox={viewBox}>
         {dispenserResourcesContext &&
-          dispenserInCurLevel.map((dispenser: DispenserResource) => {
+          dispenserInCurLevel.map((dispenser, idx) => {
             return (
               <MarkerComponent
                 key={dispenser.guid}
                 guid={dispenser.guid}
-                location={[dispenser.location.x, dispenser.location.y]}
+                location={dispenserLocations[idx]}
                 iconPath={dispenserResourcesContext.getIconPath(dispenser.guid) || undefined}
                 footprint={footprint}
                 onClick={onDispenserClick}

--- a/packages/dashboard/src/components/schedule-visualizer/doors-overlay.tsx
+++ b/packages/dashboard/src/components/schedule-visualizer/doors-overlay.tsx
@@ -10,7 +10,7 @@ const debug = Debug('ScheduleVisualizer:DoorsOverlay');
 const DoorMarker = React.memo(DoorMarker_);
 
 export interface DoorsOverlayProps extends SVGOverlayProps {
-  doors: RmfModels.Door[];
+  doors: readonly RmfModels.Door[];
   onDoorClick?(door: RmfModels.Door): void;
 }
 
@@ -21,47 +21,25 @@ export const DoorsOverlay = (props: DoorsOverlayProps) => {
   const viewBox = viewBoxFromLeafletBounds(props.bounds);
   const doorsState = useContext(DoorStateContext);
 
-  const v1s = React.useMemo(() => doors.map((door) => [door.v1_x, door.v1_y] as [number, number]), [
-    doors,
-  ]);
-  const v2s = React.useMemo(() => doors.map((door) => [door.v2_x, door.v2_y] as [number, number]), [
-    doors,
-  ]);
-
   const handleDoorClick = React.useCallback<Required<DoorMarkerProps>['onClick']>(
-    (ev) => {
-      const dataIdx = ev.currentTarget.getAttribute('data-index');
-      if (dataIdx === null) {
-        console.error('error handling door marker click (data-index not found)');
-        return;
-      }
-      const idx = parseInt(dataIdx);
-      if (isNaN(idx) || idx > doors.length - 1) {
-        console.error('error handling door marker click (data-index is not a valid index');
-        return;
-      }
-      onDoorClick && onDoorClick(doors[idx]);
-    },
-    [doors, onDoorClick],
+    (_, door) => onDoorClick && onDoorClick(door),
+    [onDoorClick],
   );
 
   return (
     <SVGOverlay {...otherProps}>
       <svg viewBox={viewBox}>
-        {doors.map((door, idx) => (
+        {doors.map((door) => (
           <DoorMarker
             key={door.name}
             onClick={handleDoorClick}
-            v1={v1s[idx]}
-            v2={v2s[idx]}
-            doorType={door.door_type}
+            door={door}
             doorMode={
               doorsState && doorsState[door.name] && doorsState[door.name].current_mode.value
             }
             aria-label={door.name}
             data-component="DoorMarker"
             data-testid="doorMarker"
-            data-index={idx}
           />
         ))}
       </svg>

--- a/packages/dashboard/src/components/schedule-visualizer/doors-overlay.tsx
+++ b/packages/dashboard/src/components/schedule-visualizer/doors-overlay.tsx
@@ -1,7 +1,7 @@
-import * as RmfModels from 'rmf-models';
 import Debug from 'debug';
 import React, { useContext } from 'react';
 import { DoorMarker as DoorMarker_, DoorMarkerProps } from 'react-components';
+import * as RmfModels from 'rmf-models';
 import { viewBoxFromLeafletBounds } from '../../util/css-utils';
 import { DoorStateContext } from '../rmf-app';
 import SVGOverlay, { SVGOverlayProps } from './svg-overlay';
@@ -10,7 +10,7 @@ const debug = Debug('ScheduleVisualizer:DoorsOverlay');
 const DoorMarker = React.memo(DoorMarker_);
 
 export interface DoorsOverlayProps extends SVGOverlayProps {
-  doors: readonly RmfModels.Door[];
+  doors: RmfModels.Door[];
   onDoorClick?(door: RmfModels.Door): void;
 }
 
@@ -21,23 +21,47 @@ export const DoorsOverlay = (props: DoorsOverlayProps) => {
   const viewBox = viewBoxFromLeafletBounds(props.bounds);
   const doorsState = useContext(DoorStateContext);
 
+  const v1s = React.useMemo(() => doors.map((door) => [door.v1_x, door.v1_y] as [number, number]), [
+    doors,
+  ]);
+  const v2s = React.useMemo(() => doors.map((door) => [door.v2_x, door.v2_y] as [number, number]), [
+    doors,
+  ]);
+
   const handleDoorClick = React.useCallback<Required<DoorMarkerProps>['onClick']>(
-    (_, door) => onDoorClick && onDoorClick(door),
-    [onDoorClick],
+    (ev) => {
+      const dataIdx = ev.currentTarget.getAttribute('data-index');
+      if (dataIdx === null) {
+        console.error('error handling door marker click (data-index not found)');
+        return;
+      }
+      const idx = parseInt(dataIdx);
+      if (isNaN(idx) || idx > doors.length - 1) {
+        console.error('error handling door marker click (data-index is not a valid index');
+        return;
+      }
+      onDoorClick && onDoorClick(doors[idx]);
+    },
+    [doors, onDoorClick],
   );
 
   return (
     <SVGOverlay {...otherProps}>
       <svg viewBox={viewBox}>
-        {doors.map((door) => (
+        {doors.map((door, idx) => (
           <DoorMarker
             key={door.name}
             onClick={handleDoorClick}
-            door={door}
-            doorMode={doorsState && doorsState[door.name] && doorsState[door.name].current_mode}
+            v1={v1s[idx]}
+            v2={v2s[idx]}
+            doorType={door.door_type}
+            doorMode={
+              doorsState && doorsState[door.name] && doorsState[door.name].current_mode.value
+            }
             aria-label={door.name}
             data-component="DoorMarker"
             data-testid="doorMarker"
+            data-index={idx}
           />
         ))}
       </svg>

--- a/packages/dashboard/src/components/schedule-visualizer/index.tsx
+++ b/packages/dashboard/src/components/schedule-visualizer/index.tsx
@@ -12,15 +12,15 @@ import {
   Trajectory,
   TrajectoryResponse,
 } from '../../managers/robot-trajectory-manager';
+import { AppConfigContext } from '../app-contexts';
 import { FleetStateContext, RmfIngressContext } from '../rmf-app';
 import DispensersOverlay from './dispensers-overlay';
 import DoorsOverlay from './doors-overlay';
 import LiftsOverlay from './lift-overlay';
 import { NegotiationColors } from './negotiation-colors';
 import RobotTrajectoriesOverlay from './robot-trajectories-overlay';
-import RobotsOverlay from './robots-overlay';
+import RobotsOverlay, { RobotsOverlayProps } from './robots-overlay';
 import WaypointsOverlay from './waypoints-overlay';
-import { AppConfigContext } from '../app-contexts';
 
 const debug = Debug('ScheduleVisualizer');
 
@@ -46,7 +46,7 @@ export interface ScheduleVisualizerProps extends React.PropsWithChildren<{}> {
   mapFloorSort?(levels: RmfModels.Level[]): string[];
   onDoorClick?(door: RmfModels.Door): void;
   onLiftClick?(lift: RmfModels.Lift): void;
-  onRobotClick?(fleet: string, robot: RmfModels.RobotState): void;
+  onRobotClick?: RobotsOverlayProps['onRobotClick'];
   onDispenserClick?(event: React.MouseEvent, guid: string): void;
 }
 

--- a/packages/dashboard/src/components/schedule-visualizer/robots-overlay.tsx
+++ b/packages/dashboard/src/components/schedule-visualizer/robots-overlay.tsx
@@ -1,7 +1,7 @@
-import * as RmfModels from 'rmf-models';
 import Debug from 'debug';
 import React, { useMemo } from 'react';
 import { RobotMarker as RobotMarker_, RobotMarkerProps } from 'react-components';
+import * as RmfModels from 'rmf-models';
 import { viewBoxFromLeafletBounds } from '../../util/css-utils';
 import { ResourcesContext } from '../app-contexts';
 import SVGOverlay, { SVGOverlayProps } from './svg-overlay';
@@ -10,10 +10,10 @@ const debug = Debug('ScheduleVisualizer:RobotsOverlay');
 const RobotMarker = React.memo(RobotMarker_);
 
 export interface RobotsOverlayProps extends SVGOverlayProps {
-  fleets: readonly RmfModels.FleetState[];
-  onRobotClick?(fleet: string, robot: RmfModels.RobotState): void;
+  fleets: RmfModels.FleetState[];
   conflictRobotNames: string[][];
   currentFloorName: string;
+  onRobotClick?: RobotMarkerProps['onClick'];
   MarkerComponent?: React.ComponentType<RobotMarkerProps>;
 }
 
@@ -22,9 +22,9 @@ export const RobotsOverlay = (props: RobotsOverlayProps) => {
 
   const {
     fleets,
-    onRobotClick,
     conflictRobotNames,
     currentFloorName,
+    onRobotClick,
     MarkerComponent = RobotMarker,
     ...otherProps
   } = props;
@@ -60,11 +60,6 @@ export const RobotsOverlay = (props: RobotsOverlayProps) => {
     }));
   }, [fleets, currentFloorName]);
 
-  const handleRobotClick = React.useCallback<Required<RobotMarkerProps>['onClick']>(
-    (_, fleetName, robot) => onRobotClick && onRobotClick(fleetName, robot),
-    [onRobotClick],
-  );
-
   const getIconPath = React.useCallback(
     (fleet: string, robot: RmfModels.RobotState) => {
       const icon = robotResourcesContext?.getIconPath(fleet, robot.model);
@@ -80,12 +75,17 @@ export const RobotsOverlay = (props: RobotsOverlayProps) => {
           robots.map((robot) => (
             <MarkerComponent
               key={robot.name}
-              robot={robot}
+              name={robot.name}
+              model={robot.model}
+              // Round to 2 decmial places (1cm) to prevent extra rendering when robot is idle
+              x={Math.round(robot.location.x * 100) / 100}
+              y={Math.round(robot.location.y * 100) / 100}
+              yaw={Math.round(robot.location.yaw * 100) / 100}
               fleetName={fleetContainer[`${robot.name}_${robot.model}`]}
               footprint={footprint}
               variant={inConflict(robot.name) ? 'inConflict' : 'normal'}
               iconPath={getIconPath(fleet, robot)}
-              onClick={handleRobotClick}
+              onClick={onRobotClick}
               aria-label={robot.name}
               data-component="RobotMarker"
               data-testid="robotMarker"

--- a/packages/dashboard/src/components/schedule-visualizer/robots-overlay.tsx
+++ b/packages/dashboard/src/components/schedule-visualizer/robots-overlay.tsx
@@ -77,7 +77,7 @@ export const RobotsOverlay = (props: RobotsOverlayProps) => {
               key={robot.name}
               name={robot.name}
               model={robot.model}
-              // Round to 2 decmial places (1cm) to prevent extra rendering when robot is idle
+              // Round to 2 decimal places (1cm) to prevent extra rendering when robot is idle
               x={Math.round(robot.location.x * 100) / 100}
               y={Math.round(robot.location.y * 100) / 100}
               yaw={Math.round(robot.location.yaw * 100) / 100}

--- a/packages/react-components/lib/doors/door-marker.tsx
+++ b/packages/react-components/lib/doors/door-marker.tsx
@@ -53,12 +53,10 @@ function useDoorStyle(doorMode?: number): string {
   }
 }
 
-function getDoorCenter(
-  v1: [number, number],
-  v2: [number, number],
-  doorType: number,
-): [number, number] {
-  switch (doorType) {
+function getDoorCenter(door: RmfModels.Door): [number, number] {
+  const v1 = [door.v1_x, door.v1_y];
+  const v2 = [door.v2_x, door.v2_y];
+  switch (door.door_type) {
     case RmfModels.Door.DOOR_TYPE_SINGLE_SLIDING:
     case RmfModels.Door.DOOR_TYPE_SINGLE_SWING:
     case RmfModels.Door.DOOR_TYPE_SINGLE_TELESCOPE:
@@ -131,7 +129,7 @@ const DummyDoor = (props: DummyDoorProps) => {
   );
 };
 
-type DoorMarkerImplProps = Omit<DoorMarkerProps, 'onClick' | 'doorType'>;
+type DoorMarkerImplProps = Omit<DoorMarkerProps, 'onClick'>;
 
 /*
  * Single swing doors:
@@ -142,13 +140,13 @@ type DoorMarkerImplProps = Omit<DoorMarkerProps, 'onClick' | 'doorType'>;
  *  - selected by the motion_direction parameter, which is +1 or -1
  */
 const SingleSwingDoor = (props: DoorMarkerImplProps) => {
-  const { v1, v2, doorMode } = props;
+  const { door, doorMode } = props;
   const doorStyle = useDoorStyle(doorMode);
 
   return (
     <>
-      <BaseDoor v1={v1} v2={v2} className={doorStyle} />
-      <DummyDoor v1={v1} v2={v2} />
+      <BaseDoor v1={[door.v1_x, door.v1_y]} v2={[door.v2_x, door.v2_y]} className={doorStyle} />
+      <DummyDoor v1={[door.v1_x, door.v1_y]} v2={[door.v2_x, door.v2_y]} />
     </>
   );
 };
@@ -174,9 +172,12 @@ const SingleTelescopeDoor = SingleSlidingDoor;
  * - same motion-direction selection as single hinge
  */
 const DoubleSwingDoor = (props: DoorMarkerImplProps) => {
-  const { v1, v2, doorMode } = props;
-  const [hingeX1, hingeY1, hingeX2, hingeY2] = [v1[0], v1[1], v2[0], v2[1]];
-  const [extendX1, extendY1] = [hingeX1 + (v2[0] - v1[0]) / 2, hingeY1 + (v2[1] - v1[1]) / 2];
+  const { door, doorMode } = props;
+  const [hingeX1, hingeY1, hingeX2, hingeY2] = [door.v1_x, door.v1_y, door.v2_x, door.v2_y];
+  const [extendX1, extendY1] = [
+    hingeX1 + (door.v2_x - door.v1_x) / 2,
+    hingeY1 + (door.v2_y - door.v1_y) / 2,
+  ];
   const doorStyle = useDoorStyle(doorMode);
   return (
     <>
@@ -207,9 +208,7 @@ const DoubleTelescopeDoor = DoubleSlidingDoor;
  * onClick: Action to trigger on click.
  */
 export interface DoorMarkerProps extends Omit<React.SVGProps<SVGGElement>, 'onClick'> {
-  v1: [number, number];
-  v2: [number, number];
-  doorType: number;
+  door: RmfModels.Door;
   doorMode?: number;
   /**
    * Whether the component should perform a translate transform to put it inline with the position
@@ -218,38 +217,38 @@ export interface DoorMarkerProps extends Omit<React.SVGProps<SVGGElement>, 'onCl
    * default: true
    */
   translate?: boolean;
-  onClick?: React.MouseEventHandler;
+  onClick?(event: React.MouseEvent, door: RmfModels.Door): void;
 }
 
 export const DoorMarker = React.forwardRef(
   (props: DoorMarkerProps, ref: React.Ref<SVGGElement>) => {
-    const { v1, v2, doorType, doorMode, translate = true, onClick, ...otherProps } = props;
-    debug('render');
+    const { door, doorMode, translate = true, onClick, ...otherProps } = props;
+    debug(`render ${door.name}`);
     const classes = useDoorStyles();
 
     const renderDoor = () => {
-      switch (doorType) {
+      switch (door.door_type) {
         case RmfModels.Door.DOOR_TYPE_SINGLE_SWING:
-          return <SingleSwingDoor v1={v1} v2={v2} doorMode={doorMode} />;
+          return <SingleSwingDoor door={door} doorMode={doorMode} />;
         case RmfModels.Door.DOOR_TYPE_SINGLE_SLIDING:
-          return <SingleSlidingDoor v1={v1} v2={v2} doorMode={doorMode} />;
+          return <SingleSlidingDoor door={door} doorMode={doorMode} />;
         case RmfModels.Door.DOOR_TYPE_SINGLE_TELESCOPE:
-          return <SingleTelescopeDoor v1={v1} v2={v2} doorMode={doorMode} />;
+          return <SingleTelescopeDoor door={door} doorMode={doorMode} />;
         case RmfModels.Door.DOOR_TYPE_DOUBLE_SWING:
-          return <DoubleSwingDoor v1={v1} v2={v2} doorMode={doorMode} />;
+          return <DoubleSwingDoor door={door} doorMode={doorMode} />;
         case RmfModels.Door.DOOR_TYPE_DOUBLE_SLIDING:
-          return <DoubleSlidingDoor v1={v1} v2={v2} doorMode={doorMode} />;
+          return <DoubleSlidingDoor door={door} doorMode={doorMode} />;
         case RmfModels.Door.DOOR_TYPE_DOUBLE_TELESCOPE:
-          return <DoubleTelescopeDoor v1={v1} v2={v2} doorMode={doorMode} />;
+          return <DoubleTelescopeDoor door={door} doorMode={doorMode} />;
         default:
           return null;
       }
     };
 
     try {
-      const center = React.useMemo(() => getDoorCenter(v1, v2, doorType), [v1, v2, doorType]);
+      const center = getDoorCenter(door);
       return (
-        <g ref={ref} onClick={onClick} {...otherProps}>
+        <g ref={ref} onClick={(ev) => onClick && onClick(ev, door)} {...otherProps}>
           <g
             className={onClick ? classes.marker : undefined}
             transform={!translate ? `translate(${-center[0]} ${center[1]})` : undefined}

--- a/packages/react-components/lib/lifts/lift-marker.tsx
+++ b/packages/react-components/lib/lifts/lift-marker.tsx
@@ -178,7 +178,14 @@ export const LiftMarker = React.forwardRef(function (
         </g>
         <g>
           {doors.map((door, i) => (
-            <DoorMarker key={i} door={door} doorMode={doorMode} translate={true} />
+            <DoorMarker
+              key={i}
+              v1={[door.v1_x, door.v1_y]}
+              v2={[door.v2_x, door.v2_y]}
+              doorType={door.door_type}
+              doorMode={doorMode?.value}
+              translate={true}
+            />
           ))}
         </g>
       </g>

--- a/packages/react-components/lib/lifts/lift-marker.tsx
+++ b/packages/react-components/lib/lifts/lift-marker.tsx
@@ -178,14 +178,7 @@ export const LiftMarker = React.forwardRef(function (
         </g>
         <g>
           {doors.map((door, i) => (
-            <DoorMarker
-              key={i}
-              v1={[door.v1_x, door.v1_y]}
-              v2={[door.v2_x, door.v2_y]}
-              doorType={door.door_type}
-              doorMode={doorMode?.value}
-              translate={true}
-            />
+            <DoorMarker key={i} door={door} doorMode={doorMode?.value} translate={true} />
           ))}
         </g>
       </g>

--- a/packages/react-components/lib/robots/base-marker.ts
+++ b/packages/react-components/lib/robots/base-marker.ts
@@ -1,7 +1,9 @@
-import * as RmfModels from 'rmf-models';
-
 export interface BaseMarkerProps extends Omit<React.SVGAttributes<SVGGElement>, 'onClick'> {
-  robot: RmfModels.RobotState;
+  name: string;
+  model: string;
+  x: number;
+  y: number;
+  yaw: number;
   footprint: number;
   fleetName: string;
   /**
@@ -12,5 +14,5 @@ export interface BaseMarkerProps extends Omit<React.SVGAttributes<SVGGElement>, 
    */
   translate?: boolean;
   variant?: 'normal' | 'inConflict';
-  onClick?(event: React.MouseEvent, fleet: string, robot: RmfModels.RobotState): void;
+  onClick?(event: React.MouseEvent, fleet: string, robot: string): void;
 }

--- a/packages/react-components/lib/robots/robot-marker.tsx
+++ b/packages/react-components/lib/robots/robot-marker.tsx
@@ -38,7 +38,11 @@ export const RobotMarker = React.forwardRef(
   (props: RobotMarkerProps, ref: React.Ref<SVGGElement>) => {
     // some props are not used but have to be declared to correctly set `otherProps`
     const {
-      robot,
+      name,
+      model,
+      x,
+      y,
+      yaw: rmfYaw,
       footprint,
       fleetName,
       iconPath,
@@ -48,13 +52,13 @@ export const RobotMarker = React.forwardRef(
       onClick,
       ...otherProps
     } = props;
-    debug(`render ${robot.name}`);
+    debug(`render ${name}`);
     const [useImageMarker, setUseImageMarker] = React.useState(!!iconPath);
     const [robotColor, setRobotColor] = React.useState<string | undefined>(undefined);
     const colorManager = React.useContext(ColorContext);
     const classes = useStyles();
-    const pos = fromRmfCoords([robot.location.x, robot.location.y]);
-    const yaw = (fromRmfYaw(robot.location.yaw) / Math.PI) * 180;
+    const pos = fromRmfCoords([x, y]);
+    const yaw = (fromRmfYaw(rmfYaw) / Math.PI) * 180;
 
     const translateTransform = translate ? `translate(${pos[0]} ${pos[1]})` : undefined;
 
@@ -70,15 +74,15 @@ export const RobotMarker = React.forwardRef(
         return;
       }
       (async () => {
-        const color = await colorManager.robotPrimaryColor(fleetName, robot.name, robot.model);
+        const color = await colorManager.robotPrimaryColor(fleetName, name, model);
         isMounted.current && setRobotColor(color);
       })();
-    }, [colorManager, fleetName, robot.model, robot.name, useImageMarker]);
+    }, [name, model, colorManager, fleetName, useImageMarker]);
 
     return (
-      <g ref={ref} onClick={(ev) => onClick && onClick(ev, fleetName, robot)} {...otherProps}>
+      <g ref={ref} onClick={(ev) => onClick && onClick(ev, fleetName, name)} {...otherProps}>
         <g transform={translateTransform}>
-          <g className={classes.clickable} aria-label={robot.name} transform={`rotate(${yaw})`}>
+          <g className={classes.clickable} aria-label={name} transform={`rotate(${yaw})`}>
             {useImageMarker && iconPath ? (
               <ImageMarker
                 {...props}
@@ -89,7 +93,7 @@ export const RobotMarker = React.forwardRef(
               <DefaultMarker color={robotColor} {...props} />
             ) : null}
           </g>
-          <SvgText text={robot.name} targetWidth={footprint * 1.9} className={classes.text} />
+          <SvgText text={name} targetWidth={footprint * 1.9} className={classes.text} />
         </g>
       </g>
     );

--- a/packages/react-components/lib/robots/trajectory-paths.tsx
+++ b/packages/react-components/lib/robots/trajectory-paths.tsx
@@ -98,8 +98,16 @@ export const FollowAnimationPath = (props: TrajectoryPathProps): JSX.Element => 
 
     const offsets = keyframeOffsets(trajectory);
     const pathAnim = pathRef.current;
+
+    // Idle robots still have a trajectory with a path length of 0. This prevents a divide
+    // by 0 error.
+    const totalLength = pathAnim.getTotalLength();
+    if (totalLength < 0.01) {
+      return;
+    }
+
     const strokeWidth = Number(pathAnim.getAttribute('stroke-width') || 1);
-    const strokeDash = strokeWidth / pathAnim.getTotalLength();
+    const strokeDash = strokeWidth / totalLength;
     pathAnim.setAttribute('stroke-dasharray', `${strokeDash} ${2 - strokeDash}`);
 
     pathAnim.animate(

--- a/packages/react-components/lib/stack-navigator.ts
+++ b/packages/react-components/lib/stack-navigator.ts
@@ -30,15 +30,17 @@ export function useStackNavigator<KeyType>(
   homeView: KeyType,
 ): [KeyType[], StackNavigatorDispatch<KeyType>] {
   const [stack, setStack] = React.useState<KeyType[]>(initialState);
-  return [
-    stack,
-    {
-      push: (viewId: KeyType) => setStack((prev) => [...prev, viewId]),
-      pop: () => setStack((prev) => (prev.length > 1 ? prev.slice(0, prev.length - 1) : prev)),
-      home: () => setStack((prev) => [...prev, homeView]),
-      reset: () => setStack(initialState),
-    },
-  ];
+  return React.useMemo(() => {
+    return [
+      stack,
+      {
+        push: (viewId: KeyType) => setStack((prev) => [...prev, viewId]),
+        pop: () => setStack((prev) => (prev.length > 1 ? prev.slice(0, prev.length - 1) : prev)),
+        home: () => setStack((prev) => [...prev, homeView]),
+        reset: () => setStack(initialState),
+      },
+    ];
+  }, [homeView, initialState, stack]);
 }
 
 export default useStackNavigator;

--- a/packages/react-components/lib/stack-navigator.ts
+++ b/packages/react-components/lib/stack-navigator.ts
@@ -30,17 +30,16 @@ export function useStackNavigator<KeyType>(
   homeView: KeyType,
 ): [KeyType[], StackNavigatorDispatch<KeyType>] {
   const [stack, setStack] = React.useState<KeyType[]>(initialState);
-  return React.useMemo(() => {
-    return [
-      stack,
-      {
-        push: (viewId: KeyType) => setStack((prev) => [...prev, viewId]),
-        pop: () => setStack((prev) => (prev.length > 1 ? prev.slice(0, prev.length - 1) : prev)),
-        home: () => setStack((prev) => [...prev, homeView]),
-        reset: () => setStack(initialState),
-      },
-    ];
-  }, [homeView, initialState, stack]);
+  const dispatch = React.useMemo(
+    () => ({
+      push: (viewId: KeyType) => setStack((prev) => [...prev, viewId]),
+      pop: () => setStack((prev) => (prev.length > 1 ? prev.slice(0, prev.length - 1) : prev)),
+      home: () => setStack((prev) => [...prev, homeView]),
+      reset: () => setStack(initialState),
+    }),
+    [homeView, initialState],
+  );
+  return [stack, dispatch];
 }
 
 export default useStackNavigator;

--- a/packages/react-components/stories/benchmarks/robots.stories.tsx
+++ b/packages/react-components/stories/benchmarks/robots.stories.tsx
@@ -1,6 +1,6 @@
-import * as RmfModels from 'rmf-models';
 import { Meta, Story } from '@storybook/react';
 import React from 'react';
+import * as RmfModels from 'rmf-models';
 import { RobotMarker } from '../../lib';
 import { makeRobot } from '../../tests/robots/test-utils';
 
@@ -105,7 +105,11 @@ export const RobotMarkers: Story<RobotMarkerArgs> = ({ count, ...args }) => {
       {animationStates.map(({ robot }) => (
         <RobotMarker
           key={robot.name}
-          robot={robot}
+          name={robot.name}
+          model={robot.model}
+          x={robot.location.x}
+          y={robot.location.y}
+          yaw={robot.location.yaw}
           fleetName="test_fleet"
           footprint={1}
           {...args}

--- a/packages/react-components/stories/door-markers.stories.tsx
+++ b/packages/react-components/stories/door-markers.stories.tsx
@@ -1,6 +1,6 @@
-import * as RmfModels from 'rmf-models';
 import { Meta, Story } from '@storybook/react';
 import React from 'react';
+import * as RmfModels from 'rmf-models';
 import { DoorMarker } from '../lib';
 import { makeDoor, makeDoorState } from '../tests/doors/test-utils';
 
@@ -12,7 +12,13 @@ export default {
 function makeStory(door: RmfModels.Door, doorState?: RmfModels.DoorState): Story {
   return (args) => (
     <svg viewBox="-2 -2 4 4" width={400} height={400}>
-      <DoorMarker door={door} doorMode={doorState?.current_mode || undefined} {...args} />
+      <DoorMarker
+        v1={[door.v1_x, door.v1_y]}
+        v2={[door.v2_x, door.v2_y]}
+        doorType={door.door_type}
+        doorMode={doorState?.current_mode.value || undefined}
+        {...args}
+      />
     </svg>
   );
 }
@@ -57,7 +63,13 @@ export const NoTranslate: Story = (args) => {
   const door = makeDoor({ v1_x: 10, v1_y: 10, v2_x: 11, v2_y: 11 });
   return (
     <svg viewBox="-2 -2 4 4" width={400} height={400}>
-      <DoorMarker door={door} translate={false} {...args} />
+      <DoorMarker
+        v1={[door.v1_x, door.v1_y]}
+        v2={[door.v2_x, door.v2_y]}
+        doorType={door.door_type}
+        translate={false}
+        {...args}
+      />
     </svg>
   );
 };

--- a/packages/react-components/stories/door-markers.stories.tsx
+++ b/packages/react-components/stories/door-markers.stories.tsx
@@ -12,13 +12,7 @@ export default {
 function makeStory(door: RmfModels.Door, doorState?: RmfModels.DoorState): Story {
   return (args) => (
     <svg viewBox="-2 -2 4 4" width={400} height={400}>
-      <DoorMarker
-        v1={[door.v1_x, door.v1_y]}
-        v2={[door.v2_x, door.v2_y]}
-        doorType={door.door_type}
-        doorMode={doorState?.current_mode.value || undefined}
-        {...args}
-      />
+      <DoorMarker door={door} doorMode={doorState?.current_mode.value || undefined} {...args} />
     </svg>
   );
 }
@@ -63,13 +57,7 @@ export const NoTranslate: Story = (args) => {
   const door = makeDoor({ v1_x: 10, v1_y: 10, v2_x: 11, v2_y: 11 });
   return (
     <svg viewBox="-2 -2 4 4" width={400} height={400}>
-      <DoorMarker
-        v1={[door.v1_x, door.v1_y]}
-        v2={[door.v2_x, door.v2_y]}
-        doorType={door.door_type}
-        translate={false}
-        {...args}
-      />
+      <DoorMarker door={door} translate={false} {...args} />
     </svg>
   );
 };

--- a/packages/react-components/stories/robot-markers.stories.tsx
+++ b/packages/react-components/stories/robot-markers.stories.tsx
@@ -8,33 +8,39 @@ import { makeRobot } from '../tests/robots/test-utils';
 export default {
   title: 'Robot Markers',
   component: RobotMarker,
+  parameters: { controls: { include: ['onClick'], hideNoControlsWarning: true } },
 } as Meta;
 
-function makeRobotProps(
-  robot?: Partial<RmfModels.RobotState>,
+function makeRobotMarkerProps(
+  robotState?: Partial<RmfModels.RobotState>,
   props?: Partial<Omit<RobotMarkerProps, 'robot'>>,
 ): RobotMarkerProps {
   props = props || {};
+  const robot = makeRobot(robotState);
   return {
-    robot: makeRobot(robot),
+    name: robot.name,
+    model: robot.model,
+    x: robot.location.x,
+    y: robot.location.y,
+    yaw: robot.location.yaw,
     fleetName: 'testFleet',
     footprint: 1,
     ...props,
   };
 }
 
-const robots: Record<string, RobotMarkerProps> = {
-  Basic: makeRobotProps({ name: 'BasicRobot' }),
-  'Really Really Loooonnnnnggggg Name': makeRobotProps({
+const robotMarkerProps: Record<string, RobotMarkerProps> = {
+  Basic: makeRobotMarkerProps({ name: 'BasicRobot' }),
+  'Really Really Loooonnnnnggggg Name': makeRobotMarkerProps({
     name: 'I have a really really loooonnnnnggggg name',
   }),
-  'In Conflict': makeRobotProps({ name: 'ConflictingRobot' }, { variant: 'inConflict' }),
-  'Name With Space': makeRobotProps({ name: 'I have spaces' }),
-  'With Icon': makeRobotProps(
+  'In Conflict': makeRobotMarkerProps({ name: 'ConflictingRobot' }, { variant: 'inConflict' }),
+  'Name With Space': makeRobotMarkerProps({ name: 'I have spaces' }),
+  'With Icon': makeRobotMarkerProps(
     { name: 'RobotWithIcon', model: 'fleetWithIcon' },
     { fleetName: 'fleetWithIcon', iconPath: '/assets/tinyRobot.png' },
   ),
-  'With Icon, In Conflict': makeRobotProps(
+  'With Icon, In Conflict': makeRobotMarkerProps(
     { name: 'RobotWithIcon', model: 'fleetWithIcon' },
     { fleetName: 'fleetWithIcon', iconPath: '/assets/tinyRobot.png', variant: 'inConflict' },
   ),
@@ -43,7 +49,7 @@ const robots: Record<string, RobotMarkerProps> = {
 export const Gallery: Story = (args) => {
   return (
     <Grid container spacing={2}>
-      {Object.keys(robots).map((k) => (
+      {Object.keys(robotMarkerProps).map((k) => (
         <Grid item key={k}>
           <Paper>
             <Grid container direction="column" alignItems="center">
@@ -52,7 +58,7 @@ export const Gallery: Story = (args) => {
               </Grid>
               <Grid item>
                 <svg viewBox="-2 -2 4 4" style={{ minWidth: 200 }}>
-                  <RobotMarker {...robots[k]} {...args} />
+                  <RobotMarker {...robotMarkerProps[k]} {...args} />
                 </svg>
               </Grid>
             </Grid>
@@ -64,24 +70,20 @@ export const Gallery: Story = (args) => {
 };
 
 export const NoTranslate: Story = (args) => {
+  const robotMarkerProps = makeRobotMarkerProps({
+    location: {
+      level_name: 'test',
+      x: 10,
+      y: 10,
+      yaw: 0,
+      t: { sec: 0, nanosec: 0 },
+      index: 0,
+    },
+  });
+
   return (
     <svg viewBox="-2 -2 4 4" width={400} height={400}>
-      <RobotMarker
-        robot={makeRobot({
-          location: {
-            level_name: 'test',
-            x: 10,
-            y: 10,
-            yaw: 0,
-            t: { sec: 0, nanosec: 0 },
-            index: 0,
-          },
-        })}
-        fleetName="test_fleet"
-        footprint={1}
-        translate={false}
-        {...args}
-      />
+      <RobotMarker {...robotMarkerProps} translate={false} {...args} />
     </svg>
   );
 };

--- a/packages/react-components/tests/doors/door-marker.spec.tsx
+++ b/packages/react-components/tests/doors/door-marker.spec.tsx
@@ -8,7 +8,7 @@ it('smoke test with different door modes', () => {
   allDoorModes().forEach((mode) => {
     render(
       <svg>
-        <DoorMarker door={makeDoor()} doorMode={mode} />
+        <DoorMarker door={makeDoor()} doorMode={mode.value} />
       </svg>,
     );
     cleanup();

--- a/packages/react-components/tests/robots/default-marker.spec.tsx
+++ b/packages/react-components/tests/robots/default-marker.spec.tsx
@@ -6,12 +6,17 @@ import { makeRobot } from './test-utils';
 
 it('smoke test with different variants', () => {
   const variants: RobotMarkerProps['variant'][] = ['inConflict', 'normal', undefined];
+  const robot = makeRobot();
   variants.forEach((v) => {
     render(
       <svg>
         <DefaultMarker
           color="blue"
-          robot={makeRobot()}
+          name={robot.name}
+          model={robot.model}
+          x={robot.location.x}
+          y={robot.location.y}
+          yaw={robot.location.yaw}
           fleetName="test_fleet"
           footprint={1}
           variant={v}

--- a/packages/react-components/tests/robots/robot-marker.spec.tsx
+++ b/packages/react-components/tests/robots/robot-marker.spec.tsx
@@ -28,18 +28,33 @@ describe('robot-markers', () => {
 
   it('smoke test with different variant', async () => {
     const variants: RobotMarkerProps['variant'][] = ['inConflict', 'normal', undefined];
+    const robot = makeRobot();
     for (const v of variants) {
       await render(
-        <RobotMarker robot={makeRobot()} fleetName="test_fleet" footprint={1} variant={v} />,
+        <RobotMarker
+          name={robot.name}
+          model={robot.model}
+          x={robot.location.x}
+          y={robot.location.y}
+          yaw={robot.location.yaw}
+          fleetName="test_fleet"
+          footprint={1}
+          variant={v}
+        />,
       );
       cleanup();
     }
   });
 
   it('trigger onClick event', async () => {
+    const robot = makeRobot();
     const root = await render(
       <RobotMarker
-        robot={makeRobot()}
+        name={robot.name}
+        model={robot.model}
+        x={robot.location.x}
+        y={robot.location.y}
+        yaw={robot.location.yaw}
         fleetName="test_fleet"
         footprint={1}
         onClick={fakeOnClick}
@@ -51,8 +66,18 @@ describe('robot-markers', () => {
   });
 
   it('providing iconPath renders an image', async () => {
+    const robot = makeRobot();
     const root = await render(
-      <RobotMarker robot={makeRobot()} fleetName="test_fleet" footprint={1} iconPath="test_icon" />,
+      <RobotMarker
+        name={robot.name}
+        model={robot.model}
+        x={robot.location.x}
+        y={robot.location.y}
+        yaw={robot.location.yaw}
+        fleetName="test_fleet"
+        footprint={1}
+        iconPath="test_icon"
+      />,
     );
     expect(root.container.querySelector('image')).not.toBeNull();
   });


### PR DESCRIPTION
## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

Many markers are being re-rendered needlessly, testing on the clinic world, these optimizations reduces the render times from ~10ms to ~2ms.

## Self-checks

- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
