### PR TITLE
Add direct robot assignment api call

### DIFF
--- a/packages/api-client/lib/openapi/api.ts
+++ b/packages/api-client/lib/openapi/api.ts
@@ -1559,6 +1559,70 @@ export interface RobotState {
   issues?: Array<Issue>;
 }
 /**
+ *
+ * @export
+ * @interface RobotTaskRequest
+ */
+export interface RobotTaskRequest {
+  /**
+   * Indicate that this is a task dispatch request
+   * @type {string}
+   * @memberof RobotTaskRequest
+   */
+  type: string;
+  /**
+   * The name of the robot
+   * @type {string}
+   * @memberof RobotTaskRequest
+   */
+  robot: string;
+  /**
+   * The fleet the robot belongs to
+   * @type {string}
+   * @memberof RobotTaskRequest
+   */
+  fleet: string;
+  /**
+   *
+   * @type {TaskRequest}
+   * @memberof RobotTaskRequest
+   */
+  request: TaskRequest;
+}
+/**
+ * Response to a robot task request
+ * @export
+ * @interface RobotTaskResponse
+ */
+export interface RobotTaskResponse {
+  /**
+   *
+   * @type {boolean}
+   * @memberof RobotTaskResponse
+   */
+  success: RobotTaskResponseSuccessEnum;
+  /**
+   *
+   * @type {TaskState}
+   * @memberof RobotTaskResponse
+   */
+  state: TaskState;
+  /**
+   * Any error messages explaining why the request failed
+   * @type {Array<Error>}
+   * @memberof RobotTaskResponse
+   */
+  errors?: Array<Error>;
+}
+
+export const RobotTaskResponseSuccessEnum = {
+  False: false,
+} as const;
+
+export type RobotTaskResponseSuccessEnum =
+  typeof RobotTaskResponseSuccessEnum[keyof typeof RobotTaskResponseSuccessEnum];
+
+/**
  * Template for defining a response message that only indicates success and describes any errors
  * @export
  * @interface SimpleResponse
@@ -1807,6 +1871,39 @@ export const TaskDiscoveryRequestTypeEnum = {
 
 export type TaskDiscoveryRequestTypeEnum =
   typeof TaskDiscoveryRequestTypeEnum[keyof typeof TaskDiscoveryRequestTypeEnum];
+
+/**
+ * Response to a task dispatch request
+ * @export
+ * @interface TaskDispatchResponse
+ */
+export interface TaskDispatchResponse {
+  /**
+   *
+   * @type {boolean}
+   * @memberof TaskDispatchResponse
+   */
+  success: TaskDispatchResponseSuccessEnum;
+  /**
+   *
+   * @type {TaskState}
+   * @memberof TaskDispatchResponse
+   */
+  state: TaskState;
+  /**
+   * Any error messages explaining why the request failed
+   * @type {Array<Error>}
+   * @memberof TaskDispatchResponse
+   */
+  errors?: Array<Error>;
+}
+
+export const TaskDispatchResponseSuccessEnum = {
+  False: false,
+} as const;
+
+export type TaskDispatchResponseSuccessEnum =
+  typeof TaskDispatchResponseSuccessEnum[keyof typeof TaskDispatchResponseSuccessEnum];
 
 /**
  *
@@ -6408,6 +6505,51 @@ export const TasksApiAxiosParamCreator = function (configuration?: Configuration
     },
     /**
      *
+     * @summary Post Robot Task
+     * @param {RobotTaskRequest} robotTaskRequest
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    postRobotTaskTasksRobotTaskPost: async (
+      robotTaskRequest: RobotTaskRequest,
+      options: AxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'robotTaskRequest' is not null or undefined
+      assertParamExists('postRobotTaskTasksRobotTaskPost', 'robotTaskRequest', robotTaskRequest);
+      const localVarPath = `/tasks/robot_task`;
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
+
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      localVarHeaderParameter['Content-Type'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        robotTaskRequest,
+        localVarRequestOptions,
+        configuration,
+      );
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     *
      * @summary Post Skip Phase
      * @param {TaskPhaseSkipRequest} taskPhaseSkipRequest
      * @param {*} [options] Override http request option.
@@ -6806,6 +6948,23 @@ export const TasksApiFp = function (configuration?: Configuration) {
     },
     /**
      *
+     * @summary Post Robot Task
+     * @param {RobotTaskRequest} robotTaskRequest
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async postRobotTaskTasksRobotTaskPost(
+      robotTaskRequest: RobotTaskRequest,
+      options?: AxiosRequestConfig,
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<RobotTaskResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.postRobotTaskTasksRobotTaskPost(
+        robotTaskRequest,
+        options,
+      );
+      return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+    },
+    /**
+     *
      * @summary Post Skip Phase
      * @param {TaskPhaseSkipRequest} taskPhaseSkipRequest
      * @param {*} [options] Override http request option.
@@ -7038,6 +7197,21 @@ export const TasksApiFactory = function (
     ): AxiosPromise<TaskRewindResponse> {
       return localVarFp
         .postRewindTaskTasksRewindTaskPost(taskRewindRequest, options)
+        .then((request) => request(axios, basePath));
+    },
+    /**
+     *
+     * @summary Post Robot Task
+     * @param {RobotTaskRequest} robotTaskRequest
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    postRobotTaskTasksRobotTaskPost(
+      robotTaskRequest: RobotTaskRequest,
+      options?: any,
+    ): AxiosPromise<RobotTaskResponse> {
+      return localVarFp
+        .postRobotTaskTasksRobotTaskPost(robotTaskRequest, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -7280,6 +7454,23 @@ export class TasksApi extends BaseAPI {
   ) {
     return TasksApiFp(this.configuration)
       .postRewindTaskTasksRewindTaskPost(taskRewindRequest, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   *
+   * @summary Post Robot Task
+   * @param {RobotTaskRequest} robotTaskRequest
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof TasksApi
+   */
+  public postRobotTaskTasksRobotTaskPost(
+    robotTaskRequest: RobotTaskRequest,
+    options?: AxiosRequestConfig,
+  ) {
+    return TasksApiFp(this.configuration)
+      .postRobotTaskTasksRobotTaskPost(robotTaskRequest, options)
       .then((request) => request(this.axios, this.basePath));
   }
 

