### PR TITLE
feat(dashboard): auto refresh tasks in task page

### DIFF
--- a/packages/api-client/lib/index.ts
+++ b/packages/api-client/lib/index.ts
@@ -14,7 +14,9 @@ import {
 } from 'rmf-models';
 import { io, Socket } from 'socket.io-client';
 
-export type Listener<T = unknown> = (resp: T) => void;
+// https://stackoverflow.com/questions/52667959/what-is-the-purpose-of-bivariancehack-in-typescript-types
+export type Listener<T = unknown> = { bivarianceHack(resp: T): void }['bivarianceHack'];
+export type Subscription = Listener;
 
 export class SioClient {
   public sio: Socket;

--- a/packages/api-client/lib/index.ts
+++ b/packages/api-client/lib/index.ts
@@ -1,3 +1,4 @@
+import Debug from 'debug';
 import {
   BuildingMap,
   DispenserHealth,
@@ -14,6 +15,8 @@ import {
 } from 'rmf-models';
 import { io, Socket } from 'socket.io-client';
 
+const debug = Debug('rmf-client');
+
 // https://stackoverflow.com/questions/52667959/what-is-the-purpose-of-bivariancehack-in-typescript-types
 export type Listener<T = unknown> = { bivarianceHack(resp: T): void }['bivarianceHack'];
 export type Subscription = Listener;
@@ -28,11 +31,13 @@ export class SioClient {
   subscribe<T>(path: string, listener: Listener<T>): Listener<T> {
     this.sio.emit('subscribe', { path });
     this.sio.on(path, (msg: T) => listener(msg));
+    debug(`subscribed to ${path}`);
     return listener;
   }
 
   unsubscribe(listener: Listener): void {
     this.sio.offAny(listener);
+    debug(`unsubscribed listener\n${listener}`);
   }
 
   subscribeBuildingMap(listener: Listener<BuildingMap>): Listener<BuildingMap> {

--- a/packages/api-client/lib/index.ts
+++ b/packages/api-client/lib/index.ts
@@ -10,8 +10,11 @@ import {
   LiftHealth,
   LiftState,
   RobotHealth,
+  TaskSummary,
 } from 'rmf-models';
 import { io, Socket } from 'socket.io-client';
+
+export type Listener<T = unknown> = (resp: T) => void;
 
 export class SioClient {
   public sio: Socket;
@@ -20,57 +23,75 @@ export class SioClient {
     this.sio = io(...args);
   }
 
-  subscribe<T>(path: string, cb: (resp: T) => void): void {
+  subscribe<T>(path: string, listener: Listener<T>): Listener<T> {
     this.sio.emit('subscribe', { path });
-    this.sio.on(path, (msg: T) => cb(msg));
+    this.sio.on(path, (msg: T) => listener(msg));
+    return listener;
   }
 
-  subscribeBuildingMap(cb: (buildingMap: BuildingMap) => void): void {
-    return this.subscribe<BuildingMap>(`/building_map`, cb);
+  unsubscribe(listener: Listener): void {
+    this.sio.offAny(listener);
   }
 
-  subscribeDoorState(doorName: string, cb: (doorState: DoorState) => void): void {
-    return this.subscribe<DoorState>(`/doors/${doorName}/state`, cb);
+  subscribeBuildingMap(listener: Listener<BuildingMap>): Listener<BuildingMap> {
+    return this.subscribe<BuildingMap>(`/building_map`, listener);
   }
 
-  subscribeDoorHealth(doorName: string, cb: (doorHealth: DoorHealth) => void): void {
-    return this.subscribe<DoorHealth>(`/doors/${doorName}/health`, cb);
+  subscribeDoorState(doorName: string, listener: Listener<DoorState>): Listener<DoorState> {
+    return this.subscribe<DoorState>(`/doors/${doorName}/state`, listener);
   }
 
-  subscribeLiftState(liftName: string, cb: (liftState: LiftState) => void): void {
-    return this.subscribe<LiftState>(`/lifts/${liftName}/state`, cb);
+  subscribeDoorHealth(doorName: string, listener: Listener<DoorHealth>): Listener<DoorHealth> {
+    return this.subscribe<DoorHealth>(`/doors/${doorName}/health`, listener);
   }
 
-  subscribeLiftHealth(liftName: string, cb: (liftHealth: LiftHealth) => void): void {
-    return this.subscribe<LiftHealth>(`/doors/${liftName}/health`, cb);
+  subscribeLiftState(liftName: string, listener: Listener<LiftState>): Listener<LiftState> {
+    return this.subscribe<LiftState>(`/lifts/${liftName}/state`, listener);
   }
 
-  subscribeDispenserState(guid: string, cb: (dispenserState: DispenserState) => void): void {
-    return this.subscribe<DispenserState>(`/dispensers/${guid}/state`, cb);
+  subscribeLiftHealth(liftName: string, listener: Listener<LiftHealth>): Listener<LiftHealth> {
+    return this.subscribe<LiftHealth>(`/doors/${liftName}/health`, listener);
   }
 
-  subscribeDispenserHealth(guid: string, cb: (dispenserHealth: DispenserHealth) => void): void {
-    return this.subscribe<DispenserHealth>(`/dispensers/${guid}/health`, cb);
+  subscribeDispenserState(
+    guid: string,
+    listener: Listener<DispenserState>,
+  ): Listener<DispenserState> {
+    return this.subscribe<DispenserState>(`/dispensers/${guid}/state`, listener);
   }
 
-  subscribeIngestorState(guid: string, cb: (ingestorState: IngestorState) => void): void {
-    return this.subscribe<IngestorState>(`/ingestors/${guid}/state`, cb);
+  subscribeDispenserHealth(
+    guid: string,
+    listener: Listener<DispenserHealth>,
+  ): Listener<DispenserHealth> {
+    return this.subscribe<DispenserHealth>(`/dispensers/${guid}/health`, listener);
   }
 
-  subscribeIngestorHealth(guid: string, cb: (ingestorHealth: IngestorHealth) => void): void {
-    return this.subscribe<IngestorHealth>(`/ingestors/${guid}/health`, cb);
+  subscribeIngestorState(guid: string, listener: Listener<IngestorState>): Listener<IngestorState> {
+    return this.subscribe<IngestorState>(`/ingestors/${guid}/state`, listener);
   }
 
-  subscribeFleetState(name: string, cb: (fleetState: FleetState) => void): void {
-    return this.subscribe<FleetState>(`/fleets/${name}/state`, cb);
+  subscribeIngestorHealth(
+    guid: string,
+    listener: Listener<IngestorHealth>,
+  ): Listener<IngestorHealth> {
+    return this.subscribe<IngestorHealth>(`/ingestors/${guid}/health`, listener);
+  }
+
+  subscribeFleetState(name: string, listener: Listener<FleetState>): Listener<FleetState> {
+    return this.subscribe<FleetState>(`/fleets/${name}/state`, listener);
   }
 
   subscribeRobotHealth(
     fleetName: string,
     robotName: string,
-    cb: (robotHealth: RobotHealth) => void,
-  ): void {
-    return this.subscribe<RobotHealth>(`/fleets/${fleetName}/${robotName}/health`, cb);
+    listener: Listener<RobotHealth>,
+  ): Listener<RobotHealth> {
+    return this.subscribe<RobotHealth>(`/fleets/${fleetName}/${robotName}/health`, listener);
+  }
+
+  subscribeTaskSummary(taskId: string, listener: Listener<TaskSummary>): Listener<TaskSummary> {
+    return this.subscribe<TaskSummary>(`/tasks/${taskId}/summary`, listener);
   }
 }
 

--- a/packages/api-client/lib/openapi/apis/tasks-api.ts
+++ b/packages/api-client/lib/openapi/apis/tasks-api.ts
@@ -22,6 +22,7 @@ import { HTTPValidationError } from '../models';
 import { ModelObject } from '../models';
 import { SubmitTask } from '../models';
 import { SubmitTaskResponse } from '../models';
+import { TaskSummary } from '../models';
 /**
  * TasksApi - axios parameter creator
  * @export
@@ -79,6 +80,58 @@ export const TasksApiAxiosParamCreator = function (configuration?: Configuration
       localVarRequestOptions.data = needsSerialization
         ? JSON.stringify(body !== undefined ? body : {})
         : body || '';
+
+      return {
+        url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * **Available in socket.io**
+     * @summary Get Task Summary
+     * @param {string} task_id task_id with &#x27;/&#x27; replaced with &#x27;__&#x27;
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getTaskSummaryTasksTaskIdSummaryGet: async (
+      task_id: string,
+      options: any = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'task_id' is not null or undefined
+      if (task_id === null || task_id === undefined) {
+        throw new RequiredError(
+          'task_id',
+          'Required parameter task_id was null or undefined when calling getTaskSummaryTasksTaskIdSummaryGet.',
+        );
+      }
+      const localVarPath = `/tasks/{task_id}/summary`.replace(
+        `{${'task_id'}}`,
+        encodeURIComponent(String(task_id)),
+      );
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, 'https://example.com');
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      const query = new URLSearchParams(localVarUrlObj.search);
+      for (const key in localVarQueryParameter) {
+        query.set(key, localVarQueryParameter[key]);
+      }
+      for (const key in options.query) {
+        query.set(key, options.query[key]);
+      }
+      localVarUrlObj.search = new URLSearchParams(query).toString();
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
 
       return {
         url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
@@ -295,6 +348,28 @@ export const TasksApiFp = function (configuration?: Configuration) {
       };
     },
     /**
+     * **Available in socket.io**
+     * @summary Get Task Summary
+     * @param {string} task_id task_id with &#x27;/&#x27; replaced with &#x27;__&#x27;
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getTaskSummaryTasksTaskIdSummaryGet(
+      task_id: string,
+      options?: any,
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TaskSummary>> {
+      const localVarAxiosArgs = await TasksApiAxiosParamCreator(
+        configuration,
+      ).getTaskSummaryTasksTaskIdSummaryGet(task_id, options);
+      return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+        const axiosRequestArgs = {
+          ...localVarAxiosArgs.options,
+          url: basePath + localVarAxiosArgs.url,
+        };
+        return axios.request(axiosRequestArgs);
+      };
+    },
+    /**
      *
      * @summary Get Tasks
      * @param {string} [task_id] comma separated list of task ids
@@ -398,6 +473,18 @@ export const TasksApiFactory = function (
         .then((request) => request(axios, basePath));
     },
     /**
+     * **Available in socket.io**
+     * @summary Get Task Summary
+     * @param {string} task_id task_id with &#x27;/&#x27; replaced with &#x27;__&#x27;
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getTaskSummaryTasksTaskIdSummaryGet(task_id: string, options?: any): AxiosPromise<TaskSummary> {
+      return TasksApiFp(configuration)
+        .getTaskSummaryTasksTaskIdSummaryGet(task_id, options)
+        .then((request) => request(axios, basePath));
+    },
+    /**
      *
      * @summary Get Tasks
      * @param {string} [task_id] comma separated list of task ids
@@ -484,6 +571,19 @@ export class TasksApi extends BaseAPI {
   public cancelTaskTasksCancelTaskPost(body: CancelTask, options?: any) {
     return TasksApiFp(this.configuration)
       .cancelTaskTasksCancelTaskPost(body, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+  /**
+   * **Available in socket.io**
+   * @summary Get Task Summary
+   * @param {string} task_id task_id with &#x27;/&#x27; replaced with &#x27;__&#x27;
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof TasksApi
+   */
+  public getTaskSummaryTasksTaskIdSummaryGet(task_id: string, options?: any) {
+    return TasksApiFp(this.configuration)
+      .getTaskSummaryTasksTaskIdSummaryGet(task_id, options)
       .then((request) => request(this.axios, this.basePath));
   }
   /**

--- a/packages/api-client/lib/version.ts
+++ b/packages/api-client/lib/version.ts
@@ -3,6 +3,6 @@ import { version as rmfModelVer } from 'rmf-models';
 
 export const version = {
   rmfModels: rmfModelVer,
-  rmfServer: '6bc829614a0329965578f17da55b9377a5b6097c',
+  rmfServer: 'a63bd0c39860de28249f48bd81519fba5f4c0e21',
   swaggerCodegen: '3.0.25',
 };

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -11,7 +11,9 @@
   "author": "koonpeng@openrobotics.org",
   "license": "Apache-2.0",
   "dependencies": {
+    "@types/debug": "^4.1.5",
     "axios": "^0.21.1",
+    "debug": "^4.2.0",
     "rmf-models": "*",
     "socket.io-client": "^3.1.3"
   },

--- a/packages/api-server/api_server/app.py
+++ b/packages/api-server/api_server/app.py
@@ -121,6 +121,13 @@ class App(FastIO):
 
             logger.info("updating tasks from RMF")
             try:
+                # Sometimes the node has not finished discovery so we need to call
+                # `wait_for_service` here.
+                # As of rclpy 3.0, `wait_for_service` uses a blocking sleep in a loop so
+                # using it is not recommended after the app has finish startup.
+                ready = self.rmf_gateway.get_tasks_srv.wait_for_service(1)
+                if not ready:
+                    raise HTTPException(503, "ros service not ready")
                 await self.rmf_gateway.update_tasks(rmf_repo)
             except HTTPException as e:
                 logger.error(f"failed to update tasks from RMF ({e.detail})")
@@ -148,7 +155,9 @@ class App(FastIO):
             routes.LiftsRouter(self.rmf_events, rmf_gateway_dep, self.rmf_repo),
             prefix="/lifts",
         )
-        self.include_router(routes.TasksRouter(rmf_gateway_dep), prefix="/tasks")
+        self.include_router(
+            routes.TasksRouter(self.rmf_events, rmf_gateway_dep), prefix="/tasks"
+        )
         self.include_router(
             routes.DispensersRouter(self.rmf_events, self.rmf_repo),
             prefix="/dispensers",
@@ -212,6 +221,26 @@ class App(FastIO):
             )
             self.rmf_gateway = RmfGateway(self.rmf_events, static_files)
 
+            stopping = False
+
+            def spin():
+                logger.info("start spinning rclpy node")
+                # using spin_once instead of spin because events can get missed/significantly
+                # delayed if they are added from another thread while the spin thread is sleeping
+                while not stopping:
+                    rclpy.spin_once(self.rmf_gateway, timeout_sec=0.1)
+                logger.info("finished spinning rclpy node")
+
+            spin_thread = threading.Thread(target=spin)
+            spin_thread.start()
+
+            def stop_spinning():
+                nonlocal stopping
+                stopping = True
+                spin_thread.join()
+
+            shutdown_cbs.append(stop_spinning)
+
             # Order is important here
             # 1. load states from db, this populate the sio/fast_io rooms with the latest data
             await load_states(self.rmf_gateway, self.rmf_repo)
@@ -232,28 +261,6 @@ class App(FastIO):
                 logger=logger.getChild("HealthWatchdog"),
             )
             await health_watchdog.start()
-
-            # 3. start spinning only after setting everything up so that subscriptions
-            # are not "lost" and the spin thread is sleeping because there is no "work"
-            stopping = False
-
-            def spin():
-                logger.info("start spinning rclpy node")
-                # using spin_once instead of spin because events can get missed/significantly
-                # delayed if they are added from another thread while the spin thread is sleeping
-                while not stopping:
-                    rclpy.spin_once(self.rmf_gateway, timeout_sec=0.1)
-                logger.info("finished spinning rclpy node")
-
-            spin_thread = threading.Thread(target=spin)
-            spin_thread.start()
-
-            def stop_spinning():
-                nonlocal stopping
-                stopping = True
-                spin_thread.join()
-
-            shutdown_cbs.append(stop_spinning)
 
             self._started.set_result(True)
             logger.info("started app")

--- a/packages/api-server/api_server/fast_io/errors.py
+++ b/packages/api-server/api_server/fast_io/errors.py
@@ -1,0 +1,2 @@
+class SubscribeError(Exception):
+    pass

--- a/packages/api-server/api_server/rmf_io/__init__.py
+++ b/packages/api-server/api_server/rmf_io/__init__.py
@@ -1,4 +1,4 @@
-from .book_keeper import RmfBookKeeper
+from .book_keeper import RmfBookKeeper, RmfBookKeeperEvents
 from .events import RmfEvents
 from .health_watchdog import HealthWatchdog
 from .topics import topics

--- a/packages/api-server/api_server/routes/tasks/tasks.py
+++ b/packages/api-server/api_server/routes/tasks/tasks.py
@@ -1,12 +1,14 @@
 from datetime import datetime
-from typing import Callable, Optional
+from typing import Callable, Dict, Optional
 
 from fastapi import Depends, HTTPException
 from fastapi.param_functions import Query
 from fastapi.responses import JSONResponse
 
+from api_server.models.tasks import TaskSummary
+
 from ...dependencies import WithBaseQuery, base_query_params
-from ...fast_io import FastIORouter
+from ...fast_io import DataStore, FastIORouter
 from ...gateway import RmfGateway
 from ...models import (
     CancelTask,
@@ -18,6 +20,7 @@ from ...models import (
     TaskTypeEnum,
 )
 from ...models import tortoise_models as ttm
+from ...rmf_io import RmfEvents
 from ...services.tasks import convert_task_request
 from .dispatcher import DispatcherClient
 
@@ -25,6 +28,7 @@ from .dispatcher import DispatcherClient
 class TasksRouter(FastIORouter):
     def __init__(
         self,
+        rmf_events: RmfEvents,
         rmf_gateway_dep: Callable[[], RmfGateway],
     ):
         super().__init__(tags=["Tasks"])
@@ -35,6 +39,35 @@ class TasksRouter(FastIORouter):
             if _dispatcher_client is None:
                 _dispatcher_client = DispatcherClient(rmf_gateway_dep())
             return _dispatcher_client
+
+        class TaskSummaryDataStore(DataStore[TaskSummary]):
+            async def get(
+                self,
+                key: str,
+                path_params: Dict[str, str],
+            ):
+                # FIXME: This would fail if task_id contains "_/"
+                task_id = path_params["task_id"].replace("__", "/")
+                data = await ttm.TaskSummary.get_or_none(id_=task_id)
+                if data is None:
+                    return None
+                return TaskSummary(**data.data)
+
+            async def set(
+                self, key: str, path_params: Dict[str, str], data: TaskSummary
+            ):
+                # RmfBookKeeper will handle writing to db
+                pass
+
+        @self.watch(
+            "/{task_id}/summary",
+            target=rmf_events.task_summaries,
+            response_model=TaskSummary,
+            data_store=TaskSummaryDataStore(),
+            param_docs={"task_id": "task_id with '/' replaced with '__'"},
+        )
+        async def get_task_summary(task_summary: TaskSummary):
+            return {"task_id": task_summary.task_id.replace("/", "__")}, task_summary
 
         class GetTasksResponse(Pagination.response_model(TaskProgress)):
             pass

--- a/packages/api-server/api_server/routes/tasks/tasks.py
+++ b/packages/api-server/api_server/routes/tasks/tasks.py
@@ -1,11 +1,11 @@
+import asyncio
 from datetime import datetime
 from typing import Callable, Dict, Optional
 
 from fastapi import Depends, HTTPException
 from fastapi.param_functions import Query
 from fastapi.responses import JSONResponse
-
-from api_server.models.tasks import TaskSummary
+from rx import operators as rx_ops
 
 from ...dependencies import WithBaseQuery, base_query_params
 from ...fast_io import DataStore, FastIORouter
@@ -20,7 +20,8 @@ from ...models import (
     TaskTypeEnum,
 )
 from ...models import tortoise_models as ttm
-from ...rmf_io import RmfEvents
+from ...models.tasks import TaskSummary
+from ...rmf_io import RmfBookKeeperEvents, RmfEvents
 from ...services.tasks import convert_task_request
 from .dispatcher import DispatcherClient
 from .utils import convert_task_status_msg
@@ -30,6 +31,7 @@ class TasksRouter(FastIORouter):
     def __init__(
         self,
         rmf_events: RmfEvents,
+        bookkeeper_events: RmfBookKeeperEvents,
         rmf_gateway_dep: Callable[[], RmfGateway],
     ):
         super().__init__(tags=["Tasks"])
@@ -150,6 +152,22 @@ class TasksRouter(FastIORouter):
             rmf_resp = await dispatcher_client.submit_task_request(req_msg)
             if not rmf_resp.success:
                 raise HTTPException(422, rmf_resp.message)
+
+            # wait for the new task summary to be written to db so that subsequent calls
+            # to `/tasks` will include the new task.
+            fut = asyncio.Future()
+            sub = bookkeeper_events.task_summary_written.pipe(
+                rx_ops.filter(lambda t: sub.dispose() or t.task_id == rmf_resp.task_id)
+            ).subscribe(fut.set_result)
+            try:
+                # there is a slight chance that the new task is written to db before
+                # the ros service call returns. So we put a timeout and ignore the error.
+                await asyncio.wait_for(fut, 5)
+            except asyncio.TimeoutError:
+                pass
+            finally:
+                sub.dispose()
+
             return {"task_id": rmf_resp.task_id}
 
         @self.post("/cancel_task")

--- a/packages/api-server/api_server/test/fast_io_app.py
+++ b/packages/api-server/api_server/test/fast_io_app.py
@@ -9,7 +9,6 @@ router_with_prefix = FastIORouter(prefix="/router_with_prefix")
 router_include_with_prefix = FastIORouter()
 router_both_prefix = FastIORouter(prefix="/router_both_prefix")
 target = Subject()
-target_no_sticky = Subject()
 target_with_prefix = Subject()
 target_include_with_prefix = Subject()
 target_both_prefix = Subject()
@@ -27,18 +26,6 @@ def router_watch_availability(rental: dict):
 @router.post("/video_rental/return_video")
 def router_post_return_video(return_video: ReturnVideo):
     target.on_next({"film": return_video.film_title, "available": True})
-
-
-@router.watch(
-    "/no_sticky/video_rental/{film_title}/available", target_no_sticky, sticky=False
-)
-def router_no_sticky_watch_availability(rental: dict):
-    return {"film_title": rental["film"]}, rental
-
-
-@router.post("/no_sticky/video_rental/return_video")
-def router_no_sticky_post_return_video(return_video: ReturnVideo):
-    target_no_sticky.on_next({"film": return_video.film_title, "available": True})
 
 
 @router_with_prefix.watch("/video_rental/{film_title}/available", target_with_prefix)

--- a/packages/api-server/api_server/test_fast_io.py
+++ b/packages/api-server/api_server/test_fast_io.py
@@ -1,6 +1,7 @@
 import time
 import unittest
-from concurrent.futures import Future, TimeoutError
+from concurrent import futures
+from concurrent.futures import Future
 
 import requests
 import socketio
@@ -98,4 +99,4 @@ class TestFastIO(unittest.TestCase):
             json={"film_title": "aegis rim"},
         )
         self.assertEqual(200, resp.status_code)
-        self.assertRaises(TimeoutError, lambda: fut.result(1))
+        self.assertRaises(futures.TimeoutError, lambda: fut.result(1))

--- a/packages/api-server/api_server/test_fast_io.py
+++ b/packages/api-server/api_server/test_fast_io.py
@@ -1,4 +1,3 @@
-import concurrent.futures
 import time
 import unittest
 from concurrent.futures import Future
@@ -67,42 +66,6 @@ class TestFastIO(unittest.TestCase):
 
     def test_receive_events(self):
         self.check_events("")
-
-    def test_get_endpoint_on_non_sticky_watch_returns_422(self):
-        resp = requests.get(
-            f"{self.base_url}/no_sticky/video_rental/aegis rim/available"
-        )
-        self.assertEqual(resp.status_code, 422)
-
-    def test_non_sticky_watch_does_not_send_last_event(self):
-        resp = requests.post(
-            f"{self.base_url}/no_sticky/video_rental/return_video",
-            json={"film_title": "aegis rim"},
-        )
-        self.assertEqual(resp.status_code, 200)
-
-        self.check_subscribe_success("/no_sticky")
-
-        event_fut = Future()
-        self.client.on(
-            "/no_sticky/video_rental/aegis rim/available", event_fut.set_result
-        )
-        self.assertRaises(concurrent.futures.TimeoutError, lambda: event_fut.result(1))
-        event_fut.cancel()
-
-    def test_non_sticky_watch_sends_new_events(self):
-        self.check_subscribe_success("/no_sticky")
-
-        event_fut = Future()
-        self.client.on(
-            "/no_sticky/video_rental/aegis rim/available", event_fut.set_result
-        )
-        resp = requests.post(
-            f"{self.base_url}/no_sticky/video_rental/return_video",
-            json={"film_title": "aegis rim"},
-        )
-        self.assertEqual(resp.status_code, 200)
-        event_fut.result(1)
 
     def test_receive_events_router_with_prefix(self):
         self.check_events("/router_with_prefix")

--- a/packages/dashboard-e2e/tests/ui-interactions.test.ts
+++ b/packages/dashboard-e2e/tests/ui-interactions.test.ts
@@ -107,7 +107,7 @@ describe('ui interactions', () => {
         $('button[aria-label="Submit"]').click();
         return $('div=Successfully created task').isDisplayed();
       },
-      { timeout: 5000, interval: 500 },
+      { timeout: 15000, interval: 500 },
     );
-  });
+  }).timeout(20000);
 });

--- a/packages/dashboard-e2e/tests/ui-interactions.test.ts
+++ b/packages/dashboard-e2e/tests/ui-interactions.test.ts
@@ -102,12 +102,10 @@ describe('ui interactions', () => {
     $('#start-location').setValue('coe');
     $('#finish-location').setValue('pantry');
 
-    browser.waitUntil(
-      () => {
-        $('button[aria-label="Submit"]').click();
-        return $('div=Successfully created task').isDisplayed();
-      },
-      { timeout: 15000, interval: 500 },
-    );
+    $('button[aria-label="Submit"]').click();
+    browser.waitUntil(() => $('div=Successfully created task').isDisplayed(), {
+      timeout: 15000,
+      interval: 500,
+    });
   }).timeout(20000);
 });

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -64,6 +64,7 @@
     "canvas": "^2.6.1",
     "chalk": "^4.1.0",
     "concurrently": "^5.3.0",
+    "debug": "^4.2.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.5",
     "enzyme-to-json": "^3.5.0",

--- a/packages/dashboard/src/components/tasks/auto-refresh.tsx
+++ b/packages/dashboard/src/components/tasks/auto-refresh.tsx
@@ -69,7 +69,7 @@ export function useAutoRefresh(
         } else {
           const newTasks = value;
           setTaskIds(newTasks.map((t) => t.task_id));
-          setTasks(value);
+          setTasks(newTasks);
         }
       },
     }),

--- a/packages/dashboard/src/components/tasks/auto-refresh.tsx
+++ b/packages/dashboard/src/components/tasks/auto-refresh.tsx
@@ -1,0 +1,66 @@
+import { SioClient, Subscription } from 'api-client';
+import React from 'react';
+import * as RmfModels from 'rmf-models';
+
+export interface AutoRefreshState {
+  tasks: RmfModels.TaskSummary[];
+  enabled: boolean;
+}
+
+export interface AutoRefreshDispatcher {
+  setTasks: React.Dispatch<React.SetStateAction<RmfModels.TaskSummary[]>>;
+  setEnabled: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export function useAutoRefresh(
+  sioClient?: SioClient,
+  initalTasks: RmfModels.TaskSummary[] | (() => RmfModels.TaskSummary[]) = [],
+  initialAutoRefresh: boolean | (() => boolean) = false,
+): [AutoRefreshState, AutoRefreshDispatcher] {
+  const [tasks, setTasks] = React.useState<RmfModels.TaskSummary[]>(initalTasks);
+  const [taskIds, setTaskIds] = React.useState<string[]>(() => tasks.map((t) => t.task_id));
+  const [enabled, setEnabled] = React.useState(initialAutoRefresh);
+
+  React.useEffect(() => {
+    if (!enabled || !sioClient) {
+      return;
+    }
+
+    const subscriptions: Subscription[] = [];
+
+    taskIds.forEach((taskId, idx) => {
+      subscriptions.push(
+        sioClient.subscribeTaskSummary(taskId, (newTask) =>
+          setTasks((prev) => [...prev.slice(0, idx), newTask, ...prev.slice(idx + 1)]),
+        ),
+      );
+    });
+
+    return () => {
+      subscriptions.forEach((s) => sioClient.unsubscribe(s));
+    };
+  }, [enabled, sioClient, taskIds]);
+
+  const autoRefreshState = React.useMemo(() => ({ tasks, enabled }), [tasks, enabled]);
+  const autoRefreshDispatcher = React.useMemo<AutoRefreshDispatcher>(
+    () => ({
+      setEnabled,
+      setTasks: (value) => {
+        if (typeof value === 'function') {
+          setTasks((prev) => {
+            const newTasks = value(prev);
+            setTaskIds(newTasks.map((t) => t.task_id));
+            return newTasks;
+          });
+        } else {
+          const newTasks = value;
+          setTaskIds(newTasks.map((t) => t.task_id));
+          setTasks(value);
+        }
+      },
+    }),
+    [],
+  );
+
+  return [autoRefreshState, autoRefreshDispatcher];
+}

--- a/packages/dashboard/src/components/tasks/auto-refresh.tsx
+++ b/packages/dashboard/src/components/tasks/auto-refresh.tsx
@@ -27,7 +27,7 @@ export interface AutoRefreshDispatcher {
 export function useAutoRefresh(
   sioClient?: SioClient,
   initalTasks: RmfModels.TaskSummary[] | (() => RmfModels.TaskSummary[]) = [],
-  initialAutoRefresh: boolean | (() => boolean) = false,
+  initialAutoRefresh: boolean | (() => boolean) = true,
 ): [AutoRefreshState, AutoRefreshDispatcher] {
   //TODO: See if it is possible to refactor this to be item agnostic, so it can be used for other components.
 

--- a/packages/dashboard/src/components/tasks/auto-refresh.tsx
+++ b/packages/dashboard/src/components/tasks/auto-refresh.tsx
@@ -12,11 +12,25 @@ export interface AutoRefreshDispatcher {
   setEnabled: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
+/**
+ * Helper hook to implement auto refresh feature of for task summaries. This helps to manage the
+ * tasks list state so that task events are only subscribed for the current list of tasks, and no
+ * extra subscribe/unsubscribe are made when a new task update comes in.
+ *
+ * task summaries event for a task is subscribed when:
+ *   1. auto refresh is enabled.
+ *   2. task is in the current set of tracked tasks.
+ *
+ * When the task list is change via the `setTasks` dispatch function, all current subscriptions are
+ * unsubscribed and the new tasks are subscribed.
+ */
 export function useAutoRefresh(
   sioClient?: SioClient,
   initalTasks: RmfModels.TaskSummary[] | (() => RmfModels.TaskSummary[]) = [],
   initialAutoRefresh: boolean | (() => boolean) = false,
 ): [AutoRefreshState, AutoRefreshDispatcher] {
+  //TODO: See if it is possible to refactor this to be item agnostic, so it can be used for other components.
+
   const [tasks, setTasks] = React.useState<RmfModels.TaskSummary[]>(initalTasks);
   const [taskIds, setTaskIds] = React.useState<string[]>(() => tasks.map((t) => t.task_id));
   const [enabled, setEnabled] = React.useState(initialAutoRefresh);

--- a/packages/dashboard/src/components/tasks/task-page.tsx
+++ b/packages/dashboard/src/components/tasks/task-page.tsx
@@ -67,11 +67,10 @@ export function TaskPage() {
       if (!tasksApi) {
         throw new Error('tasks api not available');
       }
-      for (const t of tasks) {
-        await tasksApi.submitTaskTasksSubmitTaskPost(t);
-      }
+      await Promise.all(tasks.map((t) => tasksApi.submitTaskTasksSubmitTaskPost(t)));
+      handleRefresh();
     },
-    [tasksApi],
+    [tasksApi, handleRefresh],
   );
 
   const cancelTask = React.useCallback<Required<TaskPanelProps>['cancelTask']>(

--- a/packages/dashboard/src/components/tasks/task-page.tsx
+++ b/packages/dashboard/src/components/tasks/task-page.tsx
@@ -54,11 +54,13 @@ export function TaskPage() {
     [tasksApi],
   );
 
-  React.useEffect(() => {
-    (async () => {
-      autoRefreshDispatcher.setTasks(await fetchTasks(page));
-    })();
+  const handleRefresh = React.useCallback<Required<TaskPanelProps>['onRefresh']>(async () => {
+    autoRefreshDispatcher.setTasks(await fetchTasks(page));
   }, [fetchTasks, page, autoRefreshDispatcher]);
+
+  React.useEffect(() => {
+    handleRefresh();
+  }, [handleRefresh]);
 
   const submitTasks = React.useCallback<Required<TaskPanelProps>['submitTasks']>(
     async (tasks) => {
@@ -108,6 +110,7 @@ export function TaskPage() {
       deliveryWaypoints={placeNames}
       submitTasks={submitTasks}
       cancelTask={cancelTask}
+      onRefresh={handleRefresh}
       onAutoRefresh={autoRefreshDispatcher.setEnabled}
     />
   );

--- a/packages/dashboard/src/components/tasks/tests/auto-refresh.test.tsx
+++ b/packages/dashboard/src/components/tasks/tests/auto-refresh.test.tsx
@@ -1,0 +1,81 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { SioClient } from 'api-client';
+import * as RmfModels from 'rmf-models';
+import { useAutoRefresh } from '../auto-refresh';
+
+function makeTasks(...taskIds: string[]) {
+  return taskIds.map((id) => new RmfModels.TaskSummary({ task_id: id }));
+}
+
+describe('auto refresh hook', () => {
+  let mockSubscribe: jest.Mock;
+  let mockUnsub: jest.Mock;
+  let sioClient: SioClient;
+
+  beforeEach(() => {
+    mockSubscribe = jest.fn().mockImplementation((_, listener) => listener);
+    mockUnsub = jest.fn();
+    sioClient = ({
+      subscribeTaskSummary: mockSubscribe,
+      unsubscribe: mockUnsub,
+    } as Partial<SioClient>) as SioClient;
+  });
+
+  it('smoke test', () => {
+    const { result } = renderHook(() => useAutoRefresh(sioClient));
+    let [state, dispatch] = result.current;
+
+    // mockSubscribe not called because auto refresh is disabled
+    // auto refresh should be disabled by default
+    act(() => {
+      dispatch.setTasks(makeTasks('task1', 'task2'));
+    });
+    [state, dispatch] = result.current;
+    expect(state.tasks).toHaveLength(2);
+    expect(mockSubscribe).not.toHaveBeenCalled();
+
+    // it should subscribe to the task events when auto refresh is enabled
+    act(() => {
+      dispatch.setEnabled(true);
+    });
+    [state, dispatch] = result.current;
+    expect(state.tasks).toHaveLength(2);
+    expect(state.enabled).toBe(true);
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+    const subscribedTasks = mockSubscribe.mock.calls.map((args) => args[0]);
+    expect(subscribedTasks).toContain('task1');
+    expect(subscribedTasks).toContain('task2');
+
+    // tasks should be unsubscribed when auto refresh is disabled
+    act(() => {
+      dispatch.setEnabled(false);
+    });
+    [state, dispatch] = result.current;
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+    expect(mockUnsub).toHaveBeenCalledTimes(2);
+    const subscriptions = mockSubscribe.mock.calls.map((args) => args[1]);
+    expect(mockUnsub).toHaveBeenCalledWith(subscriptions[0]);
+    expect(mockUnsub).toHaveBeenCalledWith(subscriptions[1]);
+  });
+
+  it('change subscriptions when tasks changes', () => {
+    const { result } = renderHook(() =>
+      useAutoRefresh(sioClient, makeTasks('task1', 'task2'), true),
+    );
+    let dispatch = result.current[1];
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      dispatch.setTasks(makeTasks('task3', 'task4'));
+    });
+    expect(mockSubscribe).toHaveBeenCalledTimes(4);
+    const subscribeCalls = mockSubscribe.mock.calls;
+    const newTaskIds = subscribeCalls.slice(2).map((args) => args[0]);
+    expect(newTaskIds).toContain('task3');
+    expect(newTaskIds).toContain('task4');
+    const subscriptions = subscribeCalls.map((args) => args[1]);
+    expect(mockUnsub).toHaveBeenCalledTimes(2);
+    expect(mockUnsub).toHaveBeenCalledWith(subscriptions[0]);
+    expect(mockUnsub).toHaveBeenCalledWith(subscriptions[1]);
+  });
+});

--- a/packages/dashboard/src/components/tasks/tests/auto-refresh.test.tsx
+++ b/packages/dashboard/src/components/tasks/tests/auto-refresh.test.tsx
@@ -22,7 +22,7 @@ describe('auto refresh hook', () => {
   });
 
   it('smoke test', () => {
-    const { result } = renderHook(() => useAutoRefresh(sioClient));
+    const { result } = renderHook(() => useAutoRefresh(sioClient, undefined, false));
     let [state, dispatch] = result.current;
 
     // mockSubscribe not called because auto refresh is disabled

--- a/packages/dashboard/src/components/tasks/tests/auto-refresh.test.tsx
+++ b/packages/dashboard/src/components/tasks/tests/auto-refresh.test.tsx
@@ -94,5 +94,8 @@ describe('auto refresh hook', () => {
     const state = result.current[0];
     expect(state.tasks).toHaveLength(1);
     expect(state.tasks[0].state).toBe(RmfModels.TaskSummary.STATE_QUEUED);
+    // check that no extra subscribe/unsubscribe is made when task is updated.
+    expect(mockSubscribe).toHaveBeenCalledTimes(1);
+    expect(mockUnsub).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-components/lib/robots/robot-table.tsx
+++ b/packages/react-components/lib/robots/robot-table.tsx
@@ -14,12 +14,11 @@ import {
   Typography,
 } from '@material-ui/core';
 import { Refresh as RefreshIcon } from '@material-ui/icons';
+import { TaskProgress } from 'api-client';
 import React from 'react';
 import * as RmfModels from 'rmf-models';
 import { taskTypeToStr } from '../tasks/utils';
-import { robotModeToString, allocateTasksToRobots, VerboseRobot } from './utils';
-import { PaginationOptions } from '../tasks/task-table';
-import { TaskProgress } from 'api-client';
+import { allocateTasksToRobots, robotModeToString, VerboseRobot } from './utils';
 
 const useStyles = makeStyles((theme) => ({
   table: {
@@ -115,6 +114,11 @@ function RobotRow({ robot, onClick }: RobotRowProps) {
     );
   }
 }
+
+export type PaginationOptions = Omit<
+  React.ComponentPropsWithoutRef<typeof TablePagination>,
+  'component'
+>;
 
 export interface RobotTableProps extends PaperProps {
   /**

--- a/packages/react-components/lib/tasks/task-panel.tsx
+++ b/packages/react-components/lib/tasks/task-panel.tsx
@@ -42,7 +42,7 @@ export interface TaskPanelProps extends React.HTMLProps<HTMLDivElement> {
    * Should only contain the tasks of the current page.
    */
   tasks: RmfModels.TaskSummary[];
-  paginationOptions: TaskTableProps['paginationOptions'];
+  paginationOptions?: TaskTableProps['paginationOptions'];
   cleaningZones?: string[];
   loopWaypoints?: string[];
   deliveryWaypoints?: string[];

--- a/packages/react-components/lib/tasks/task-panel.tsx
+++ b/packages/react-components/lib/tasks/task-panel.tsx
@@ -98,7 +98,7 @@ export function TaskPanel({
   const [openSnackbar, setOpenSnackbar] = React.useState(false);
   const [snackbarMessage, setSnackbarMessage] = React.useState('');
   const [snackbarSeverity, setSnackbarSeverity] = React.useState<AlertProps['severity']>('success');
-  const [autoRefresh, setAutoRefresh] = React.useState(false);
+  const [autoRefresh, setAutoRefresh] = React.useState(true);
 
   const handleCancelTask = React.useCallback(
     async (task: RmfModels.TaskSummary) => {

--- a/packages/react-components/lib/tasks/task-panel.tsx
+++ b/packages/react-components/lib/tasks/task-panel.tsx
@@ -194,29 +194,31 @@ export function TaskPanel({
           )}
         </Paper>
       </Grid>
-      <CreateTaskForm
-        cleaningZones={cleaningZones}
-        loopWaypoints={loopWaypoints}
-        deliveryWaypoints={deliveryWaypoints}
-        dispensers={dispensers}
-        ingestors={ingestors}
-        open={openCreateTaskForm}
-        onClose={() => setOpenCreateTaskForm(false)}
-        submitTasks={submitTasks}
-        tasksFromFile={tasksFromFile}
-        onCancelClick={() => setOpenCreateTaskForm(false)}
-        onSuccess={() => {
-          setOpenCreateTaskForm(false);
-          setSnackbarSeverity('success');
-          setSnackbarMessage('Successfully created task');
-          setOpenSnackbar(true);
-        }}
-        onFail={(e) => {
-          setSnackbarSeverity('error');
-          setSnackbarMessage(`Failed to create task: ${e.message}`);
-          setOpenSnackbar(true);
-        }}
-      />
+      {openCreateTaskForm && (
+        <CreateTaskForm
+          cleaningZones={cleaningZones}
+          loopWaypoints={loopWaypoints}
+          deliveryWaypoints={deliveryWaypoints}
+          dispensers={dispensers}
+          ingestors={ingestors}
+          open={openCreateTaskForm}
+          onClose={() => setOpenCreateTaskForm(false)}
+          submitTasks={submitTasks}
+          tasksFromFile={tasksFromFile}
+          onCancelClick={() => setOpenCreateTaskForm(false)}
+          onSuccess={() => {
+            setOpenCreateTaskForm(false);
+            setSnackbarSeverity('success');
+            setSnackbarMessage('Successfully created task');
+            setOpenSnackbar(true);
+          }}
+          onFail={(e) => {
+            setSnackbarSeverity('error');
+            setSnackbarMessage(`Failed to create task: ${e.message}`);
+            setOpenSnackbar(true);
+          }}
+        />
+      )}
       <input type="file" style={{ display: 'none' }} ref={uploadFileInputRef} />
       <Snackbar open={openSnackbar} onClose={() => setOpenSnackbar(false)} autoHideDuration={2000}>
         <Alert severity={snackbarSeverity}>{snackbarMessage}</Alert>

--- a/packages/react-components/lib/tasks/task-panel.tsx
+++ b/packages/react-components/lib/tasks/task-panel.tsx
@@ -7,9 +7,14 @@ import {
   TableContainer,
   TablePagination,
   Toolbar,
+  Tooltip,
   Typography,
 } from '@material-ui/core';
-import { AddOutlined as AddOutlinedIcon, Refresh as RefreshIcon } from '@material-ui/icons';
+import {
+  AddOutlined as AddOutlinedIcon,
+  Autorenew as AutorenewIcon,
+  Refresh as RefreshIcon,
+} from '@material-ui/icons';
 import { Alert, AlertProps } from '@material-ui/lab';
 import type { SubmitTask } from 'api-client';
 import React from 'react';
@@ -32,6 +37,9 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(2),
     marginLeft: theme.spacing(1),
     flex: '0 0 auto',
+  },
+  enabledToggleButton: {
+    background: theme.palette.action.selected,
   },
 }));
 
@@ -64,6 +72,7 @@ export interface TaskPanelProps extends React.HTMLProps<HTMLDivElement> {
   submitTasks?: CreateTaskFormProps['submitTasks'];
   cancelTask?: (task: RmfModels.TaskSummary) => Promise<void>;
   onRefresh?: () => void;
+  onAutoRefresh?: (enabled: boolean) => void;
 }
 
 export function TaskPanel({
@@ -77,6 +86,7 @@ export function TaskPanel({
   submitTasks,
   cancelTask,
   onRefresh,
+  onAutoRefresh,
   ...divProps
 }: TaskPanelProps): JSX.Element {
   const classes = useStyles();
@@ -88,6 +98,7 @@ export function TaskPanel({
   const [openSnackbar, setOpenSnackbar] = React.useState(false);
   const [snackbarMessage, setSnackbarMessage] = React.useState('');
   const [snackbarSeverity, setSnackbarSeverity] = React.useState<AlertProps['severity']>('success');
+  const [autoRefresh, setAutoRefresh] = React.useState(false);
 
   const handleCancelTask = React.useCallback(
     async (task: RmfModels.TaskSummary) => {
@@ -131,6 +142,8 @@ export function TaskPanel({
     });
   };
 
+  const autoRefreshTooltipPrefix = autoRefresh ? 'Disable' : 'Enable';
+
   return (
     <div {...divProps}>
       <Grid container wrap="nowrap" justify="center" style={{ height: 'inherit' }}>
@@ -139,12 +152,28 @@ export function TaskPanel({
             <Typography className={classes.tableTitle} variant="h6">
               Tasks
             </Typography>
-            <IconButton onClick={() => onRefresh && onRefresh()} aria-label="Refresh">
-              <RefreshIcon />
-            </IconButton>
-            <IconButton onClick={() => setOpenCreateTaskForm(true)} aria-label="Create Task">
-              <AddOutlinedIcon />
-            </IconButton>
+            <Tooltip title={`${autoRefreshTooltipPrefix} auto refresh`}>
+              <IconButton
+                className={autoRefresh ? classes.enabledToggleButton : undefined}
+                onClick={() => {
+                  setAutoRefresh((prev) => !prev);
+                  onAutoRefresh && onAutoRefresh(!autoRefresh);
+                }}
+                aria-label={`${autoRefreshTooltipPrefix} auto refresh`}
+              >
+                <AutorenewIcon />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Refersh">
+              <IconButton onClick={() => onRefresh && onRefresh()} aria-label="Refresh">
+                <RefreshIcon />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Create task">
+              <IconButton onClick={() => setOpenCreateTaskForm(true)} aria-label="Create Task">
+                <AddOutlinedIcon />
+              </IconButton>
+            </Tooltip>
           </Toolbar>
           <TableContainer>
             <TaskTable tasks={tasks} onTaskClick={(_ev, task) => setSelectedTask(task)} />

--- a/packages/react-components/lib/tasks/task-panel.tsx
+++ b/packages/react-components/lib/tasks/task-panel.tsx
@@ -1,24 +1,37 @@
-import { Grid, makeStyles, Paper, Snackbar, Typography } from '@material-ui/core';
+import {
+  Grid,
+  IconButton,
+  makeStyles,
+  Paper,
+  Snackbar,
+  TableContainer,
+  TablePagination,
+  Toolbar,
+  Typography,
+} from '@material-ui/core';
+import { AddOutlined as AddOutlinedIcon, Refresh as RefreshIcon } from '@material-ui/icons';
 import { Alert, AlertProps } from '@material-ui/lab';
 import type { SubmitTask } from 'api-client';
 import React from 'react';
 import * as RmfModels from 'rmf-models';
 import { CreateTaskForm, CreateTaskFormProps } from './create-task';
 import { TaskInfo } from './task-info';
-import { TaskTable, TaskTableProps } from './task-table';
+import { TaskTable } from './task-table';
 import { parseTasksFile } from './utils';
 
 const useStyles = makeStyles((theme) => ({
+  tableContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  tableTitle: {
+    flex: '1 1 100%',
+  },
   detailPanelContainer: {
     width: 350,
     padding: theme.spacing(2),
     marginLeft: theme.spacing(1),
     flex: '0 0 auto',
-  },
-  taskTable: {
-    height: '100%',
-    display: 'flex',
-    flexDirection: 'column',
   },
 }));
 
@@ -42,7 +55,7 @@ export interface TaskPanelProps extends React.HTMLProps<HTMLDivElement> {
    * Should only contain the tasks of the current page.
    */
   tasks: RmfModels.TaskSummary[];
-  paginationOptions?: TaskTableProps['paginationOptions'];
+  paginationOptions?: Omit<React.ComponentPropsWithoutRef<typeof TablePagination>, 'component'>;
   cleaningZones?: string[];
   loopWaypoints?: string[];
   deliveryWaypoints?: string[];
@@ -121,16 +134,25 @@ export function TaskPanel({
   return (
     <div {...divProps}>
       <Grid container wrap="nowrap" justify="center" style={{ height: 'inherit' }}>
-        <Grid style={{ flex: '1 1 auto' }}>
-          <TaskTable
-            className={classes.taskTable}
-            tasks={tasks}
-            paginationOptions={paginationOptions}
-            onCreateTaskClick={() => setOpenCreateTaskForm(true)}
-            onTaskClick={(_ev, task) => setSelectedTask(task)}
-            onRefreshClick={() => onRefresh && onRefresh()}
-          />
-        </Grid>
+        <Paper className={classes.tableContainer}>
+          <Toolbar>
+            <Typography className={classes.tableTitle} variant="h6">
+              Tasks
+            </Typography>
+            <IconButton onClick={() => onRefresh && onRefresh()} aria-label="Refresh">
+              <RefreshIcon />
+            </IconButton>
+            <IconButton onClick={() => setOpenCreateTaskForm(true)} aria-label="Create Task">
+              <AddOutlinedIcon />
+            </IconButton>
+          </Toolbar>
+          <TableContainer>
+            <TaskTable tasks={tasks} onTaskClick={(_ev, task) => setSelectedTask(task)} />
+          </TableContainer>
+          {paginationOptions && (
+            <TablePagination component="div" {...paginationOptions} style={{ flex: '0 0 auto' }} />
+          )}
+        </Paper>
         <Paper className={classes.detailPanelContainer}>
           {selectedTask ? (
             <TaskInfo

--- a/packages/react-components/lib/tasks/task-phases.tsx
+++ b/packages/react-components/lib/tasks/task-phases.tsx
@@ -1,4 +1,13 @@
-import { Box, Grid, makeStyles, Theme, Tooltip, Typography, useTheme } from '@material-ui/core';
+import {
+  Box,
+  BoxProps,
+  Grid,
+  makeStyles,
+  Theme,
+  Tooltip,
+  Typography,
+  useTheme,
+} from '@material-ui/core';
 import clsx from 'clsx';
 import React from 'react';
 import * as RmfModels from 'rmf-models';
@@ -92,11 +101,11 @@ function PhaseSeparator({ leftColor, rightColor }: PhaseSeparatorProps) {
   );
 }
 
-export interface TaskPhasesProps {
+export interface TaskPhasesProps extends BoxProps {
   taskSummary: RmfModels.TaskSummary;
 }
 
-export function TaskPhases({ taskSummary }: TaskPhasesProps): JSX.Element {
+export function TaskPhases({ taskSummary, ...boxProps }: TaskPhasesProps): JSX.Element {
   const classes = useStyles();
   const theme = useTheme();
   const phaseColors = getPhaseColors(theme);
@@ -138,7 +147,7 @@ export function TaskPhases({ taskSummary }: TaskPhasesProps): JSX.Element {
   });
 
   return (
-    <Box>
+    <Box {...boxProps}>
       <Grid container={true} wrap="nowrap" className={classes.taskPhasesContainer}>
         {phases.map((phase, idx) => (
           <React.Fragment key={idx}>

--- a/packages/react-components/lib/tasks/task-table.tsx
+++ b/packages/react-components/lib/tasks/task-table.tsx
@@ -21,6 +21,9 @@ const useStyles = makeStyles((theme) => ({
   phasesCell: {
     padding: `0 ${theme.spacing(1)}px`,
   },
+  phasesRow: {
+    marginBottom: theme.spacing(1),
+  },
 }));
 
 interface TaskRowProps {
@@ -53,7 +56,7 @@ function TaskRow({ task, onClick }: TaskRowProps) {
         onMouseOut={() => setHover(false)}
       >
         <TableCell className={classes.phasesCell} colSpan={5}>
-          <TaskPhases taskSummary={task}></TaskPhases>
+          <TaskPhases className={classes.phasesRow} taskSummary={task}></TaskPhases>
         </TableCell>
       </TableRow>
     </>

--- a/packages/react-components/lib/tasks/task-table.tsx
+++ b/packages/react-components/lib/tasks/task-table.tsx
@@ -1,19 +1,4 @@
-import {
-  IconButton,
-  makeStyles,
-  Paper,
-  PaperProps,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TablePagination,
-  TableRow,
-  Toolbar,
-  Typography,
-} from '@material-ui/core';
-import { AddOutlined as AddOutlinedIcon, Refresh as RefreshIcon } from '@material-ui/icons';
+import { makeStyles, Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core';
 import clsx from 'clsx';
 import { formatDistanceToNow } from 'date-fns';
 import React from 'react';
@@ -21,13 +6,9 @@ import * as RmfModels from 'rmf-models';
 import { rosTimeToJs } from '../utils';
 import { TaskPhases } from './task-phases';
 import { taskStateToStr } from './utils';
-
 const useStyles = makeStyles((theme) => ({
   table: {
     minWidth: 650,
-  },
-  title: {
-    flex: '1 1 100%',
   },
   taskRowHover: {
     background: theme.palette.action.hover,
@@ -83,70 +64,37 @@ const toRelativeDate = (rosTime: RmfModels.Time) => {
   return formatDistanceToNow(rosTimeToJs(rosTime), { addSuffix: true });
 };
 
-export type PaginationOptions = Omit<
-  React.ComponentPropsWithoutRef<typeof TablePagination>,
-  'component'
->;
-
-export interface TaskTableProps extends PaperProps {
+export interface TaskTableProps {
   /**
    * The current list of tasks to display, when pagination is enabled, this should only
    * contain the tasks for the current page.
    */
   tasks: RmfModels.TaskSummary[];
-  paginationOptions?: PaginationOptions;
-  onCreateTaskClick?: React.MouseEventHandler<HTMLButtonElement>;
   onTaskClick?(ev: React.MouseEvent<HTMLDivElement>, task: RmfModels.TaskSummary): void;
-  onRefreshClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
-export function TaskTable({
-  tasks,
-  paginationOptions,
-  onCreateTaskClick,
-  onTaskClick,
-  onRefreshClick,
-  ...paperProps
-}: TaskTableProps): JSX.Element {
+export function TaskTable({ tasks, onTaskClick }: TaskTableProps): JSX.Element {
   const classes = useStyles();
   return (
-    <Paper {...paperProps}>
-      <Toolbar>
-        <Typography className={classes.title} variant="h6">
-          Tasks
-        </Typography>
-        <IconButton onClick={onRefreshClick} aria-label="Refresh">
-          <RefreshIcon />
-        </IconButton>
-        <IconButton onClick={onCreateTaskClick} aria-label="Create Task">
-          <AddOutlinedIcon />
-        </IconButton>
-      </Toolbar>
-      <TableContainer style={{ flex: '1 1 auto' }}>
-        <Table className={classes.table} stickyHeader size="small" style={{ tableLayout: 'fixed' }}>
-          <TableHead>
-            <TableRow>
-              <TableCell>Task Id</TableCell>
-              <TableCell>Assignee</TableCell>
-              <TableCell>Start Time</TableCell>
-              <TableCell>End Time</TableCell>
-              <TableCell>State</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {tasks.map((task) => (
-              <TaskRow
-                key={task.task_id}
-                task={task}
-                onClick={(ev) => onTaskClick && onTaskClick(ev, task)}
-              />
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-      {paginationOptions && (
-        <TablePagination component="div" {...paginationOptions} style={{ flex: '0 0 auto' }} />
-      )}
-    </Paper>
+    <Table className={classes.table} stickyHeader size="small" style={{ tableLayout: 'fixed' }}>
+      <TableHead>
+        <TableRow>
+          <TableCell>Task Id</TableCell>
+          <TableCell>Assignee</TableCell>
+          <TableCell>Start Time</TableCell>
+          <TableCell>End Time</TableCell>
+          <TableCell>State</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {tasks.map((task) => (
+          <TaskRow
+            key={task.task_id}
+            task={task}
+            onClick={(ev) => onTaskClick && onTaskClick(ev, task)}
+          />
+        ))}
+      </TableBody>
+    </Table>
   );
 }

--- a/packages/react-components/stories/tasks/task-panel.stories.tsx
+++ b/packages/react-components/stories/tasks/task-panel.stories.tsx
@@ -1,14 +1,19 @@
 import { Meta, Story } from '@storybook/react';
 import React from 'react';
 import * as RmfModels from 'rmf-models';
-import { FetchTasksResult, TaskPanel as TaskPanel_, TaskPanelProps } from '../../lib';
+import { TaskPanel as TaskPanel_, TaskPanelProps } from '../../lib';
 import { makeTask } from '../../tests/test-data/tasks';
 
 export default {
   title: 'Tasks/Task Panel',
   component: TaskPanel_,
   argTypes: {
-    fetchTasks: {
+    tasks: {
+      table: {
+        disable: true,
+      },
+    },
+    paginationOptions: {
       table: {
         disable: true,
       },
@@ -33,10 +38,19 @@ const tasks = [
 ];
 
 export const TaskPanel: Story<TaskPanelProps> = (args) => {
+  const [page, setPage] = React.useState(0);
   return (
     <>
       <TaskPanel_
         {...args}
+        tasks={tasks.slice(page * 10, page * 10 + 10)}
+        paginationOptions={{
+          page,
+          count: tasks.length,
+          rowsPerPage: 10,
+          rowsPerPageOptions: [10],
+          onChangePage: (_ev, newPage) => setPage(newPage),
+        }}
         style={{ height: '95vh', margin: 'auto', maxWidth: 1600 }}
         submitTasks={() => new Promise((res) => setTimeout(res, 1000))}
         cancelTask={() => new Promise((res) => setTimeout(res, 1000))}
@@ -45,15 +59,7 @@ export const TaskPanel: Story<TaskPanelProps> = (args) => {
   );
 };
 
-async function fetchTasks(limit: number, offset: number): Promise<FetchTasksResult> {
-  return {
-    tasks: tasks.slice(offset, offset + limit),
-    totalCount: tasks.length,
-  };
-}
-
 TaskPanel.args = {
-  fetchTasks,
   cleaningZones: ['test_zone_0', 'test_zone_1'],
   loopWaypoints: ['test_waypoint_0', 'test_waypoint_1'],
   deliveryWaypoints: ['test_waypoint_0', 'test_waypoint_1'],

--- a/packages/react-components/stories/tasks/task-table.stories.tsx
+++ b/packages/react-components/stories/tasks/task-table.stories.tsx
@@ -1,9 +1,8 @@
-import { Snackbar } from '@material-ui/core';
-import { Alert, AlertProps } from '@material-ui/lab';
+import { Paper, TableContainer, TablePagination } from '@material-ui/core';
 import { Meta, Story } from '@storybook/react';
 import React from 'react';
 import * as RmfModels from 'rmf-models';
-import { CreateTaskForm, PaginationOptions, TaskTable, TaskTableProps } from '../../lib';
+import { TaskTable, TaskTableProps } from '../../lib';
 import { makeTask } from '../../tests/test-data/tasks';
 
 const failedTask = makeTask('failed_task', 3, 3);
@@ -40,53 +39,21 @@ export default {
 } as Meta;
 
 export const Table: Story<TaskTableProps> = (args) => {
-  const [openCreateTaskForm, setOpenCreateTaskForm] = React.useState(false);
-  const [openSnackbar, setOpenSnackbar] = React.useState(false);
-  const [snackbarMessage, setSnackbarMessage] = React.useState('');
-  const [snackbarSeverity, setSnackbarSeverity] = React.useState<AlertProps['severity']>('success');
   const [page, setPage] = React.useState(0);
-  const paginationOptions: PaginationOptions = {
-    count: args.tasks.length,
-    rowsPerPage: 10,
-    rowsPerPageOptions: [10],
-    page,
-    onChangePage: (_ev, newPage) => setPage(newPage),
-  };
   return (
-    <>
-      <TaskTable
-        {...args}
-        style={{ height: '95vh', display: 'flex', flexDirection: 'column' }}
-        tasks={args.tasks.slice(page * 10, (page + 1) * 10)}
-        paginationOptions={paginationOptions}
-        onCreateTaskClick={() => setOpenCreateTaskForm(true)}
+    <Paper>
+      <TableContainer>
+        <TaskTable {...args} tasks={args.tasks.slice(page * 10, (page + 1) * 10)} />
+      </TableContainer>
+      <TablePagination
+        component="div"
+        count={args.tasks.length}
+        rowsPerPage={10}
+        rowsPerPageOptions={[10]}
+        page={page}
+        onChangePage={(_ev, newPage) => setPage(newPage)}
       />
-      <CreateTaskForm
-        cleaningZones={['test_zone_0', 'test_zone_1']}
-        loopWaypoints={['test_waypoint_0', 'test_waypoint_1']}
-        deliveryWaypoints={['test_waypoint_0', 'test_waypoint_1']}
-        dispensers={['test_dispenser_0', 'test_dispenser_1']}
-        ingestors={['test_ingestor_0', 'test_ingestor_1']}
-        open={openCreateTaskForm}
-        onClose={() => setOpenCreateTaskForm(false)}
-        submitTasks={async () => new Promise((res) => setTimeout(res, 1000))}
-        onCancelClick={() => setOpenCreateTaskForm(false)}
-        onSuccess={() => {
-          setOpenCreateTaskForm(false);
-          setSnackbarSeverity('success');
-          setSnackbarMessage('Successfully created task');
-          setOpenSnackbar(true);
-        }}
-        onFail={(e) => {
-          setSnackbarSeverity('error');
-          setSnackbarMessage(`Failed to create task: ${e.message}`);
-          setOpenSnackbar(true);
-        }}
-      />
-      <Snackbar open={openSnackbar} onClose={() => setOpenSnackbar(false)} autoHideDuration={2000}>
-        <Alert severity={snackbarSeverity}>{snackbarMessage}</Alert>
-      </Snackbar>
-    </>
+    </Paper>
   );
 };
 

--- a/packages/react-components/tests/tasks/task-panel.spec.tsx
+++ b/packages/react-components/tests/tasks/task-panel.spec.tsx
@@ -5,24 +5,13 @@ import * as RmfModels from 'rmf-models';
 import { TaskPanel, TaskPanelProps } from '../../lib';
 import { makeTask } from '../test-data/tasks';
 
-function makeFetchTasks(tasks: RmfModels.TaskSummary[]): TaskPanelProps['fetchTasks'] {
-  return async (limit, offset) => {
-    return {
-      tasks: tasks.slice(offset, offset + limit),
-      totalCount: tasks.length,
-    };
-  };
-}
-
 describe('TaskPanel', () => {
   describe('task detail', () => {
     const mount = async (cancelTask?: TaskPanelProps['cancelTask']) => {
       const task = makeTask('test_task', 3, 3);
       task.task_profile.description.task_type.type = RmfModels.TaskType.TYPE_CLEAN;
       task.task_profile.description.clean.start_waypoint = 'test_waypoint';
-      const root = render(
-        <TaskPanel fetchTasks={makeFetchTasks([task])} cancelTask={cancelTask} />,
-      );
+      const root = render(<TaskPanel tasks={[task]} cancelTask={cancelTask} />);
       userEvent.click(await root.findByText('test_task'));
       return root;
     };
@@ -48,14 +37,14 @@ describe('TaskPanel', () => {
   });
 
   it('clicking on create task button opens the create task form', () => {
-    const root = render(<TaskPanel fetchTasks={makeFetchTasks([])} />);
+    const root = render(<TaskPanel tasks={[]} />);
     userEvent.click(root.getByLabelText('Create Task'));
     root.getByText('Create Task');
   });
 
   it('success snackbar is shown when successfully created a task', async () => {
     const spy = jasmine.createSpy().and.resolveTo(undefined);
-    const root = render(<TaskPanel fetchTasks={makeFetchTasks([])} submitTasks={spy} />);
+    const root = render(<TaskPanel tasks={[]} submitTasks={spy} />);
     userEvent.click(root.getByLabelText('Create Task'));
     userEvent.click(root.getByLabelText('Submit'));
     await waitFor(() => root.getByText('Successfully created task'));
@@ -63,7 +52,7 @@ describe('TaskPanel', () => {
 
   it('failure snackbar is shown when failed to created a task', async () => {
     const spy = jasmine.createSpy().and.rejectWith(new Error('error!!'));
-    const root = render(<TaskPanel fetchTasks={makeFetchTasks([])} submitTasks={spy} />);
+    const root = render(<TaskPanel tasks={[]} submitTasks={spy} />);
     userEvent.click(root.getByLabelText('Create Task'));
     userEvent.click(root.getByLabelText('Submit'));
     await waitFor(() => root.getByText('Failed to create task', { exact: false }));

--- a/packages/react-components/tests/tasks/task-panel.spec.tsx
+++ b/packages/react-components/tests/tasks/task-panel.spec.tsx
@@ -57,4 +57,39 @@ describe('TaskPanel', () => {
     userEvent.click(root.getByLabelText('Submit'));
     await waitFor(() => root.getByText('Failed to create task', { exact: false }));
   });
+
+  it('pagination is shown when pagination option is provided', () => {
+    const spy = jasmine.createSpy();
+    const root = render(
+      <TaskPanel
+        tasks={[makeTask('test', 1, 1)]}
+        paginationOptions={{
+          count: 1,
+          page: 0,
+          rowsPerPage: 10,
+          rowsPerPageOptions: [10],
+          onChangePage: spy,
+        }}
+      />,
+    );
+    root.getByText('1-1 of 1');
+  });
+
+  it('clicking on auto refresh button toggles auto refresh', () => {
+    const spy = jasmine.createSpy();
+    const root = render(<TaskPanel tasks={[]} onAutoRefresh={spy} />);
+    userEvent.click(root.getByLabelText('Enable auto refresh'));
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.calls.mostRecent().args[0]).toBe(true);
+    userEvent.click(root.getByLabelText('Disable auto refresh'));
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy.calls.mostRecent().args[0]).toBe(false);
+  });
+
+  it('clicking on refresh button triggers onRefresh', () => {
+    const spy = jasmine.createSpy();
+    const root = render(<TaskPanel tasks={[]} onRefresh={spy} />);
+    userEvent.click(root.getByLabelText('Refresh'));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/react-components/tests/tasks/task-panel.spec.tsx
+++ b/packages/react-components/tests/tasks/task-panel.spec.tsx
@@ -94,12 +94,12 @@ describe('TaskPanel', () => {
   it('clicking on auto refresh button toggles auto refresh', () => {
     const spy = jasmine.createSpy();
     const root = render(<TaskPanel tasks={[]} onAutoRefresh={spy} />);
-    userEvent.click(root.getByLabelText('Enable auto refresh'));
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy.calls.mostRecent().args[0]).toBe(true);
     userEvent.click(root.getByLabelText('Disable auto refresh'));
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledTimes(1);
     expect(spy.calls.mostRecent().args[0]).toBe(false);
+    userEvent.click(root.getByLabelText('Enable auto refresh'));
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy.calls.mostRecent().args[0]).toBe(true);
   });
 
   it('clicking on refresh button triggers onRefresh', () => {

--- a/packages/react-components/tests/tasks/task-table.spec.tsx
+++ b/packages/react-components/tests/tasks/task-table.spec.tsx
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import React from 'react';
 import * as RmfModels from 'rmf-models';
 import { TaskTable } from '../../lib';
@@ -11,20 +10,6 @@ describe('TaskTable', () => {
     const root = render(<TaskTable tasks={tasks} />);
     root.getByText('task_0');
     root.getByText('task_1');
-  });
-
-  it('clicking on create task button trigger onCreateTaskClick', () => {
-    const spy = jasmine.createSpy();
-    const root = render(<TaskTable tasks={[]} onCreateTaskClick={spy} />);
-    userEvent.click(root.getByLabelText('Create Task'));
-    expect(spy).toHaveBeenCalledTimes(1);
-  });
-
-  it('clicking on refresh button triggers onRefreshClick', () => {
-    const spy = jasmine.createSpy();
-    const root = render(<TaskTable tasks={[]} onRefreshClick={spy} />);
-    userEvent.click(root.getByLabelText('Refresh'));
-    expect(spy).toHaveBeenCalledTimes(1);
   });
 
   it('smoke test for different task states', () => {
@@ -43,22 +28,5 @@ describe('TaskTable', () => {
 
     const tasks = [activeTask, cancelledTask, completedTask, failedTask, pendingTask, queuedTask];
     render(<TaskTable tasks={tasks} />);
-  });
-
-  it('pagination is shown when pagination option is provided', () => {
-    const spy = jasmine.createSpy();
-    const root = render(
-      <TaskTable
-        tasks={[makeTask('test', 1, 1)]}
-        paginationOptions={{
-          count: 1,
-          page: 0,
-          rowsPerPage: 10,
-          rowsPerPageOptions: [10],
-          onChangePage: spy,
-        }}
-      />,
-    );
-    root.getByText('1-1 of 1');
   });
 });


### PR DESCRIPTION
## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

This adds a button on the task page to toggle auto refresh. "Auto refresh" may different meaning to different people, this PR implements auto refresh like this:

* Currently shown tasks on the task page will be listened for new task updates.
* Auto refresh never changes the ordering or the list of tasks currently shown, only currently shown tasks will be updated.
* Clicking the refresh button will fetch a new set of tasks from the server using the current filter/page settings, this may change the task list and/or the ordering of the tasks.

This means that when a new task is created, it won't appear on the task page without a manual refresh, even if auto refresh is turned on. However, when a task state or status changes, e.g. from `ACTIVE` to `COMPLETED` it will be automatically refreshed if auto refresh is turned on and the task is currently shown on the active page.

Other things that this PR adds:

* Wait for the task summary to be written to database before returning from submit task endpoint. This ensures that subsequent calls to `/tasks` will contain the new task.
* Add a small margin after each task phases row to make each task more easily distinguished.
* Add unsubscribe feature in the server.
* Add task summary endpoints in socket.io.

## Self-checks

- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
