### PR TITLE
Expandable robot issues on robot panel

### DIFF
--- a/packages/react-components/lib/robots/robot-info.tsx
+++ b/packages/react-components/lib/robots/robot-info.tsx
@@ -9,14 +9,13 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText,
-  // Collapse,
+  Collapse,
 } from '@mui/material';
-// import ExpandLess from '@mui/icons-material/ExpandLess';
-// import ExpandMore from '@mui/icons-material/ExpandMore';
+import ExpandLess from '@mui/icons-material/ExpandLess';
+import ExpandMore from '@mui/icons-material/ExpandMore';
 import ReportProblemRoundedIcon from '@mui/icons-material/ReportProblemRounded';
-import type { TaskState, RobotState } from 'api-client';
-// import React, { useState } from 'react';
-import React from 'react';
+import type { TaskState, RobotState, Issue } from 'api-client';
+import React, { useState } from 'react';
 import { CircularProgressBar } from './circular-progress-bar';
 import { LinearProgressBar } from './linear-progress-bar';
 
@@ -46,29 +45,36 @@ const StyledDiv = styled('div')(() => ({
 type TaskStatus = Required<TaskState>['status'];
 type RobotIssues = Required<RobotState>['issues'];
 
-// const ExpandableIssue = (category: string, detail: string): JSX.Element => {
-//   const [open, setOpen] = useState(false);
-//   const handleClick = () => {
-//     setOpen(!open);
-//   };
+export interface ExpandableIssueProps {
+  category: string;
+  detail: string;
+  onClick?: () => void;
+}
 
-//   return (
-//     <div>
-//       <ListItem button onClick={handleClick}>
-//         <ListItemIcon>
-//           <ReportProblemRoundedIcon />
-//         </ListItemIcon>
-//         <ListItemText>{category}</ListItemText>
-//         {open ? <ExpandLess /> : <ExpandMore />}
-//       </ListItem>
-//       <Collapse in={open} timeout="auto" unmountOnExit>
-//         <ListItem>
-//           <ListItemText>{detail}</ListItemText>
-//         </ListItem>
-//       </Collapse>
-//     </div>
-//   );
-// };
+const ExpandableIssue = (props: ExpandableIssueProps): JSX.Element => {
+  const { category, detail } = props;
+  const [open, setOpen] = useState(false);
+  const handleClick = () => {
+    setOpen(!open);
+  };
+
+  return (
+    <div>
+      <ListItem button onClick={handleClick}>
+        <ListItemIcon>
+          <ReportProblemRoundedIcon />
+        </ListItemIcon>
+        <ListItemText>{category}</ListItemText>
+        {open ? <ExpandLess /> : <ExpandMore />}
+      </ListItem>
+      <Collapse in={open} timeout="auto" unmountOnExit>
+        <ListItem>
+          <ListItemText>{detail}</ListItemText>
+        </ListItem>
+      </Collapse>
+    </div>
+  );
+};
 
 export interface RobotInfoProps {
   robotName: string;
@@ -155,30 +161,30 @@ export function RobotInfo({
         </Grid>
 
         <Divider />
+        <div style={{ marginBottom: theme.spacing(1) }}></div>
 
-        <Grid container item xs={12} justifyContent="center">
+        <Grid container item xs={12} justifyContent="left">
           <Typography variant="h6" gutterBottom>
             Issues
           </Typography>
         </Grid>
-        <Grid container item xs={12} justifyContent="center">
+        <Grid container item xs={12} justifyContent="left">
           <List dense disablePadding component="div" role="list">
-            {robotIssuesArray.map((issue, i) => (
-              // <ExpandableIssue key={i}
-              //   category={issue.category !== undefined ? issue.category : 'unnamed category'}
-              //   detail={JSON.stringify(issue.detail)} />
-              <ListItem key={i}>
-                <ListItemIcon>
-                  <ReportProblemRoundedIcon />
-                </ListItemIcon>
-                <ListItemText>{JSON.stringify(issue)}</ListItemText>
-              </ListItem>
+            {robotIssuesArray.map((issue: Issue, i) => (
+              <ExpandableIssue
+                key={i}
+                category={issue.category !== undefined ? issue.category : 'unnamed category'}
+                detail={JSON.stringify(issue.detail)}
+              />
             ))}
             {robotIssuesArray.length === 0 && (
               <Typography gutterBottom>No pending issues.</Typography>
             )}
           </List>
         </Grid>
+
+        <Divider />
+        <div style={{ marginBottom: theme.spacing(1) }}></div>
       </Grid>
     </StyledDiv>
   );


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

## What's new

Basic grid-based list of issues where the category is shown, and after expanding the details of the issue is shown.

### Quick and dirty test

This can be tested by spoofing some issues in https://github.com/open-rmf/rmf_ros2/blob/main/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp#L853-L859 from the original to
```
// for (const auto& issue : issues)
      for (int i = 0; i < 3; ++i)
      {
        nlohmann::json issue_msg;
        // issue_msg["category"] = issue->category;
        // issue_msg["detail"] = issue->detail;
        issue_msg["category"] = "fake_category";
        std::stringstream ss;
        ss << i;
        issue_msg["detail"] = ss.str();
        issues_msg.push_back(std::move(issue_msg));
      }
```

```
cd ~/ws
rm -rf install/rmf_fleet_adapter build/rmf_fleet_adapter
colcon build --packages-select rmf_fleet_adapter

source install/setup.bash
ros2 launch rmf_demos_gz office.launch.xml server_uri:="ws://localhost:8001"
```

![image](https://user-images.githubusercontent.com/5383623/163787146-d1c037eb-0242-430f-8aca-1fc6f6677fda.png)


