### PR TITLE
Fix on task_summaries topic and switch launcher pkg rmf_demos_gz

### DIFF
--- a/example-deployment/README.md
+++ b/example-deployment/README.md
@@ -36,7 +36,7 @@ others:
 For this example we will be using [rmf_demos](https://github.com/open-rmf/rmf_demos) as a local "deployment" of RMF, check that you have a working installation with
 
 ```bash
-ros2 launch rmf_demos office.launch.xml
+ros2 launch rmf_demos_gz office.launch.xml
 ```
 
 ## kubernetes
@@ -278,7 +278,7 @@ The jobs we will run in this example can be found at `k8s/example-full/cronjobs.
 If not done so already, launch the office demo
 
 ```bash
-ros2 launch rmf_demos office.launch.xml headless:=true
+ros2 launch rmf_demos_gz office.launch.xml headless:=true
 ```
 
 Go to https://example.com/dashboard, if everything works, you should see a log in screen, use user=example, password=example.

--- a/packages/api-server/api_server/gateway.py
+++ b/packages/api-server/api_server/gateway.py
@@ -24,7 +24,7 @@ from rmf_fleet_msgs.msg import FleetState as RmfFleetState
 from rmf_ingestor_msgs.msg import IngestorState as RmfIngestorState
 from rmf_lift_msgs.msg import LiftRequest as RmfLiftRequest
 from rmf_lift_msgs.msg import LiftState as RmfLiftState
-from rmf_task_msgs.msg import TaskSummary as RmfTaskSummary
+from rmf_task_msgs.msg import Tasks as RmfTasks
 from rmf_task_msgs.srv import CancelTask as RmfCancelTask
 from rmf_task_msgs.srv import GetTaskList as RmfGetTaskList
 from rmf_task_msgs.srv import SubmitTask as RmfSubmitTask
@@ -173,12 +173,13 @@ class RmfGateway(rclpy.node.Node):
         self._subscriptions.append(fleet_states_sub)
 
         task_summaries_sub = self.create_subscription(
-            RmfTaskSummary,
-            "task_summaries",
-            lambda msg: self.rmf_events.task_summaries.on_next(
-                TaskSummary.from_orm(msg)
-            ),
-            10,
+            RmfTasks,
+            "dispatcher_ongoing_tasks",
+            lambda msg: [
+                self.rmf_events.task_summaries.on_next(
+                    TaskSummary.from_orm(task)
+                ) for task in msg.tasks
+            ],
         )
         self._subscriptions.append(task_summaries_sub)
 

--- a/packages/api-server/api_server/gateway.py
+++ b/packages/api-server/api_server/gateway.py
@@ -180,6 +180,7 @@ class RmfGateway(rclpy.node.Node):
                     TaskSummary.from_orm(task)
                 ) for task in msg.tasks
             ],
+            10,
         )
         self._subscriptions.append(task_summaries_sub)
 

--- a/packages/dashboard/rmf-launcher.js
+++ b/packages/dashboard/rmf-launcher.js
@@ -46,7 +46,7 @@ exports.LocalLauncher = class {
 
     const headless = !process.env.RMF_DASHBOARD_NO_HEADLESS;
     const demoMap = process.env.RMF_DASHBOARD_DEMO_MAP || 'office.launch.xml';
-    const demoArgs = ['launch', 'rmf_demos', demoMap];
+    const demoArgs = ['launch', 'rmf_demos_gz', demoMap];
     if (headless) {
       demoArgs.push('headless:=true');
     }


### PR DESCRIPTION
- change task status subscribtion topic  from `task_summaries` (rmf_tasks_msgs/TaskSummary) to `dispatcher_ongoing_tasks` (`rmf_task_msgs.msg/Tasks`). To filter properly cancel self-allocated tasks and remove `ResponsiveWait` Tasks. https://github.com/open-rmf/rmf_ros2/pull/60
- rmf_demos scenarios launcher pkg to `rmf_demos_gz` https://github.com/open-rmf/rmf_demos/pull/78