### PR TITLE
Change fleet/robots task summary to task progress

### DIFF
--- a/packages/api-server/api_server/app.py
+++ b/packages/api-server/api_server/app.py
@@ -157,7 +157,8 @@ class App(FastIO):
             routes.IngestorsRouter(self.rmf_events, self.rmf_repo), prefix="/ingestors"
         )
         self.include_router(
-            routes.FleetsRouter(self.rmf_events, logger=logger), prefix="/fleets"
+            routes.FleetsRouter(self.rmf_events, rmf_gateway_dep, logger=logger),
+            prefix="/fleets",
         )
 
         @self.fapi.on_event("startup")

--- a/packages/api-server/api_server/models/fleets.py
+++ b/packages/api-server/api_server/models/fleets.py
@@ -2,7 +2,7 @@ from typing import List
 
 from pydantic import BaseModel
 
-from api_server.models.tasks import TaskSummary
+from api_server.models.tasks import TaskProgress
 
 from .health import BasicHealth
 from .ros_pydantic import rmf_fleet_msgs
@@ -23,4 +23,4 @@ class Robot(BaseModel):
     fleet: str
     name: str
     state: RobotState
-    tasks: List[TaskSummary] = []
+    tasks: List[TaskProgress] = []

--- a/packages/api-server/api_server/routes/fleets.py
+++ b/packages/api-server/api_server/routes/fleets.py
@@ -5,7 +5,7 @@ from fastapi import Depends, Query
 
 from api_server.models.fleets import Robot
 from api_server.models.pagination import Pagination
-from api_server.models.tasks import TaskStateEnum, TaskSummary
+from api_server.models.tasks import TaskStateEnum
 
 from ..dependencies import WithBaseQuery, base_query_params
 from ..fast_io import FastIORouter

--- a/packages/api-server/api_server/routes/fleets.py
+++ b/packages/api-server/api_server/routes/fleets.py
@@ -13,7 +13,7 @@ from ..gateway import RmfGateway
 from ..models import Fleet, FleetState, RobotHealth
 from ..models import tortoise_models as ttm
 from ..rmf_io import RmfEvents
-from .tasks.dispatcher import convert_task_status_msg
+from .tasks.utils import convert_task_status_msg
 
 
 class FleetsRouter(FastIORouter):

--- a/packages/api-server/api_server/routes/tasks/dispatcher.py
+++ b/packages/api-server/api_server/routes/tasks/dispatcher.py
@@ -45,29 +45,3 @@ class DispatcherClient:
         if not response.success:
             raise HTTPException(500, response.message)
         return response.success
-
-
-def convert_task_status_msg(
-    task_summary: TaskSummary, rmf_gateway: RmfGateway
-) -> TaskProgress:
-    """
-    convert rmf task summary msg to a task
-    """
-    now = rmf_gateway.get_clock().now().to_msg().sec  # only use sec
-    # Generate a progress percentage
-    duration = abs(task_summary.end_time.sec - task_summary.start_time.sec)
-    # check if is completed
-    if task_summary.state == RmfTaskSummary.STATE_COMPLETED:
-        progress = "100%"
-    # check if it state is queued/cancelled
-    elif duration == 0 or (task_summary.state in [0, 4]):
-        progress = "0%"
-    else:
-        percent = int(100 * (now - task_summary.start_time.sec) / float(duration))
-        if percent < 0:
-            progress = "0%"
-        elif percent > 100:
-            progress = "Delayed"
-        else:
-            progress = f"{percent}%"
-    return TaskProgress(task_summary=task_summary, progress=progress)

--- a/packages/api-server/api_server/routes/tasks/dispatcher.py
+++ b/packages/api-server/api_server/routes/tasks/dispatcher.py
@@ -1,5 +1,4 @@
 from fastapi.exceptions import HTTPException
-from rmf_task_msgs.msg import TaskSummary as RmfTaskSummary
 from rmf_task_msgs.srv import CancelTask as RmfCancelTask
 from rmf_task_msgs.srv import SubmitTask as RmfSubmitTask
 

--- a/packages/api-server/api_server/routes/tasks/dispatcher.py
+++ b/packages/api-server/api_server/routes/tasks/dispatcher.py
@@ -5,7 +5,6 @@ from rmf_task_msgs.srv import SubmitTask as RmfSubmitTask
 
 from ... import models as mdl
 from ...gateway import RmfGateway
-from ...models.tasks import TaskProgress, TaskSummary
 
 
 class DispatcherClient:

--- a/packages/api-server/api_server/routes/tasks/dispatcher.py
+++ b/packages/api-server/api_server/routes/tasks/dispatcher.py
@@ -46,25 +46,28 @@ class DispatcherClient:
             raise HTTPException(500, response.message)
         return response.success
 
