### PR TITLE
fix disabled auth in example-full

### DIFF
--- a/example-deployment/k8s/example-full/kustomization.yaml
+++ b/example-deployment/k8s/example-full/kustomization.yaml
@@ -33,3 +33,7 @@ configMapGenerator:
   - name: reporting-server-config
     files:
       - reporting_server_config.py
+  - name: rmf-server-config
+    files:
+      - rmf_server_config.py
+    behavior: replace


### PR DESCRIPTION
This PR aims to load the rmf_server_config.py in `example-full` so that auth is properly enabled.