### PR TITLE
Fix - long icon rendering time

### DIFF
--- a/packages/dashboard/src/components/schedule-visualizer/index.tsx
+++ b/packages/dashboard/src/components/schedule-visualizer/index.tsx
@@ -268,21 +268,18 @@ export default function ScheduleVisualizer({
         }),
       );
       await safeAsync(Promise.all(promises));
+      const newRobots = Object.values(fleetStates).flatMap((fleetState) =>
+        fleetState.robots
+          .filter(
+            (r) =>
+              r.location.level_name === currentLevel.name &&
+              `${fleetState.name}/${r.name}` in robotsStore,
+          )
+          .map((r) => robotsStore[`${fleetState.name}/${r.name}`]),
+      );
+      setRobots(newRobots);
     })();
-  }, [safeAsync, fleetStates, robotsStore, resourceManager]);
-
-  React.useEffect(() => {
-    const newRobots = Object.values(fleetStates).flatMap((fleetState) =>
-      fleetState.robots
-        .filter(
-          (r) =>
-            r.location.level_name === currentLevel.name &&
-            `${fleetState.name}/${r.name}` in robotsStore,
-        )
-        .map((r) => robotsStore[`${fleetState.name}/${r.name}`]),
-    );
-    setRobots(newRobots);
-  }, [safeAsync, fleetStates, robotsStore, currentLevel]);
+  }, [safeAsync, fleetStates, robotsStore, resourceManager, currentLevel]);
 
   React.useEffect(() => {
     (async () => {


### PR DESCRIPTION
Signed-off-by: ChawinTan <chawin15@gmail.com>

## What's new

fixes #514

<b>Before</b>
https://user-images.githubusercontent.com/29136440/139360824-e68ed8e8-cb45-404f-aa81-83910361fb4d.mp4


<b>After</b>
https://user-images.githubusercontent.com/29136440/139360832-7d9839c7-6ad7-4fbb-9a3c-bca06603df5e.mp4

Previously, the robot icons were loaded one interval after the rest of the items. With this fix, everything is now loaded together on the first interval.

There are 2 separate useEffects that is used to handle the rendering of fleets. Previously, the second useEffect was executed when robotStore was still empty due to the asynchronous nature of the code in the first useEffect. As a result,  the robot icons only appeared on the second interval.

Shifting the block of code to the first useEffect and executing it after the promises are resolved seems to solve the problem. 

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [x] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
