### PR TITLE
Fix/robot pagination

### DIFF
--- a/packages/api-server/api_server/routes/fleets.py
+++ b/packages/api-server/api_server/routes/fleets.py
@@ -92,13 +92,14 @@ class FleetsRouter(FastIORouter):
                 # multiple fleets with the same robot name and there are active tasks
                 # assigned to those robots and the robot states are not synced to the
                 # tasks summaries.
-                if r is None:
+                if r is None and t.fleet_name == "":
                     logger.warn(
                         f'task "{t.id_}" is assigned to an unknown fleet/robot ({t.fleet_name}/{t.robot_name}'
                     )
-                r.tasks.append(
-                    convert_task_status_msg(t.to_pydantic(), rmf_gateway_dep())
-                )
+                elif r and t.fleet_name:
+                    r.tasks.append(
+                        convert_task_status_msg(t.to_pydantic(), rmf_gateway_dep())
+                    )
 
             return Pagination(
                 total_count=robot_states.total_count, items=list(robots.values())

--- a/packages/dashboard/src/components/robots/robot-page.tsx
+++ b/packages/dashboard/src/components/robots/robot-page.tsx
@@ -29,8 +29,8 @@ export function RobotPage() {
     const resp = await fleetsApi?.getRobotsFleetsRobotsGet(
       undefined,
       undefined,
-      10,
-      page * 10,
+      20,
+      page * 20,
       'fleet_name,robot_name',
     );
     setTotalCount(resp.data.total_count);
@@ -48,8 +48,8 @@ export function RobotPage() {
       fetchVerboseRobots={fetchVerboseRobots}
       paginationOptions={{
         count: totalCount,
-        rowsPerPage: 10,
-        rowsPerPageOptions: [10],
+        rowsPerPage: 20,
+        rowsPerPageOptions: [20],
         page,
         onChangePage: (_ev, newPage) => setPage(newPage),
       }}


### PR DESCRIPTION
This bug is caused by a robot not queried in the list of robots as it is out of scope of the pagination, but exists in the task that it is assigned to, causing the api server to keep throwing an error as the task is being assigned to a `noneType` robot.

Fixed this on the front end and backend:

- Increase the pagination size on the robot panel
- Restrict the logging only to a situation when robot is None and task is unassigned (task.fleet_name is empty)
- Restrict the robot assignment to a situation when only Robot exist and task is already assigned to a robot

Hopefully, a pagination size of 20 is enough to accommodate all the robots for demoing and even if it exceeds, the api server would not throw an error anymore but only log warnings.