### PR TITLE
build: fix `npm start` immediate after bootstrap not working

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -5,3 +5,6 @@ legacy-peer-deps = true
 
 # pipenv can be INCREDIBLY slow, this lets user know what it is still running.
 foreground-scripts = true
+
+# make npm error out if version is not supported
+engine-strict = true

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,10 @@
         "prettier": "^2.1.2",
         "pyright": "^1.1.181",
         "typescript": "~4.4.4"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=8"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "packages/ros-translator",
     "pipenv-install"
   ],
+  "engines": {
+    "node": ">=14",
+    "npm": ">=8"
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/lib/index.js",
   "scripts": {
-    "build": "tsc --build",
+    "build": "../../scripts/nws.sh build -d && tsc --build",
     "clean": "tsc --build --clean",
     "prepack": "npm run clean && npm run build && npm run lint",
     "lint": "eslint --ext ts,tsx lib"

--- a/packages/api-client/tsconfig.json
+++ b/packages/api-client/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "references": [
-    { "path": "../rmf-models" }
-  ],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -4,10 +4,10 @@
   "description": "dummy package",
   "private": true,
   "scripts": {
-    "prepack": "pipenv run python setup.py bdist_wheel",
-    "start": "pipenv run python -m api_server",
-    "test": "pipenv run python -m unittest",
-    "test:cov": "pipenv run python -m coverage run -m unittest",
+    "prepack": "../../scripts/nws.sh build -d && pipenv run python setup.py bdist_wheel",
+    "start": "../../scripts/nws.sh build -d && pipenv run python -m api_server",
+    "test": "../../scripts/nws.sh build -d && pipenv run python -m unittest",
+    "test:cov": "../../scripts/nws.sh build -d && pipenv run python -m coverage run -m unittest",
     "test:report": "pipenv run python -m coverage html && xdg-open htmlcov/index.html",
     "lint": "pipenv run pyright && pipenv run pylint api_server --ignore=ros_pydantic"
   },

--- a/packages/dashboard-e2e/package.json
+++ b/packages/dashboard-e2e/package.json
@@ -6,9 +6,9 @@
     "test": "tests"
   },
   "scripts": {
-    "start": "node scripts/start.js",
+    "start": "../../scripts/nws.sh build -d && node scripts/start.js",
     "start:rmf-server": "npm --prefix ../api-server start",
-    "test": "node scripts/test-e2e.js",
+    "test": "../../scripts/nws.sh build -d && node scripts/test-e2e.js",
     "test:dev": "E2E_DASHBOARD_URL=http://localhost:3000 RMF_LAUNCH_MODE=none wdio"
   },
   "devDependencies": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -4,22 +4,22 @@
   "private": true,
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
-    "start": "concurrently npm:start:rmf-server npm:start:rmf npm:start:react",
+    "start": "../../scripts/nws.sh build -d && concurrently npm:start:rmf-server npm:start:rmf npm:start:react",
     "start:clinic": "RMF_DASHBOARD_DEMO_MAP=clinic.launch.xml npm start",
     "start:airport": "RMF_DASHBOARD_DEMO_MAP=airport_terminal.launch.xml npm start",
     "start:react": "react-scripts start",
     "start:rmf": "node scripts/start-rmf.js",
     "start:rmf-server": "RMF_SERVER_USE_SIM_TIME=true npm --prefix ../api-server start",
     "start:rmf-server:psql": "RMF_API_SERVER_CONFIG=../api-server/psql_local_config.py RMF_SERVER_USE_SIM_TIME=true npm --prefix ../api-server start",
-    "build": "tsc --build && react-scripts build",
-    "test": "tsc --build && react-scripts test",
+    "build": "../../scripts/nws.sh build -d && react-scripts build",
+    "test": "../../scripts/nws.sh build -d && react-scripts test",
     "test:coverage": "npm run test -- --coverage --watchAll=false",
     "test:e2e": "cd e2e && npm test",
     "test:e2e:dev": "cd e2e && npm run test:dev",
     "eject": "react-scripts eject",
     "setup": "node ./scripts/setup/setup.js",
     "storybook": "start-storybook -p 9009 -s public -s src/stories/static",
-    "build:storybook": "tsc --build && build-storybook -s public -s src/stories/static"
+    "build:storybook": "../../scripts/nws.sh build -d && build-storybook -s public -s src/stories/static"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -97,8 +97,7 @@
       "!src/managers/**",
       "!src/components/rmf-app/**",
       "!**/stories/**",
-      "!**/tests/**",
-      "!src/components/__trash/**"
+      "!**/tests/**"
     ]
   }
 }

