### PR TITLE
fix(example-deployment): fix reporting infinite redirect

### DIFF
--- a/example-deployment/docker/dashboard.dockerfile
+++ b/example-deployment/docker/dashboard.dockerfile
@@ -19,9 +19,17 @@ FROM nginx:stable
 COPY --from=0 /root/rmf-web/packages/dashboard/build /usr/share/nginx/html/dashboard
 SHELL ["bash", "-c"]
 RUN echo -e 'server {\n\
+  listen 80;\n\
+  server_name localhost;\n\
+\n\
   location / {\n\
     root /usr/share/nginx/html;\n\
     index index.html index.htm;\n\
     try_files $uri /dashboard/index.html;\n\
   }\n\
-}\n' > /etc/nginx/conf.d/dashboard.conf
+\n\
+  error_page 500 502 503 504 /50x.html;\n\
+  location = /50x.html {\n\
+    root /usr/share/nginx/html;\n\
+  }\n\
+}\n' > /etc/nginx/conf.d/default.conf

--- a/example-deployment/docker/reporting.dockerfile
+++ b/example-deployment/docker/reporting.dockerfile
@@ -25,9 +25,17 @@ FROM nginx:stable
 COPY --from=0 /root/rmf-web/packages/reporting/build /usr/share/nginx/html/reporting
 SHELL ["bash", "-c"]
 RUN echo -e 'server {\n\
+  listen 80;\n\
+  server_name localhost;\n\
+\n\
   location / {\n\
     root /usr/share/nginx/html;\n\
     index index.html index.htm;\n\
     try_files $uri /reporting/index.html;\n\
   }\n\
-}\n' > /etc/nginx/conf.d/reporting.conf
+\n\
+  error_page 500 502 503 504 /50x.html;\n\
+  location = /50x.html {\n\
+    root /usr/share/nginx/html;\n\
+  }\n\
+}\n' > /etc/nginx/conf.d/default.conf

--- a/example-deployment/k8s/reporting.yaml
+++ b/example-deployment/k8s/reporting.yaml
@@ -11,7 +11,6 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 80
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/example-deployment/keycloak-tools/bootstrap-keycloak.js
+++ b/example-deployment/keycloak-tools/bootstrap-keycloak.js
@@ -92,38 +92,75 @@ async function createAudienceClientScope(headers, name, description, audience) {
       },
     );
 
-    // create example user
-    await tryRequest(
-      `${baseUrl}/admin/realms/rmf-web/users`,
-      {
-        method: 'POST',
-        headers: authHeaders(token),
-      },
-      {
-        username: 'example',
-        enabled: true,
-      },
-    );
+    {
+      // create admin user
+      await tryRequest(
+        `${baseUrl}/admin/realms/rmf-web/users`,
+        {
+          method: 'POST',
+          headers: authHeaders(token),
+        },
+        {
+          username: 'admin',
+          enabled: true,
+        },
+      );
 
-    // get the newly created user
-    resp = await request(`${baseUrl}/admin/realms/rmf-web/users?username=example`, {
-      method: 'GET',
-      headers: authHeaders(token),
-    });
-    const user = JSON.parse(resp.body)[0];
-
-    // set the password
-    await request(
-      `${baseUrl}/admin/realms/rmf-web/users/${user.id}/reset-password`,
-      {
-        method: 'PUT',
+      // get the newly created user
+      resp = await request(`${baseUrl}/admin/realms/rmf-web/users?username=admin`, {
+        method: 'GET',
         headers: authHeaders(token),
-      },
-      {
-        value: 'example',
-        temporary: false,
-      },
-    );
+      });
+      const user = JSON.parse(resp.body)[0];
+
+      // set the password
+      await request(
+        `${baseUrl}/admin/realms/rmf-web/users/${user.id}/reset-password`,
+        {
+          method: 'PUT',
+          headers: authHeaders(token),
+        },
+        {
+          value: 'admin',
+          temporary: false,
+        },
+      );
+    }
+
+    {
+      // create example user
+      await tryRequest(
+        `${baseUrl}/admin/realms/rmf-web/users`,
+        {
+          method: 'POST',
+          headers: authHeaders(token),
+        },
+        {
+          username: 'example',
+          enabled: true,
+        },
+      );
+
+      // get the newly created user
+      resp = await request(`${baseUrl}/admin/realms/rmf-web/users?username=example`, {
+        method: 'GET',
+        headers: authHeaders(token),
+      });
+      const user = JSON.parse(resp.body)[0];
+
+      // set the password
+      await request(
+        `${baseUrl}/admin/realms/rmf-web/users/${user.id}/reset-password`,
+        {
+          method: 'PUT',
+          headers: authHeaders(token),
+        },
+        {
+          value: 'example',
+          temporary: false,
+        },
+      );
+    }
 
     await tryRequest(
       `${baseUrl}/admin/realms/rmf-web/events/config`,


### PR DESCRIPTION
## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

The root cause is because `/etc/nginx/conf.d/default.conf` already contains a `location / {}` block and that conflicts with the declaration in `/etc/nginx/conf.d/reporting.conf`. The reason it works in dashboard is because `dashboard.conf` gets loaded before `default.conf` because or file system sorting ("da" comes before "de").

This also adds the admin user for use with the new authorization changes. It should be used in favor of "example" when performing some things like submitting tasks.

## Self-checks

- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