-    def convert_task_status_msg(self, task_summary: TaskSummary) -> TaskProgress:
-        """
-        convert rmf task summary msg to a task
-        """
-        now = self.rmf_gateway.get_clock().now().to_msg().sec  # only use sec
-        # Generate a progress percentage
-        duration = abs(task_summary.end_time.sec - task_summary.start_time.sec)
-        # check if is completed
-        if task_summary.state == RmfTaskSummary.STATE_COMPLETED:
-            progress = "100%"
-        # check if it state is queued/cancelled
-        elif duration == 0 or (task_summary.state in [0, 4]):
+
+def convert_task_status_msg(
+    task_summary: TaskSummary, rmf_gateway: RmfGateway
+) -> TaskProgress:
+    """
+    convert rmf task summary msg to a task
+    """
+    now = rmf_gateway.get_clock().now().to_msg().sec  # only use sec
+    # Generate a progress percentage
+    duration = abs(task_summary.end_time.sec - task_summary.start_time.sec)
+    # check if is completed
+    if task_summary.state == RmfTaskSummary.STATE_COMPLETED:
+        progress = "100%"
+    # check if it state is queued/cancelled
+    elif duration == 0 or (task_summary.state in [0, 4]):
+        progress = "0%"
+    else:
+        percent = int(100 * (now - task_summary.start_time.sec) / float(duration))
+        if percent < 0:
             progress = "0%"
+        elif percent > 100:
+            progress = "Delayed"
         else:
-            percent = int(100 * (now - task_summary.start_time.sec) / float(duration))
-            if percent < 0:
-                progress = "0%"
-            elif percent > 100:
-                progress = "Delayed"
-            else:
-                progress = f"{percent}%"
-        return TaskProgress(task_summary=task_summary, progress=progress)
+            progress = f"{percent}%"
+    return TaskProgress(task_summary=task_summary, progress=progress)

--- a/packages/api-server/api_server/routes/tasks/tasks.py
+++ b/packages/api-server/api_server/routes/tasks/tasks.py
@@ -41,7 +41,6 @@ class TasksRouter(FastIORouter):
 
         @self.get("", response_model=GetTasksResponse)
         async def get_tasks(
-            dispatcher_client: DispatcherClient = Depends(dispatcher_client_dep),
             with_base_query: WithBaseQuery[ttm.TaskSummary] = Depends(
                 base_query_params({"task_id": "id_"})
             ),

--- a/packages/api-server/api_server/routes/tasks/tasks.py
+++ b/packages/api-server/api_server/routes/tasks/tasks.py
@@ -19,7 +19,7 @@ from ...models import (
 )
 from ...models import tortoise_models as ttm
 from ...services.tasks import convert_task_request
-from .dispatcher import DispatcherClient
+from .dispatcher import DispatcherClient, convert_task_status_msg
 
 
 class TasksRouter(FastIORouter):
@@ -97,7 +97,7 @@ class TasksRouter(FastIORouter):
 
             results = await with_base_query(ttm.TaskSummary.filter(**filter_params))
             results.items = [
-                dispatcher_client.convert_task_status_msg(item.to_pydantic())
+                convert_task_status_msg(item.to_pydantic(), rmf_gateway_dep())
                 for item in results.items
             ]
             return results

--- a/packages/api-server/api_server/routes/tasks/tasks.py
+++ b/packages/api-server/api_server/routes/tasks/tasks.py
@@ -19,7 +19,8 @@ from ...models import (
 )
 from ...models import tortoise_models as ttm
 from ...services.tasks import convert_task_request
-from .dispatcher import DispatcherClient, convert_task_status_msg
+from .dispatcher import DispatcherClient
+from .utils import convert_task_status_msg
 
 
 class TasksRouter(FastIORouter):

--- a/packages/api-server/api_server/routes/tasks/utils.py
+++ b/packages/api-server/api_server/routes/tasks/utils.py
@@ -1,0 +1,30 @@
+from rmf_task_msgs.msg import TaskSummary as RmfTaskSummary
+
+from ...gateway import RmfGateway
+from ...models.tasks import TaskProgress, TaskSummary
+
+
+def convert_task_status_msg(
+    task_summary: TaskSummary, rmf_gateway: RmfGateway
+) -> TaskProgress:
+    """
+    convert rmf task summary msg to a task
+    """
+    now = rmf_gateway.get_clock().now().to_msg().sec  # only use sec
+    # Generate a progress percentage
+    duration = abs(task_summary.end_time.sec - task_summary.start_time.sec)
+    # check if is completed
+    if task_summary.state == RmfTaskSummary.STATE_COMPLETED:
+        progress = "100%"
+    # check if it state is queued/cancelled
+    elif duration == 0 or (task_summary.state in [0, 4]):
+        progress = "0%"
+    else:
+        percent = int(100 * (now - task_summary.start_time.sec) / float(duration))
+        if percent < 0:
+            progress = "0%"
+        elif percent > 100:
+            progress = "Delayed"
+        else:
+            progress = f"{percent}%"
+    return TaskProgress(task_summary=task_summary, progress=progress)


### PR DESCRIPTION
Signed-off-by: ChawinTan <chawin15@gmail.com>

## What's new

Replace `TaskSummary` in `fleets/robots` with `TaskProgress`.

This should make fetching robot and tasks data much easier in robot panel page.

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

## Self-checks

- [x] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
