### PR TITLE
log time with 64 bit

### DIFF
--- a/packages/api-server/api_server/models/tortoise_models/log.py
+++ b/packages/api-server/api_server/models/tortoise_models/log.py
@@ -1,10 +1,10 @@
-from tortoise.fields import CharEnumField, IntField, TextField
+from tortoise.fields import BigIntField, CharEnumField, IntField, TextField
 
 from api_server.models.rmf_api import log_entry
 
 
 class LogMixin:
     seq = IntField()
-    unix_millis_time = IntField(null=False, index=True)
+    unix_millis_time = BigIntField(null=False, index=True)
     tier = CharEnumField(log_entry.Tier, max_length=255)
     text = TextField()


### PR DESCRIPTION
Originated from https://github.com/open-rmf/rmf-web/pull/603

Previously will get receive an error printout when the timestamp is more than 32bit `IntField` . 