--- a/packages/api-client/lib/version.ts
+++ b/packages/api-client/lib/version.ts
@@ -3,6 +3,6 @@ import { version as rmfModelVer } from 'rmf-models';
 
 export const version = {
   rmfModels: rmfModelVer,
-  rmfServer: '63417326bac8d143d3545e6b28304012c017f09c',
+  rmfServer: '91ee53fd2cd90d8a1d075eafa9dfcefff5c05613',
   openapiGenerator: '5.4.0',
 };

--- a/packages/api-client/lib/version.ts
+++ b/packages/api-client/lib/version.ts
@@ -3,6 +3,6 @@ import { version as rmfModelVer } from 'rmf-models';
 
 export const version = {
   rmfModels: rmfModelVer,
-  rmfServer: '9dec007143fd6aa3491d7a1bf817feca3c1c099b',
+  rmfServer: '63417326bac8d143d3545e6b28304012c017f09c',
   openapiGenerator: '5.4.0',
 };

--- a/packages/api-client/schema/index.ts
+++ b/packages/api-client/schema/index.ts
@@ -570,6 +570,39 @@ export default {
         },
       },
     },
+    '/tasks/robot_task': {
+      post: {
+        tags: ['Tasks'],
+        summary: 'Post Robot Task',
+        operationId: 'post_robot_task_tasks_robot_task_post',
+        requestBody: {
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/RobotTaskRequest' } },
+          },
+          required: true,
+        },
+        responses: {
+          '200': {
+            description: 'Successful Response',
+            content: {
+              'application/json': { schema: { $ref: '#/components/schemas/RobotTaskResponse' } },
+            },
+          },
+          '400': {
+            description: 'Bad Request',
+            content: {
+              'application/json': { schema: { $ref: '#/components/schemas/RobotTaskResponse' } },
+            },
+          },
+          '422': {
+            description: 'Validation Error',
+            content: {
+              'application/json': { schema: { $ref: '#/components/schemas/HTTPValidationError' } },
+            },
+          },
+        },
+      },
+    },
     '/tasks/interrupt_task': {
       post: {
         tags: ['Tasks'],
@@ -2418,6 +2451,26 @@ export default {
           },
         },
       },
