### PR TITLE
clone objects to trigger rendering

### DIFF
--- a/packages/dashboard/src/components/dashboard/dashboard.tsx
+++ b/packages/dashboard/src/components/dashboard/dashboard.tsx
@@ -192,9 +192,9 @@ export default function Dashboard(_props: {}): React.ReactElement {
               buildingMap={buildingMap}
               dispensers={dispensers}
               ingestors={ingestors}
-              doorStates={doorStatesRef.current}
-              liftStates={liftStatesRef.current}
-              fleetStates={fleetStatesRef.current}
+              doorStates={Object.assign({}, doorStatesRef.current)}
+              liftStates={Object.assign({}, liftStatesRef.current)}
+              fleetStates={Object.assign({}, fleetStatesRef.current)}
               mode="normal"
             ></ScheduleVisualizer>
           </Card>


### PR DESCRIPTION
Fixes https://github.com/open-rmf/rmf-web/issues/496 by doing a shallow copy that forces a render.

Naively I am understanding there are some drawbacks to using [shallow copies](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign), but i'm not sure if they are relevant in our case. The alternative deep copy seems to be `JSON.parse(JSON.stringify())`.

It is taking about 1 seconds to load icons now switching tabs away / back to the buildings tab, when before it took minimal time, i'm wondering if that is something that can be fixed.