### PR TITLE
fix response body for robot_task

### DIFF
--- a/packages/api-server/api_server/routes/tasks/tasks.py
+++ b/packages/api-server/api_server/routes/tasks/tasks.py
@@ -139,8 +139,9 @@ async def post_robot_task(
     )
     if not resp.__root__.__root__.success:
         return RawJSONResponse(resp.json(), 400)
+    ## TODO:(YL) clarify response implementation compare to /dispatch_task
     await task_repo.save_task_state(
-        cast(mdl.TaskDispatchResponseItem, resp.__root__).state
+        cast(mdl.TaskDispatchResponseItem, resp.__root__).__root__.state
     )
     return resp.__root__
 

--- a/packages/api-server/api_server/routes/tasks/tasks.py
+++ b/packages/api-server/api_server/routes/tasks/tasks.py
@@ -139,7 +139,6 @@ async def post_robot_task(
     )
     if not resp.__root__.__root__.success:
         return RawJSONResponse(resp.json(), 400)
-    ## TODO:(YL) clarify response implementation compare to /dispatch_task
     await task_repo.save_task_state(
         cast(mdl.TaskDispatchResponseItem, resp.__root__).__root__.state
     )

--- a/packages/api-server/api_server/routes/tasks/tasks.py
+++ b/packages/api-server/api_server/routes/tasks/tasks.py
@@ -140,7 +140,7 @@ async def post_robot_task(
     if not resp.__root__.__root__.success:
         return RawJSONResponse(resp.json(), 400)
     await task_repo.save_task_state(
-        cast(mdl.TaskDispatchResponseItem, resp.__root__).__root__.state
+        cast(mdl.TaskDispatchResponseItem, resp.__root__.__root__).state
     )
     return resp.__root__
 


### PR DESCRIPTION
Originated from https://github.com/open-rmf/rmf-web/pull/603


This is related to the direct assignment call when calling the `/robot_task` REST API. The request works, but response body is incorrect, hence the fix.

## to test
Test the `/robot_task` endpoint on `http://localhost:8000/docs`  with the json request body below: (rmf_demos's office world)

```json
{
  "type": "robot_task_request",
  "robot": "tinyRobot1",
  "fleet": "tinyRobot",
  "request": {
    "unix_millis_earliest_start_time": 0,
    "category": "patrol",
    "description": {
      "places": [
        "pantry",
        "lounge"
      ],
      "rounds": 2
    }
  }
}
```