+      RobotTaskRequest: {
+        title: 'RobotTaskRequest',
+        required: ['type', 'robot', 'fleet', 'request'],
+        type: 'object',
+        properties: {
+          type: {
+            title: 'Type',
+            type: 'string',
+            description: 'Indicate that this is a task dispatch request',
+          },
+          robot: { title: 'Robot', type: 'string', description: 'The name of the robot' },
+          fleet: { title: 'Fleet', type: 'string', description: 'The fleet the robot belongs to' },
+          request: { $ref: '#/components/schemas/TaskRequest' },
+        },
+      },
+      RobotTaskResponse: {
+        title: 'RobotTaskResponse',
+        allOf: [{ $ref: '#/components/schemas/TaskDispatchResponse' }],
+        description: 'Response to a robot task request',
+      },
       SimpleResponse: {
         title: 'SimpleResponse',
         anyOf: [
@@ -2563,6 +2616,14 @@ export default {
             description: 'Indicate that this is a task discovery request',
           },
         },
+      },
+      TaskDispatchResponse: {
+        title: 'TaskDispatchResponse',
+        anyOf: [
+          { $ref: '#/components/schemas/TaskDispatchResponseItem' },
+          { $ref: '#/components/schemas/TaskDispatchResponseItem1' },
+        ],
+        description: 'Response to a task dispatch request',
       },
       TaskDispatchResponseItem: {
         title: 'TaskDispatchResponseItem',

--- a/packages/api-server/api_server/models/__init__.py
+++ b/packages/api-server/api_server/models/__init__.py
@@ -24,6 +24,8 @@ from .rmf_api.resume_task_request import TaskResumeRequest
 from .rmf_api.resume_task_response import TaskResumeResponse
 from .rmf_api.rewind_task_request import TaskRewindRequest
 from .rmf_api.rewind_task_response import TaskRewindResponse
+from .rmf_api.robot_task_request import RobotTaskRequest
+from .rmf_api.robot_task_response import *
 from .rmf_api.skip_phase_request import TaskPhaseSkipRequest
 from .rmf_api.skip_phase_response import SkipPhaseResponse
 from .rmf_api.task_discovery_request import TaskDiscoveryRequest

--- a/packages/api-server/api_server/routes/tasks/tasks.py
+++ b/packages/api-server/api_server/routes/tasks/tasks.py
@@ -142,7 +142,7 @@ async def post_robot_task(
     if not resp.__root__.__root__.success:
         return RawJSONResponse(resp.json(), 400)
     await task_repo.save_task_state(
-        cast(mdl.TaskDispatchResponse, resp.__root__).__root__.state
+        cast(mdl.TaskDispatchResponseItem, resp.__root__).__root__.state
     )
     return resp.__root__
 

--- a/packages/api-server/api_server/routes/tasks/tasks.py
+++ b/packages/api-server/api_server/routes/tasks/tasks.py
@@ -142,7 +142,7 @@ async def post_robot_task(
     if not resp.__root__.__root__.success:
         return RawJSONResponse(resp.json(), 400)
     await task_repo.save_task_state(
-        cast(mdl.TaskDispatchResponseItem, resp.__root__).__root__.state
+        cast(mdl.TaskDispatchResponseItem, resp.__root__).state
     )
     return resp.__root__
 


### PR DESCRIPTION
This PR aims to add direct robot assignment REST api calls in the rmf_server, following this: https://github.com/open-rmf/rmf_demos/blob/redesign_v2/rmf_demos_tasks/rmf_demos_tasks/direct_patrol.py