### PR TITLE
set RMF_SERVER_USE_SIM_TIME variable concretely in example-deployment

### DIFF
--- a/example-deployment/docker/builder.dockerfile
+++ b/example-deployment/docker/builder.dockerfile
@@ -22,3 +22,5 @@ RUN . /opt/ros/foxy/setup.bash && cd /root/rmf_ws && \
   colcon build --merge-install --install-base /opt/rmf --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 RUN rm -rf /root/rmf_ws
+
+ENV RMF_SERVER_USE_SIM_TIME=true # Set this based on your use_sim_time configuration when launching the backend


### PR DESCRIPTION
Signed-off-by: Boon Han <charayaphan.nakorn.boon.han@gmail.com>

Currently, the variable RMF_SERVER_USE_SIM_TIME, which is important for setting sim time configuration on the api-server, is not configured. When it is not configured, it seems the default behavior is to treat it as false. This can be confusing.

By setting this in the builder dockerfile, this configuration can propagate.