### PR TITLE
fix/ error on building builder.dockerfile

### DIFF
--- a/example-deployment/docker/builder.dockerfile
+++ b/example-deployment/docker/builder.dockerfile
@@ -23,4 +23,5 @@ RUN . /opt/ros/foxy/setup.bash && cd /root/rmf_ws && \
 
 RUN rm -rf /root/rmf_ws
 
-ENV RMF_SERVER_USE_SIM_TIME=true # Set this based on your use_sim_time configuration when launching the backend
+# Set this based on your use_sim_time configuration when launching the backend
+ENV RMF_SERVER_USE_SIM_TIME=true 


### PR DESCRIPTION
Signed-off-by: Matias Bavera <matiasbavera@gmail.com>

## What's new

When I tried to build the `builder.dockerfile`, I got this error
```
Error response from daemon: failed to parse .dockerfile.c9a48f26a800b30066d5: Syntax error - can't find = in "#". Must be of the form: name=value
```
After some digging I realized It was because of the comment here

```
ENV RMF_SERVER_USE_SIM_TIME=true # Set this based on your use_sim_time configuration when launching the backend
```

