### PR TITLE
handle unclosed socket ResourceWarning errors from race conditions du…

### DIFF
--- a/packages/api-server/api_server/test/test_fixtures.py
+++ b/packages/api-server/api_server/test/test_fixtures.py
@@ -137,6 +137,8 @@ class AppFixture(unittest.TestCase):
     def tearDown(self):
         for client in self._sioClients:
             if client.connected:
+                # Explicitly close Session to remove ResourceWarnings in tests
+                client.eio.http.close()
                 client.disconnect()
 
     @classmethod
@@ -167,6 +169,8 @@ class AppFixture(unittest.TestCase):
             nonlocal count
             count += 1
             if count >= needed:
+                # Explicitly close Session to remove ResourceWarnings in tests
+                client.eio.http.close()
                 client.disconnect()
                 fut.set_result(data)
 

--- a/packages/api-server/api_server/test_fast_io.py
+++ b/packages/api-server/api_server/test_fast_io.py
@@ -34,6 +34,8 @@ class TestFastIO(unittest.TestCase):
                 time.sleep(0.5)
 
     def tearDown(self):
+        # Explicitly close Session to remove ResourceWarnings in tests
+        self.client.eio.http.close()
         self.client.disconnect()
 
     def check_subscribe_success(self, prefix: str):

--- a/packages/api-server/api_server/test_sio_auth.py
+++ b/packages/api-server/api_server/test_sio_auth.py
@@ -27,6 +27,7 @@ class TestSioAuth(unittest.TestCase):
 
     def try_connect(self, token: Optional[str] = None) -> bool:
         client = socketio.Client(reconnection=False)
+
         if token:
             auth = {"token": token}
         else:
@@ -51,6 +52,8 @@ class TestSioAuth(unittest.TestCase):
                         return False
             return False
         finally:
+            # Explicitly close Session to remove ResourceWarnings in tests
+            client.eio.http.close()
             client.disconnect()
 
     def test_fail_with_no_token(self):


### PR DESCRIPTION
…e to python requests keep-alive model

Should handle https://github.com/open-rmf/rmf-web/issues/539.

We learn from [here](https://github.com/psf/requests/issues/3912#issuecomment-284328247) that Python Requests does not explicitly close sockets. We use Requests as part of [engineio](https://github.com/miguelgrinberg/python-engineio/blob/main/src/engineio/client.py#L12), the backend for Socket.IO.

I believe the mechanism for checking for unclosed sockets ( and the ResourceWarning alert ) is: If a socket is open and not in this [connected_clients](https://github.com/miguelgrinberg/python-engineio/blob/main/src/engineio/client.py#L223) list, the warning will appear.

When we run unittest, we proabably often encounter situations when the `connect_client` list no longer has an entry for a client, but Request continues to keep the connection alive in reality, leading to scary ResourceWarning errors.

The proposed solution is to manually trigger the Request session to close paired with every client.disconnect call.
Signed-off-by: Charayaphan Nakorn Boon Han <charayaphan.nakorn.boon.han@gmail.com>

