### PR TITLE
Changing default start script

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -50,7 +50,9 @@ npm run setup
 
 ### Environment Variables
 
-The default launch script with `npm start` automatically launches an instance of `rmf_demos` and all the backend servers, this is good for local development, but in production you would need to configure the dashboard so that it knows where to find the various services.
+The default launch script with `npm start` launches only the backend servers without any simulation instances from `rmf_demos`. For local development, the launch script `npm run start:sim` launches a headless simulation instance on top of all the backend servers.
+
+In production, the dashboard would need to be configured so that it knows where to find the various services.
 
 Here are the environment variables that you can set before you build the dashboard:
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
-    "start": "../../scripts/nws.sh build -d && concurrently npm:start:rmf-server npm:start:rmf npm:start:react",
-    "start:clinic": "RMF_DASHBOARD_DEMO_MAP=clinic.launch.xml npm start",
-    "start:airport": "RMF_DASHBOARD_DEMO_MAP=airport_terminal.launch.xml npm start",
+    "start": "../../scripts/nws.sh build -d && concurrently npm:start:rmf-server npm:start:react",
+    "start:sim": "../../scripts/nws.sh build -d && concurrently npm:start:rmf-server npm:start:rmf npm:start:react",
+    "start:clinic": "RMF_DASHBOARD_DEMO_MAP=clinic.launch.xml npm run start:sim",
+    "start:airport": "RMF_DASHBOARD_DEMO_MAP=airport_terminal.launch.xml npm run start:sim",
     "start:react": "react-scripts start",
     "start:rmf": "node scripts/start-rmf.js",
     "start:rmf-server": "RMF_SERVER_USE_SIM_TIME=true npm --prefix ../api-server start",


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

With more testing and demos running on the dashboard, it would be helpful to have the default start script only start up the backend servers, dashboard building and launching, without start headless simulation instances.

I checked around and it doesn't look like we are using `npm start` for the dashboard anywhere else. Just in case I missed out on anything, @koonpeng @mayman99 do you all know anywhere that may be broken due to this change? (e.g. e2e testing, CI, etc)

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
