### PR TITLE
change end time to duration

### DIFF
--- a/packages/react-components/lib/robots/robot-table.tsx
+++ b/packages/react-components/lib/robots/robot-table.tsx
@@ -160,7 +160,7 @@ export function RobotTable({
               <TableCell>Robot Name</TableCell>
               <TableCell>Start Location</TableCell>
               <TableCell>Destination</TableCell>
-              <TableCell>End Time</TableCell>
+              <TableCell>Duration</TableCell>
               <TableCell>Battery</TableCell>
               <TableCell>State</TableCell>
             </TableRow>

--- a/packages/react-components/lib/robots/robot-table.tsx
+++ b/packages/react-components/lib/robots/robot-table.tsx
@@ -162,7 +162,7 @@ export function RobotTable({
               <TableCell>Robot Name</TableCell>
               <TableCell>Start Location</TableCell>
               <TableCell>Destination</TableCell>
-              <TableCell>Duration</TableCell>
+              <TableCell>Active Task Duration</TableCell>
               <TableCell>Battery</TableCell>
               <TableCell>State</TableCell>
             </TableRow>

--- a/packages/react-components/lib/robots/robot-table.tsx
+++ b/packages/react-components/lib/robots/robot-table.tsx
@@ -104,8 +104,10 @@ function RobotRow({ robot, onClick }: RobotRowProps) {
           {returnLocationCells(robot)}
           <TableCell>
             {robot.assignedTasks
-              ? robot.assignedTasks[0].task_summary.end_time.sec -
-                robot.assignedTasks[0].task_summary.start_time.sec
+              ? `${
+                  robot.assignedTasks[0].task_summary.end_time.sec -
+                  robot.assignedTasks[0].task_summary.start_time.sec
+                }s`
               : '-'}
           </TableCell>
           <TableCell>{robot.battery_percent.toFixed(2)}%</TableCell>


### PR DESCRIPTION
Signed-off-by: ChawinTan <chawin15@gmail.com>
(cherry picked from commit 2c0589d81be297c57ffeca0bde0e99c39f09d87b)

## What's new

Related to #393

Change the `End Time` field of the robot table to `Duration` to better reflect what is displayed on the column.

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

## Self-checks

- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