--- a/packages/dashboard/tsconfig.json
+++ b/packages/dashboard/tsconfig.json
@@ -1,10 +1,4 @@
 {
-  "references": [
-    { "path": "../api-client" },
-    { "path": "../react-components" },
-    { "path": "../rmf-auth" },
-    { "path": "../rmf-models" }
-  ],
   "compilerOptions": {
     "target": "es5",
     "lib": [

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "dist/lib/index.js",
   "scripts": {
-    "build": "tsc --build",
+    "build": "../../scripts/nws.sh build -d && tsc --build",
     "build:storybook": "npm run build && build-storybook -s test-data",
-    "build:watch": "tsc --build --watch",
+    "build:watch": "npm run build -- --watch",
     "clean": "tsc --build --clean",
     "lint": "eslint --ext ts,tsx, lib",
     "prepack": "npm run clean && npm run lint && npm run build && npm run test && cp package.json dist/",

--- a/packages/react-components/tsconfig.json
+++ b/packages/react-components/tsconfig.json
@@ -1,8 +1,4 @@
 {
-  "references": [
-    { "path": "../api-client" },
-    { "path": "../rmf-models" }
-  ],
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/packages/reporting/package.json
+++ b/packages/reporting/package.json
@@ -6,14 +6,14 @@
   "private": true,
   "scripts": {
     "start": "react-scripts start",
-    "build": "tsc --build && react-scripts build",
-    "test": "tsc --build && react-scripts test",
+    "build": "../../scripts/nws.sh build -d && react-scripts build",
+    "test": "../../scripts/nws.sh build -d && react-scripts test",
     "test:coverage": "npm run test -- --coverage --watchAll=false",
     "test:e2e": "cd e2e && npm test",
     "test:e2e:dev": "cd e2e && npm run test:dev",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 9009 -s public -s src/stories/static",
-    "build:storybook": "tsc --build && build-storybook -s public -s src/stories"
+    "build:storybook": "../../scripts/nws.sh build -d && build-storybook -s public -s src/stories"
   },
   "keywords": [
     "reporting"
@@ -73,8 +73,7 @@
       "!src/react-app-env.d.ts",
       "!src/components/reporter-side-bar-structure.tsx",
       "!**/stories/**",
-      "!**/tests/**",
-      "!src/components/__trash/**"
+      "!**/tests/**"
     ]
   }
 }

--- a/packages/reporting/tsconfig.json
+++ b/packages/reporting/tsconfig.json
@@ -1,8 +1,4 @@
 {
-  "references": [
-    { "path": "../react-components" },
-    { "path": "../rmf-auth" }
-  ],
   "compilerOptions": {
     "target": "es5",
     "lib": [

--- a/packages/rmf-auth/package.json
+++ b/packages/rmf-auth/package.json
@@ -4,13 +4,13 @@
   "description": "Auth layer to be used on web UI services",
   "main": "dist/lib/index.js",
   "scripts": {
-    "build": "tsc --build",
-    "build:storybook": "npm run build && build-storybook -s test-data",
-    "build:watch": "tsc --build --watch",
+    "build": "../../scripts/nws.sh build -d && tsc --build",
+    "build:storybook": "../../scripts/nws.sh build -d && build-storybook -s test-data",
+    "build:watch": "npm run build -- --watch",
     "clean": "tsc --build --clean",
     "lint": "eslint --ext ts,tsx, lib",
     "prepack": "npm run clean && npm run lint && npm run build && npm run test && cp package.json dist/",
-    "start": "start-storybook -p 6006 -s test-data",
+    "start": "../../scripts/nws.sh build -d && start-storybook -p 6006 -s test-data",
     "test": "jest --watch",
     "test:coverage": "jest --coverage"
   },

--- a/packages/rmf-auth/tsconfig.json
+++ b/packages/rmf-auth/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "references": [
-    { "path": "../api-client" }
-  ],
   "compilerOptions": {
     "target": "es5",
     "outDir": "dist",

--- a/scripts/current-package.js
+++ b/scripts/current-package.js
@@ -1,0 +1,5 @@
+const fs = require('fs');
+
+const pkg = JSON.parse(fs.readFileSync('package.json'));
+
+console.log(pkg['name']);

--- a/scripts/nws.sh
+++ b/scripts/nws.sh
@@ -9,6 +9,13 @@ usage() {
   echo 'for some workflow like build packages, we need to run depdentant scripts in the correct order in order for the target workspace to build correctly.'
 }
 
+# detects if we are already running from another nws script, if so, exit immediately so we don't
+# run the same scripts multiple times
+if [[ -n $nws_context ]]; then
+  exit
+fi
+export nws_context=1
+
 here=$(dirname "$0")
 
 options=$(getopt -l'help' -o'h' -l'dependencies-only' -o'd' -- "$@")

--- a/scripts/nws.sh
+++ b/scripts/nws.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+usage() {
+  echo 'Usage: nws.sh [--dependencies-only|-d] <script> <packages...>'
+  echo ''
+  echo 'nws.sh (shrot for npm workspace script) is a helper script to run npm scripts in npm workspace with proper dependency ordering.'
+  echo 'As of npm 8.1.2, the --workspace argument in `npm run` only run scripts for the specified workspace,'
+  echo 'for some workflow like build packages, we need to run depdentant scripts in the correct order in order for the target workspace to build correctly.'
+}
+
+here=$(dirname "$0")
+
+options=$(getopt -l'help' -o'h' -l'dependencies-only' -o'd' -- "$@")
+[ $? -eq 0 ] || { 
+    usage
+    exit 1
+}
+eval set -- "$options"
+while true; do
+  case "$1" in
+    --help | -h)
+      usage
+      exit 1
+      ;;
+    --dependencies-only | -d)
+      dependencies_only='--dependencies-only'
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+  esac
+done
+
+cmd=$1
+shift
+targets="$@"
+
+eval npm --prefix "$(dirname $0)/.." run $cmd --if-present --include-workspace-root $(node "$here/workspace-args.js" $dependencies_only $(node $here/current-package.js))

--- a/scripts/workspace-args.js
+++ b/scripts/workspace-args.js
@@ -17,11 +17,6 @@ function getDirectDeps(pkg) {
 }
 
 function getAllDeps(pkgs, acc = new Set()) {
-  pkgs.forEach((d) => {
-    // move this to the end of the set
-    acc.delete(d);
-    acc.add(d);
-  });
   const directDeps = pkgs.flatMap((pkg) => getDirectDeps(pkg));
   if (directDeps.length === 0) {
     return acc;
@@ -38,11 +33,12 @@ const args = process.argv.slice(2);
 const flags = args.filter((arg) => arg.startsWith('-'));
 const targets = args.filter((arg) => !arg.startsWith('-'));
 const allDeps = (() => {
-  if (flags.indexOf('--only-direct') !== -1) {
-    return [...targets, ...targets.flatMap((t) => getDirectDeps(t))];
-  } else {
-    return Array.from(getAllDeps(targets));
+  const deps = [];
+  if (flags.indexOf('--dependencies-only') === -1) {
+    deps.push(...targets);
   }
+  deps.push(...Array.from(getAllDeps(targets)));
+  return deps;
 })();
 
 const workspaceArgs = [];


### PR DESCRIPTION
## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

Cause is because the bootstrap script does not automatically build all packages. The fix is to add a custom script to build all dependencies in the correct order in the `start` script.

This also adds the engine field in the root package.json to avoid running it with unsupported npm version.

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
