### PR TITLE
place bearer token in header

### DIFF
--- a/packages/rmf-auth/lib/components/context.tsx
+++ b/packages/rmf-auth/lib/components/context.tsx
@@ -39,7 +39,9 @@ export function UserProfileProvider({
       new DefaultApi({
         basePath,
         baseOptions: {
-          Authorization: token && `Bearer ${token}`,
+          headers: {
+            Authorization: token && `Bearer ${token}`,
+          }
         },
       }),
     [token, basePath],


### PR DESCRIPTION
This fixes https://github.com/open-rmf/rmf-web/issues/527 by placing the bearer token in the right place.