### PR TITLE
build: tasksv2/better dev defaults

### DIFF
--- a/packages/api-server/.gitignore
+++ b/packages/api-server/.gitignore
@@ -1,8 +1,8 @@
 /api_server.egg-info
-/static
 /test_artifacts/
 /.coverage
 /.coverage.*
 /htmlcov/
 /build/
 /dist/
+/run/

--- a/packages/api-server/api_server/app_config.py
+++ b/packages/api-server/api_server/app_config.py
@@ -3,7 +3,7 @@ import os
 import urllib.parse
 from dataclasses import dataclass
 from importlib.abc import Loader
-from typing import Any, Optional, cast
+from typing import Any, List, Optional, cast
 
 
 @dataclass
@@ -19,6 +19,7 @@ class AppConfig:
     oidc_url: Optional[str]
     aud: str
     iss: Optional[str]
+    ros_args: List[str]
 
     def __post_init__(self):
         self.public_url = urllib.parse.urlparse(cast(str, self.public_url))

--- a/packages/api-server/api_server/default_config.py
+++ b/packages/api-server/api_server/default_config.py
@@ -28,4 +28,8 @@ config = {
     # Used to verify the "iss" claim
     # If iss is set to None, it means that authentication should be disabled
     "iss": None,
+    # list of arguments passed to the ros node, "--ros-args" is automatically prepended to the list.
+    # e.g.
+    #   Run with sim time: ["-p", "use_sim_time:=true"]
+    "ros_args": [],
 }

--- a/packages/api-server/api_server/ros.py
+++ b/packages/api-server/api_server/ros.py
@@ -16,7 +16,7 @@ if use_sim_time_env:
 else:
     use_sim_time = False
 if use_sim_time:
-    rclpy.init(args=["--ros-args", "-p", "use_sim_time:=true"] + app_config.ros_args)
+    rclpy.init(args=["--ros-args"] + app_config.ros_args + ["-p", "use_sim_time:=true"])
 else:
     rclpy.init(args=["--ros-args"] + app_config.ros_args)
 

--- a/packages/api-server/api_server/ros.py
+++ b/packages/api-server/api_server/ros.py
@@ -5,17 +5,20 @@ import threading
 import rclpy
 import rclpy.node
 
+from .app_config import app_config
+
 _spin_thread: threading.Thread = None  # type: ignore
 
+# TODO: remove support for `RMF_SERVER_USE_SIM_TIME`?
 use_sim_time_env = os.environ.get("RMF_SERVER_USE_SIM_TIME", None)
 if use_sim_time_env:
     use_sim_time = not use_sim_time_env.lower() in ["0", "false"]
 else:
     use_sim_time = False
 if use_sim_time:
-    rclpy.init(args=["--ros-args", "-p", "use_sim_time:=true"])
+    rclpy.init(args=["--ros-args", "-p", "use_sim_time:=true"] + app_config.ros_args)
 else:
-    rclpy.init()
+    rclpy.init(args=["--ros-args"] + app_config.ros_args)
 
 ros_node = rclpy.node.Node("rmf_api_server")
 

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "prepack": "../../scripts/nws.sh build -d && pipenv run python setup.py bdist_wheel",
-    "start": "../../scripts/nws.sh build -d && pipenv run python -m api_server",
+    "restart": "../../scripts/nws.sh build -d && RMF_API_SERVER_CONFIG=sqlite_local_config.py pipenv run python -m api_server",
+    "start": "../../scripts/nws.sh build -d && rm -rf run && mkdir -p run && RMF_API_SERVER_CONFIG=sqlite_local_config.py pipenv run python -m api_server",
     "test": "../../scripts/nws.sh build -d && pipenv run python scripts/test.py",
     "test:cov": "../../scripts/nws.sh build -d && pipenv run python -m coverage run scripts/test.py",
     "test:report": "pipenv run python -m coverage html && xdg-open htmlcov/index.html",

--- a/packages/api-server/psql_local_config.py
+++ b/packages/api-server/psql_local_config.py
@@ -1,7 +1,3 @@
-from copy import deepcopy
+from sqlite_local_config import config
 
-from api_server.default_config import config as default_config
-
-config = deepcopy(default_config)
-
-config["db_url"] = "postgres://postgres:postgres@127.0.0.1:5432"
+config.update({"db_url": "postgres://postgres:postgres@127.0.0.1:5432"})

--- a/packages/api-server/sqlite_local_config.py
+++ b/packages/api-server/sqlite_local_config.py
@@ -1,0 +1,14 @@
+from os.path import dirname
+
+from api_server.default_config import config
+
+here = dirname(__file__)
+run_dir = f"{here}/run"
+
+config.update(
+    {
+        "db_url": f"sqlite://{run_dir}/db.sqlite3",
+        "static_directory": f"{run_dir}/static",  # The directory where static files should be stored.
+        "ros_args": ["-p", "use_sim_time:=true"],
+    }
+)


### PR DESCRIPTION
## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

* Adds `ros_arg` option to config.
  * `RMF_SERVER_USE_SIM_TIME` takes precedence over the config file.
* `npm start` uses disk-backed sqlite3 (app default is still in memory sqlite3)
* `npm start` uses sim time by default (app default is still no sim time)

These defaults, along with the recent change of `clock.py` to use ros time should allow relative `between` query to work as expected.

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
