### PR TITLE
reporting-server: refactor reporting-server with mocks

### DIFF
--- a/packages/reporting-server/parsers/test_auth_event_parser.py
+++ b/packages/reporting-server/parsers/test_auth_event_parser.py
@@ -1,13 +1,13 @@
 import unittest
 
-from models.dispenser_state import DispenserState
+from rest_server.__mocks__ import raw_data
 
 from .auth_event_parser import auth_event_parser
 
 
 class TestCaseAuthEvent(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
-        self.data = '[0m[0m20:41:54,721 INFO  [org.keycloak.events] (default task-2) JSON_EVENT::{"type":"LOGIN_ERROR","realmId":"579ce396-83c7-4094-964d-7ea07553089f","clientId":"reporting","ipAddress":"192.168.49.1","error":"user_not_found","auth_method":"openid-connect","auth_type":"code","redirect_uri":"https://example.com/reporting","code_id":"f813403c-2732-4062-9911-cf65b89a2278","username":"test"}'
+        self.data = raw_data.mock_keycloak_login_error["log"]
 
     async def test_parse_and_get_values(self):
         parsed_values = await auth_event_parser(self.data)

--- a/packages/reporting-server/parsers/test_dispenser_state_parser.py
+++ b/packages/reporting-server/parsers/test_dispenser_state_parser.py
@@ -1,15 +1,15 @@
 import unittest
 
 from models.dispenser_state import DispenserState
+from rest_server.__mocks__.parsed_data import mock_dispenser_state
 
 from .dispenser_state_parser import dispenser_state_parser
-
-# {'log': 'INFO:app.BookKeeper.dispenser_state:{"time": {"sec": 1600, "nanosec": 0}, "guid": "coke_dispenser", "mode": 0, "request_guid_queue": [], "seconds_remaining": 0.0}\n', 'stream': 'stdout'}
 
 
 class TestCaseDispenserState(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
-        self.data = 'dispenser_state:{"time": {"sec": 1600, "nanosec": 0}, "guid": "coke_dispenser", "mode": 0, "request_guid_queue": [], "seconds_remaining": 0.0}\n'
+
+        self.data = mock_dispenser_state
 
     async def test_parse_and_get_values(self):
         parsed_values = await dispenser_state_parser(self.data)

--- a/packages/reporting-server/parsers/test_doors_state_parser.py
+++ b/packages/reporting-server/parsers/test_doors_state_parser.py
@@ -1,13 +1,14 @@
 import unittest
 
 from models.door_state import DoorState
+from rest_server.__mocks__.parsed_data import mock_door_state
 
 from .doors_state_parser import doors_state_parser
 
 
 class TestCaseDoorsState(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
-        self.data = 'door_state:{"door_time": {"sec": 1596, "nanosec": 548000000}, "door_name": "hardware_door", "current_mode": {"value": 0}}\n'
+        self.data = mock_door_state
 
     async def test_parse_and_get_values(self):
         parsed_values = await doors_state_parser(self.data)

--- a/packages/reporting-server/parsers/test_fleet_state_parser.py
+++ b/packages/reporting-server/parsers/test_fleet_state_parser.py
@@ -1,13 +1,14 @@
 import unittest
 
 from models.fleet_state import FleetState
+from rest_server.__mocks__.parsed_data import mock_fleet_state
 
 from .fleet_state_parser import fleet_state_parser
 
 
 class TestCaseFleetState(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
-        self.data = 'fleet_state:{"name": "tinyRobot", "robots": [{"name": "tinyRobot1", "model": "", "task_id": "", "seq": 3190, "mode": {"mode": 1, "mode_request_id": 0}, "battery_percent": 100.0, "location": {"t": {"sec": 1598, "nanosec": 184999999}, "x": 11.553672790527344, "y": -11.317496299743652, "yaw": -1.599777340888977, "level_name": "L1", "index": 0}, "path": []}, {"name": "tinyRobot2", "model": "", "task_id": "", "seq": 3191, "mode": {"mode": 1, "mode_request_id": 0}, "battery_percent": 100.0, "location": {"t": {"sec": 1598, "nanosec": 685999999}, "x": 15.157517433166504, "y": -11.228611946105957, "yaw": -1.5839587450027466, "level_name": "L1", "index": 0}, "path": []}]}\n'
+        self.data = mock_fleet_state
 
     async def test_parse_and_get_values(self):
         parsed_values = await fleet_state_parser(self.data)

--- a/packages/reporting-server/parsers/test_health_parser.py
+++ b/packages/reporting-server/parsers/test_health_parser.py
@@ -1,10 +1,6 @@
 import unittest
 
-from models.health import HealthStatus
-
 from .health_parser import health_status_parser
-
-# {'log': 'INFO:app.BookKeeper.door_health:{"id": "hardware_door", "health_status": "HealthStatus.HEALTHY", "health_message": null}\n', 'stream': 'stdout'}
 
 
 class TestCaseHealth(unittest.IsolatedAsyncioTestCase):

--- a/packages/reporting-server/parsers/test_ingestor_parser.py
+++ b/packages/reporting-server/parsers/test_ingestor_parser.py
@@ -1,15 +1,14 @@
 import unittest
 
 from models.ingestor_state import IngestorState
+from rest_server.__mocks__.parsed_data import mock_ingestor_state
 
 from .ingestor_state_parser import ingestor_state_parser
-
-# {'log': 'INFO:app.BookKeeper.ingestor_state:{"time": {"sec": 1600, "nanosec": 0}, "guid": "coke_ingestor", "mode": 0, "request_guid_queue": [], "seconds_remaining": 0.0}\n', 'stream': 'stdout'}
 
 
 class TestCaseIngestorState(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
-        self.data = 'ingestor_state:{"time": {"sec": 1600, "nanosec": 0}, "guid": "coke_ingestor", "mode": 0, "request_guid_queue": [], "seconds_remaining": 0.0}\n'
+        self.data = mock_ingestor_state
 
     async def test_parse_and_get_values(self):
         parsed_values = await ingestor_state_parser(self.data)

--- a/packages/reporting-server/parsers/test_lift_state_parser.py
+++ b/packages/reporting-server/parsers/test_lift_state_parser.py
@@ -1,15 +1,14 @@
 import unittest
 
 from models.lift_state import LiftState
+from rest_server.__mocks__.parsed_data import mock_lift_state
 
 from .lift_state_parser import lift_state_parser
-
-# {'log': 'INFO:app.BookKeeper.lift_state:{"time": {"sec": 1600, "nanosec": 0}, "state": 1, "mode": 0, "request_guid_queue": [], "seconds_remaining": 0.0}\n', 'stream': 'stdout'}
 
 
 class TestCaseLiftState(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
-        self.data = 'lift_state: {"lift_name": "test_lift", "lift_time": 0, "available_floors": ["L1", "L2"], "current_floor": "L1", "destination_floor": "L2", "door_state": 0, "motion_state": 0, "available_modes": [0], "current_mode": 0, "session_id": "test_session"}\n'
+        self.data = mock_lift_state
         self.data_with_dict_states = 'lift_state: {"lift_name": "test_lift", "lift_time": 0, "available_floors": ["L1", "L2"], "current_floor": "L1", "destination_floor": "L2", "door_state": {"value": 0}, "motion_state": {"value": 0}, "available_modes": [0], "current_mode": {"value": 0}, "session_id": "test_session"}\n'
 
     async def test_parse_and_get_values(self):

--- a/packages/reporting-server/parsers/test_task_summary_parser.py
+++ b/packages/reporting-server/parsers/test_task_summary_parser.py
@@ -1,13 +1,14 @@
 import unittest
 
 from models.task_summary import TaskSummary
+from rest_server.__mocks__.parsed_data import mock_task_summary
 
 from .task_summary_parser import task_summary_parser
 
 
 class TestCaseTaskSummary(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
-        self.data = 'task_summary:{"fleet_name": "tinyRobot", "task_id": "Loop0", "task_profile": {"task_id": "Loop0", "submission_time": {"sec": 131, "nanosec": 553000000}, "description": {"start_time": {"sec": 1623383402, "nanosec": 0}, "priority": {"value": 0}, "task_type": {"type": 1}, "station": {"task_id": "", "robot_type": "", "place_name": ""}, "loop": {"task_id": "", "robot_type": "", "num_loops": 1, "start_name": "supplies", "finish_name": "coe"}, "delivery": {"task_id": "", "items": [], "pickup_place_name": "", "pickup_dispenser": "", "pickup_behavior": {"name": "", "parameters": []}, "dropoff_place_name": "", "dropoff_ingestor": "", "dropoff_behavior": {"name": "", "parameters": []}}, "clean": {"start_waypoint": ""}}}, "state": 0, "status": "", "submission_time": {"sec": 0, "nanosec": 0}, "start_time": {"sec": 1623383362, "nanosec": 348338289}, "end_time": {"sec": 1623383449, "nanosec": 79154833}, "robot_name": "tinyRobot2"}\n'
+        self.data = mock_task_summary
 
     async def test_parse_and_get_values(self):
         parsed_values = await task_summary_parser(self.data)

--- a/packages/reporting-server/rest_server/__mocks__/parsed_data.py
+++ b/packages/reporting-server/rest_server/__mocks__/parsed_data.py
@@ -1,0 +1,23 @@
+from . import raw_data
+
+
+def parse_log(log):
+    modified_log = log["log"].replace("INFO:app.BookKeeper.", "")
+    return modified_log
+
+
+# States
+mock_dispenser_state: str = parse_log(raw_data.mock_dispenser_state)
+
+mock_door_state: str = parse_log(raw_data.mock_door_state)
+
+mock_fleet_state: str = parse_log(raw_data.mock_fleet_state)
+
+mock_task_summary: str = parse_log(raw_data.mock_task_summary)
+
+mock_ingestor_state: str = parse_log(raw_data.mock_ingestor_state)
+
+mock_lift_state: str = parse_log(raw_data.mock_lift_state)
+
+# Health
+mock_door_health: str = parse_log(raw_data.mock_door_health)

--- a/packages/reporting-server/rest_server/__mocks__/raw_data.py
+++ b/packages/reporting-server/rest_server/__mocks__/raw_data.py
@@ -1,0 +1,67 @@
+# States
+mock_dispenser_state = {
+    "log": 'INFO:app.BookKeeper.dispenser_state:{"time": {"sec": 1600, "nanosec": 0}, "guid": "coke_dispenser", "mode": 0, "request_guid_queue": [], "seconds_remaining": 0.0}\n',
+    "stream": "stdout",
+    "kubernetes": {
+        "container_name": "app-that-writes-logs",
+        "namespace_name": "default",
+        "pod_name": "app-that-writes-logs",
+        "container_image": "busybox:latest",
+        "container_image_id": "docker-pullable://busybox@sha256:ae39a6f5c07297d7ab64dbd4f82c77c874cc6a94cea29fdec309d0992574b4f7",
+        "pod_id": "978761c6-2a19-422f-b710-d43da2348f1f",
+        "host": "minikube",
+        "master_url": "https://10.96.0.1:443/api",
+        "namespace_id": "e192acd4-e6e7-46c2-8514-44a27a367749",
+    },
+}
+
+mock_door_state = {
+    "log": 'INFO:app.BookKeeper.door_state:{"door_time": {"sec": 1596, "nanosec": 548000000}, "door_name": "hardware_door", "current_mode": {"value": 0}}\n',
+    "stream": "stdout",
+}
+
+mock_fleet_state = {
+    "log": 'INFO:app.BookKeeper.fleet_state:{"name": "tinyRobot", "robots": [{"name": "tinyRobot1", "model": "", "task_id": "", "seq": 3194, "mode": {"mode": 1, "mode_request_id": 0}, "battery_percent": 100.0, "location": {"t": {"sec": 1600, "nanosec": 189000000}, "x": 11.55367374420166, "y": -11.317498207092285, "yaw": -1.5998055934906006, "level_name": "L1", "index": 0}, "path": []}, {"name": "tinyRobot2", "model": "", "task_id": "", "seq": 3194, "mode": {"mode": 1, "mode_request_id": 0}, "battery_percent": 100.0, "location": {"t": {"sec": 1600, "nanosec": 189000000}, "x": 15.15751838684082, "y": -11.22861385345459, "yaw": -1.5839799642562866, "level_name": "L1", "index": 0}, "path": []}]}\n',
+    "stream": "stdout",
+}
+
+mock_task_summary = {
+    "log": 'INFO:app.BookKeeper.task_summary:{"fleet_name": "tinyRobot", "task_id": "Loop0", "task_profile": {"task_id": "Loop0", "submission_time": {"sec": 131, "nanosec": 553000000}, "description": {"start_time": {"sec": 1623383402, "nanosec": 0}, "priority": {"value": 0}, "task_type": {"type": 1}, "station": {"task_id": "", "robot_type": "", "place_name": ""}, "loop": {"task_id": "", "robot_type": "", "num_loops": 1, "start_name": "supplies", "finish_name": "coe"}, "delivery": {"task_id": "", "items": [], "pickup_place_name": "", "pickup_dispenser": "", "pickup_behavior": {"name": "", "parameters": []}, "dropoff_place_name": "", "dropoff_ingestor": "", "dropoff_behavior": {"name": "", "parameters": []}}, "clean": {"start_waypoint": ""}}}, "state": 0, "status": "", "submission_time": {"sec": 0, "nanosec": 0}, "start_time": {"sec": 1623383362, "nanosec": 348338289}, "end_time": {"sec": 1623383449, "nanosec": 79154833}, "robot_name": "tinyRobot2"}\n',
+    "stream": "stdout",
+}
+
+mock_ingestor_state = {
+    "log": 'INFO:app.BookKeeper.ingestor_state:{"time": {"sec": 1600, "nanosec": 0}, "guid": "coke_ingestor", "mode": 0, "request_guid_queue": [], "seconds_remaining": 0.0}\n',
+    "stream": "stdout",
+}
+
+mock_lift_state = {
+    "log": 'INFO:app.BookKeeper.lift_state: {"lift_name": "test_lift", "lift_time": 0, "available_floors": ["L1", "L2"], "current_floor": "L1", "destination_floor": "L2", "door_state": 0, "motion_state": 0, "available_modes": [0], "current_mode": 0, "session_id": "test_session"}\n',
+    "stream": "stdout",
+}
+
+
+# Health
+mock_door_health = {
+    "log": 'INFO:app.BookKeeper.door_health:{"id": "hardware_door", "health_status": "HealthStatus.HEALTHY", "health_message": null}\n',
+    "stream": "stdout",
+}
+
+# Keycloak
+mock_keycloak_login_error = {
+    "log": '[0m[0m20:41:54,721 INFO  [org.keycloak.events] (default task-2) JSON_EVENT::{"type":"LOGIN_ERROR","realmId":"579ce396-83c7-4094-964d-7ea07553089f","clientId":"reporting","ipAddress":"192.168.49.1","error":"user_not_found","auth_method":"openid-connect","auth_type":"code","redirect_uri":"https://example.com/reporting","code_id":"f813403c-2732-4062-9911-cf65b89a2278","username":"test"}',
+    "stream": "stdout",
+    "kubernetes": {
+        "container_name": "app-that-writes-logs",
+    },
+}
+
+mock_keycloak_login = {
+    "log": '19:47:08,004 INFO  [org.keycloak.events] (default task-3) JSON_EVENT::{"type":"LOGIN","realmId":"master","clientId":"security-admin-console","userId":"7d2f3cdd-9778-4847-ab9d-db68f70f043f","ipAddress":"172.22.0.1","auth_method":"openid-connect","auth_type":"code","redirect_uri":"http://localhost:8080/auth/admin/master/console/","consent":"no_consent_required","code_id":"ac8c82d7-45ac-4227-86d3-e167b176e26f","username":"admin"}',
+    "stream": "stdout",
+}
+
+mock_keycloak_logout = {
+    "log": '19:47:20,649 INFO  [org.keycloak.events] (default task-6) JSON_EVENT::{"type":"LOGOUT","realmId":"master","userId":"7d2f3cdd-9778-4847-ab9d-db68f70f043f","ipAddress":"172.22.0.1","redirect_uri":"http://localhost:8080/auth/admin/master/console/#/realms/master"}',
+    "stream": "stdout",
+}

--- a/packages/reporting-server/rest_server/__mocks__/raw_data.py
+++ b/packages/reporting-server/rest_server/__mocks__/raw_data.py
@@ -21,7 +21,7 @@ mock_door_state = {
 }
 
 mock_fleet_state = {
-    "log": 'INFO:app.BookKeeper.fleet_state:{"name": "tinyRobot", "robots": [{"name": "tinyRobot1", "model": "", "task_id": "", "seq": 3194, "mode": {"mode": 1, "mode_request_id": 0}, "battery_percent": 100.0, "location": {"t": {"sec": 1600, "nanosec": 189000000}, "x": 11.55367374420166, "y": -11.317498207092285, "yaw": -1.5998055934906006, "level_name": "L1", "index": 0}, "path": []}, {"name": "tinyRobot2", "model": "", "task_id": "", "seq": 3194, "mode": {"mode": 1, "mode_request_id": 0}, "battery_percent": 100.0, "location": {"t": {"sec": 1600, "nanosec": 189000000}, "x": 15.15751838684082, "y": -11.22861385345459, "yaw": -1.5839799642562866, "level_name": "L1", "index": 0}, "path": []}]}\n',
+    "log": 'INFO:app.BookKeeper.fleet_state:{"name": "tinyRobot", "robots": [{"name": "tinyRobot1", "model": "", "task_id": "", "seq": 3190, "mode": {"mode": 1, "mode_request_id": 0}, "battery_percent": 100.0, "location": {"t": {"sec": 1598, "nanosec": 184999999}, "x": 11.553672790527344, "y": -11.317496299743652, "yaw": -1.599777340888977, "level_name": "L1", "index": 0}, "path": []}, {"name": "tinyRobot2", "model": "", "task_id": "", "seq": 3191, "mode": {"mode": 1, "mode_request_id": 0}, "battery_percent": 100.0, "location": {"t": {"sec": 1598, "nanosec": 685999999}, "x": 15.157517433166504, "y": -11.228611946105957, "yaw": -1.5839587450027466, "level_name": "L1", "index": 0}, "path": []}]}\n',
     "stream": "stdout",
 }
 

--- a/packages/reporting-server/rest_server/repositories/test_log_creation_handler.py
+++ b/packages/reporting-server/rest_server/repositories/test_log_creation_handler.py
@@ -5,6 +5,7 @@ import unittest
 from fastapi.testclient import TestClient
 from models import DispenserState, DoorState, RawLog
 from models.auth_events import AuthEvents
+from rest_server.__mocks__ import raw_data
 from rest_server.app import get_app
 from tortoise import Tortoise
 
@@ -34,17 +35,7 @@ class TestCaseLogRMFServerCreationRepository(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response, "No data received")
 
     async def test_create_a_rmfserver_log_correctly(self):
-        data = [
-            {
-                "log": 'INFO:app.BookKeeper.dispenser_state:{"time": {"sec": 1600, "nanosec": 0}, "guid": "coke_dispenser", "mode": 0, "request_guid_queue": [], "seconds_remaining": 0.0}\n',
-                "stream": "stdout",
-            },
-            {
-                "log": 'INFO:app.BookKeeper.door_state:{"door_time": {"sec": 1596, "nanosec": 548000000}, "door_name": "hardware_door", "current_mode": {"value": 0}}\n',
-                "stream": "stdout",
-            },
-        ]
-
+        data = [raw_data.mock_dispenser_state, raw_data.mock_door_state]
         response = await create_rmf_server_log(data)
         self.assertEqual(response, "Logs were saved correctly")
 
@@ -54,28 +45,16 @@ class TestCaseLogRMFServerCreationRepository(unittest.IsolatedAsyncioTestCase):
                 "log2": 'INFO:app.BookKeeper.dispenser_state:{"time": {"sec": 1600, "nanosec": 0}, "guid": "coke_dispenser", "mode": 0, "request_guid_queue": [], "seconds_remaining": 0.0}\n',
                 "stream": "stdout",
             },
-            {
-                "log": 'INFO:app.BookKeeper.door_state:{"door_time": {"sec": 1596, "nanosec": 548000000}, "door_name": "hardware_door", "current_mode": {"value": 0}}\n',
-                "stream": "stdout",
-            },
+            raw_data.mock_door_state,
         ]
 
         response = await create_rmf_server_log(data)
         self.assertEqual(len(response), 1)
 
     async def test_rmfserver_handle_creation_of_logs(self):
-        data = [
-            {
-                "log": 'INFO:app.BookKeeper.dispenser_state:{"time": {"sec": 1600, "nanosec": 0}, "guid": "coke_dispenser", "mode": 0, "request_guid_queue": [], "seconds_remaining": 0.0}\n',
-                "stream": "stdout",
-            },
-            {
-                "log": 'INFO:app.BookKeeper.door_state:{"door_time": {"sec": 1596, "nanosec": 548000000}, "door_name": "hardware_door", "current_mode": {"value": 0}}\n',
-                "stream": "stdout",
-            },
-        ]
-
-        await create_rmf_server_log(data)
+        await create_rmf_server_log(
+            [raw_data.mock_dispenser_state, raw_data.mock_door_state]
+        )
         dispenser = await DispenserState.first()
         door = await DoorState.first()
         self.assertEqual(dispenser.guid, "coke_dispenser")
@@ -100,86 +79,36 @@ class TestCaseRawLogCreationRepository(unittest.IsolatedAsyncioTestCase):
 
     async def test_create_a_raw_log_correctly(self):
         data = [
-            {
-                "log": 'INFO:app.BookKeeper.dispenser_state:{"time": {"sec": 1600, "nanosec": 0}, "guid": "coke_dispenser", "mode": 0, "request_guid_queue": [], "seconds_remaining": 0.0}\n',
-                "stream": "stdout",
-            },
-            {
-                'INFO:app.BookKeeper.door_state:{"door_time": {"sec": 1596, "nanosec": 548000000}, "door_name": "hardware_door", "current_mode": {"value": 0}}\n'
-            },
+            raw_data.mock_dispenser_state,
+            raw_data.mock_door_state,
             "this is a test",
         ]
-
         response = await create_raw_log(data)
         self.assertEqual(response, "Logs were saved correctly")
 
     async def test_raw_log_handle_creation_of_logs(self):
         data = [
-            {
-                "log": 'INFO:app.BookKeeper.dispenser_state:{"time": {"sec": 1600, "nanosec": 0}, "guid": "coke_dispenser", "mode": 0, "request_guid_queue": [], "seconds_remaining": 0.0}\n',
-                "stream": "stdout",
-            },
-            {
-                "log": 'INFO:app.BookKeeper.door_state:{"door_time": {"sec": 1596, "nanosec": 548000000}, "door_name": "hardware_door", "current_mode": {"value": 0}}\n',
-                "stream": "stdout",
-            },
+            raw_data.mock_dispenser_state,
+            raw_data.mock_door_state,
             "this is a test",
         ]
-
         await create_raw_log(data)
         dispenser = await RawLog.all()
         self.assertEqual(len(dispenser), 3)
 
     async def test_raw_log_handle_creation_of_logs_with_container_name(self):
-        data = [
-            {
-                "log": 'INFO:app.BookKeeper.dispenser_state:{"time": {"sec": 1600, "nanosec": 0}, "guid": "coke_dispenser", "mode": 0, "request_guid_queue": [], "seconds_remaining": 0.0}\n',
-                "stream": "stdout",
-                "kubernetes": {
-                    "container_name": "app-that-writes-logs",
-                    "namespace_name": "default",
-                    "pod_name": "app-that-writes-logs",
-                    "container_image": "busybox:latest",
-                    "container_image_id": "docker-pullable://busybox@sha256:ae39a6f5c07297d7ab64dbd4f82c77c874cc6a94cea29fdec309d0992574b4f7",
-                    "pod_id": "978761c6-2a19-422f-b710-d43da2348f1f",
-                    "host": "minikube",
-                    "master_url": "https://10.96.0.1:443/api",
-                    "namespace_id": "e192acd4-e6e7-46c2-8514-44a27a367749",
-                },
-            },
-        ]
-
-        await create_raw_log(data)
+        await create_raw_log([raw_data.mock_dispenser_state])
         log = await RawLog.first()
         self.assertEqual(log.container_name, "app-that-writes-logs")
 
     async def test_keycloak_log_creation(self):
-        data = [
-            {
-                "log": '[0m[0m20:41:54,721 INFO  [org.keycloak.events] (default task-2) JSON_EVENT::{"type":"LOGIN_ERROR","realmId":"579ce396-83c7-4094-964d-7ea07553089f","clientId":"reporting","ipAddress":"192.168.49.1","error":"user_not_found","auth_method":"openid-connect","auth_type":"code","redirect_uri":"https://example.com/reporting","code_id":"f813403c-2732-4062-9911-cf65b89a2278","username":"test"}',
-                "stream": "stdout",
-                "kubernetes": {
-                    "container_name": "app-that-writes-logs",
-                },
-            },
-            {
-                "log": '19:47:08,004 INFO  [org.keycloak.events] (default task-3) JSON_EVENT::{"type":"LOGIN","realmId":"master","clientId":"security-admin-console","userId":"7d2f3cdd-9778-4847-ab9d-db68f70f043f","ipAddress":"172.22.0.1","auth_method":"openid-connect","auth_type":"code","redirect_uri":"http://localhost:8080/auth/admin/master/console/","consent":"no_consent_required","code_id":"ac8c82d7-45ac-4227-86d3-e167b176e26f","username":"admin"}',
-                "stream": "stdout",
-            },
-        ]
-
-        await create_keycloak_log(data)
+        await create_keycloak_log(
+            [raw_data.mock_keycloak_login_error, raw_data.mock_keycloak_login]
+        )
         logs = await AuthEvents.all()
         self.assertEqual(len(logs), 2)
 
     async def test_keycloak_logout_creation(self):
-        data = [
-            {
-                "log": '19:47:20,649 INFO  [org.keycloak.events] (default task-6) JSON_EVENT::{"type":"LOGOUT","realmId":"master","userId":"7d2f3cdd-9778-4847-ab9d-db68f70f043f","ipAddress":"172.22.0.1","redirect_uri":"http://localhost:8080/auth/admin/master/console/#/realms/master"}',
-                "stream": "stdout",
-            },
-        ]
-
-        await create_keycloak_log(data)
+        await create_keycloak_log([raw_data.mock_keycloak_logout])
         logs = await AuthEvents.all()
         self.assertEqual(len(logs), 1)

--- a/packages/reporting-server/rest_server/repositories/test_parser_dispatcher.py
+++ b/packages/reporting-server/rest_server/repositories/test_parser_dispatcher.py
@@ -39,7 +39,6 @@ class TestCaseLogParserDispatcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(instance.guid, "coke_dispenser")
 
     async def test_door_state_created(self):
-        print(parsed_data.mock_door_state)
         await log_model_dispatcher(parsed_data.mock_door_state)
         instance = await DoorState.first()
         self.assertEqual(instance.name, "hardware_door")

--- a/packages/reporting-server/rest_server/repositories/test_parser_dispatcher.py
+++ b/packages/reporting-server/rest_server/repositories/test_parser_dispatcher.py
@@ -13,24 +13,10 @@ from models import (
     LiftState,
     TaskSummary,
 )
+from rest_server.__mocks__ import parsed_data
 from rest_server.app import get_app
 
 from .parser_dispatcher import log_model_dispatcher
-
-# Example of logs
-# {'log': 'INFO:app.BookKeeper.dispenser_state:{"time": {"sec": 1600, "nanosec": 0}, "guid": "coke_dispenser", "mode": 0, "request_guid_queue": [], "seconds_remaining": 0.0}\n', 'stream': 'stdout'}
-
-# {'log': 'INFO:app.BookKeeper.door_state:{"door_time": {"sec": 1596, "nanosec": 548000000}, "door_name": "hardware_door", "current_mode": {"value": 0}}\n', 'stream': 'stdout'}
-
-# 'INFO:app.BookKeeper.fleet_state:{"name": "tinyRobot", "robots": [{"name": "tinyRobot1", "model": "", "task_id": "", "seq": 3194, "mode": {"mode": 1, "mode_request_id": 0}, "battery_percent": 100.0, "location": {"t": {"sec": 1600, "nanosec": 189000000}, "x": 11.55367374420166, "y": -11.317498207092285, "yaw": -1.5998055934906006, "level_name": "L1", "index": 0}, "path": []}, {"name": "tinyRobot2", "model": "", "task_id": "", "seq": 3194, "mode": {"mode": 1, "mode_request_id": 0}, "battery_percent": 100.0, "location": {"t": {"sec": 1600, "nanosec": 189000000}, "x": 15.15751838684082, "y": -11.22861385345459, "yaw": -1.5839799642562866, "level_name": "L1", "index": 0}, "path": []}]}\n', 'stream': 'stdout'}
-
-# {'log': 'INFO:app.BookKeeper.door_health:{"id": "hardware_door", "health_status": "HealthStatus.HEALTHY", "health_message": null}\n', 'stream': 'stdout'}
-
-# {'log': 'INFO:app.BookKeeper.ingestor_state:{"time": {"sec": 1600, "nanosec": 0}, "guid": "coke_ingestor", "mode": 0, "request_guid_queue": [], "seconds_remaining": 0.0}\n', 'stream': 'stdout'}
-
-# {'log': 'INFO:app.BookKeeper.lift_state:{"time": {"sec": 1600, "nanosec": 0}, "state": 1, "mode": 0, "request_guid_queue": [], "seconds_remaining": 0.0}\n', 'stream': 'stdout'}
-
-# {'log': 'INFO:app.BookKeeper.task_summary:{"fleet_name": "tinyRobot", "task_id": "Loop0", "task_profile": {"task_id": "Loop0", "submission_time": {"sec": 131, "nanosec": 553000000}, "description": {"start_time": {"sec": 1623383402, "nanosec": 0}, "priority": {"value": 0}, "task_type": {"type": 1}, "station": {"task_id": "", "robot_type": "", "place_name": ""}, "loop": {"task_id": "", "robot_type": "", "num_loops": 1, "start_name": "supplies", "finish_name": "coe"}, "delivery": {"task_id": "", "items": [], "pickup_place_name": "", "pickup_dispenser": "", "pickup_behavior": {"name": "", "parameters": []}, "dropoff_place_name": "", "dropoff_ingestor": "", "dropoff_behavior": {"name": "", "parameters": []}}, "clean": {"start_waypoint": ""}}}, "state": 0, "status": "", "submission_time": {"sec": 0, "nanosec": 0}, "start_time": {"sec": 1623383362, "nanosec": 348338289}, "end_time": {"sec": 1623383449, "nanosec": 79154833}, "robot_name": "tinyRobot2"}\n', 'stream': 'stdout'}
 
 app = get_app()
 
@@ -48,20 +34,18 @@ class TestCaseLogParserDispatcher(unittest.IsolatedAsyncioTestCase):
         await tortoise.Tortoise.close_connections()
 
     async def test_dispenser_state_created(self):
-        data = 'dispenser_state:{"time": {"sec": 1600, "nanosec": 0}, "guid": "coke_dispenser", "mode": 0, "request_guid_queue": [], "seconds_remaining": 0.0}\n'
-        await log_model_dispatcher(data)
+        await log_model_dispatcher(parsed_data.mock_dispenser_state)
         instance = await DispenserState.first()
         self.assertEqual(instance.guid, "coke_dispenser")
 
     async def test_door_state_created(self):
-        data = 'door_state:{"door_time": {"sec": 1596, "nanosec": 548000000}, "door_name": "hardware_door", "current_mode": {"value": 0}}\n'
-        await log_model_dispatcher(data)
+        print(parsed_data.mock_door_state)
+        await log_model_dispatcher(parsed_data.mock_door_state)
         instance = await DoorState.first()
         self.assertEqual(instance.name, "hardware_door")
 
     async def test_fleet_state_created(self):
-        data = 'fleet_state:{"name": "tinyRobot", "robots": [{"name": "tinyRobot1", "model": "", "task_id": "", "seq": 3194, "mode": {"mode": 1, "mode_request_id": 0}, "battery_percent": 100.0, "location": {"t": {"sec": 1600, "nanosec": 189000000}, "x": 11.55367374420166, "y": -11.317498207092285, "yaw": -1.5998055934906006, "level_name": "L1", "index": 0}, "path": []}, {"name": "tinyRobot2", "model": "", "task_id": "", "seq": 3194, "mode": {"mode": 1, "mode_request_id": 0}, "battery_percent": 100.0, "location": {"t": {"sec": 1600, "nanosec": 189000000}, "x": 15.15751838684082, "y": -11.22861385345459, "yaw": -1.5839799642562866, "level_name": "L1", "index": 0}, "path": []}]}\n'
-        await log_model_dispatcher(data)
+        await log_model_dispatcher(parsed_data.mock_fleet_state)
         instance = await FleetState.all()
         self.assertEqual(len(instance), 2)
 
@@ -72,8 +56,7 @@ class TestCaseLogParserDispatcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(instance[1].robot_name, "tinyRobot2")
 
     async def test_task_summary_created(self):
-        data = 'task_summary:{"fleet_name": "tinyRobot", "task_id": "Loop0", "task_profile": {"task_id": "Loop0", "submission_time": {"sec": 131, "nanosec": 553000000}, "description": {"start_time": {"sec": 1623383402, "nanosec": 0}, "priority": {"value": 0}, "task_type": {"type": 1}, "station": {"task_id": "", "robot_type": "", "place_name": ""}, "loop": {"task_id": "", "robot_type": "", "num_loops": 1, "start_name": "supplies", "finish_name": "coe"}, "delivery": {"task_id": "", "items": [], "pickup_place_name": "", "pickup_dispenser": "", "pickup_behavior": {"name": "", "parameters": []}, "dropoff_place_name": "", "dropoff_ingestor": "", "dropoff_behavior": {"name": "", "parameters": []}}, "clean": {"start_waypoint": ""}}}, "state": 0, "status": "", "submission_time": {"sec": 0, "nanosec": 0}, "start_time": {"sec": 1623383362, "nanosec": 348338289}, "end_time": {"sec": 1623383449, "nanosec": 79154833}, "robot_name": "tinyRobot2"}\n'
-        await log_model_dispatcher(data)
+        await log_model_dispatcher(parsed_data.mock_task_summary)
         instance = await TaskSummary.first()
         self.assertEqual(instance.task_id, "Loop0")
         self.assertEqual(instance.status, None)
@@ -100,13 +83,11 @@ class TestCaseLogParserDispatcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(instance.device, "lift_health")
 
     async def test_ingestor_state_created(self):
-        data = 'ingestor_state:{"time": {"sec": 1600, "nanosec": 0}, "guid": "coke_ingestor", "mode": 0, "request_guid_queue": [], "seconds_remaining": 0.0}\n'
-        await log_model_dispatcher(data)
+        await log_model_dispatcher(parsed_data.mock_ingestor_state)
         instance = await IngestorState.first()
         self.assertEqual(instance.guid, "coke_ingestor")
 
     async def test_lift_state_created(self):
-        data = 'lift_state: {"lift_name": "test_lift", "lift_time": 0, "available_floors": ["L1", "L2"], "current_floor": "L1", "destination_floor": "L2", "door_state": 0, "motion_state": 0, "available_modes": [0], "current_mode": 0, "session_id": "test_session"}\n'
-        await log_model_dispatcher(data)
+        await log_model_dispatcher(parsed_data.mock_lift_state)
         instance = await LiftState.first()
         self.assertEqual(instance.name, "test_lift")

--- a/packages/reporting-server/rest_server/routers/test_log.py
+++ b/packages/reporting-server/rest_server/routers/test_log.py
@@ -1,6 +1,7 @@
 import unittest
 
 from fastapi.testclient import TestClient
+from rest_server.__mocks__.raw_data import mock_keycloak_login_error
 from tortoise import Tortoise
 
 from ..app import get_app
@@ -110,13 +111,7 @@ class TestKeycloakRoute(unittest.IsolatedAsyncioTestCase):
         self.client = TestClient(app)
         response = self.client.post(
             "/log/keycloak/",
-            json=[
-                {"log343": "test"},
-                {
-                    "log": '[0m[0m20:41:54,721 INFO  [org.keycloak.events] (default task-2) JSON_EVENT::{"type":"LOGIN_ERROR","realmId":"579ce396-83c7-4094-964d-7ea07553089f","clientId":"reporting","ipAddress":"192.168.49.1","error":"user_not_found","auth_method":"openid-connect","auth_type":"code","redirect_uri":"https://example.com/reporting","code_id":"f813403c-2732-4062-9911-cf65b89a2278","username":"test"}',
-                    "stream": "stdout",
-                },
-            ],
+            json=[{"log343": "test"}, mock_keycloak_login_error],
         )
 
         assert response.status_code == 503

--- a/packages/reporting-server/rest_server/routers/test_log.py
+++ b/packages/reporting-server/rest_server/routers/test_log.py
@@ -1,3 +1,6 @@
+# conflicts with isort because of local non-relative import
+# pylint: disable=wrong-import-order
+
 import unittest
 
 from fastapi.testclient import TestClient


### PR DESCRIPTION
Signed-off-by: Matias Bavera <matiasbavera@gmail.com>

## What's new
The data being received from fluentd was being replicated in several places. What was done in this PR is to place all the mocks in one place, so if the structure changes we should change it in one place and if the tests fail it will be easier to detect.

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

## Self-checks

- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
