### PR TITLE
accept single place for loop task form

### DIFF
--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { NineKOutlined } from '@mui/icons-material';
 import {
   Autocomplete,
   Button,
@@ -12,8 +13,12 @@ import {
   styled,
   TextField,
   useTheme,
+  ListItemIcon,
+  IconButton,
 } from '@mui/material';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import PlaceOutlined from '@mui/icons-material/PlaceOutlined';
+import DeleteIcon from '@mui/icons-material/Delete';
 import type { TaskRequest } from 'api-client';
 import React from 'react';
 import { ConfirmationDialog, ConfirmationDialogProps } from '../confirmation-dialog';
@@ -394,6 +399,41 @@ function DeliveryTaskForm({
   );
 }
 
+interface PlaceListProps {
+  places: string[];
+  onClick(places_index: number): void;
+}
+
+function PlaceList({ places, onClick }: PlaceListProps) {
+  const theme = useTheme();
+  return (
+    <List
+      dense
+      sx={{
+        bgcolor: 'background.paper',
+        marginLeft: theme.spacing(3),
+        marginRight: theme.spacing(3),
+      }}
+    >
+      {places.map((value, index) => (
+        <ListItem
+          key={`${value}-${index}`}
+          secondaryAction={
+            <IconButton edge="end" aria-label="delete" onClick={() => onClick(index)}>
+              <DeleteIcon />
+            </IconButton>
+          }
+        >
+          <ListItemIcon>
+            <PlaceOutlined />
+          </ListItemIcon>
+          <ListItemText primary={`Place Name:   ${value}`} />
+        </ListItem>
+      ))}
+    </List>
+  );
+}
+
 interface LoopTaskFormProps {
   taskDesc: any;
   loopWaypoints: string[];
@@ -405,34 +445,10 @@ function LoopTaskForm({ taskDesc, loopWaypoints, onChange }: LoopTaskFormProps) 
 
   return (
     <>
-      <Autocomplete
-        id="start-location"
-        freeSolo
-        fullWidth
-        options={loopWaypoints}
-        onChange={(_ev, newValue) =>
-          newValue !== null &&
-          onChange({
-            ...taskDesc,
-            places: [newValue, taskDesc.places[1]].filter(
-              (el) => el, // filter null and empty str in places array
-            ),
-          })
-        }
-        onBlur={(ev) =>
-          onChange({
-            ...taskDesc,
-            places: [(ev.target as HTMLInputElement).value, taskDesc.places[1]].filter(
-              (el) => el, // filter null and empty str in places array
-            ),
-          })
-        }
-        renderInput={(params) => <TextField {...params} label="Location 1" margin="normal" />}
-      />
       <Grid container wrap="nowrap">
         <Grid style={{ flex: '1 1 100%' }}>
           <Autocomplete
-            id="finish-location"
+            id="place-input"
             freeSolo
             fullWidth
             options={loopWaypoints}
@@ -440,22 +456,20 @@ function LoopTaskForm({ taskDesc, loopWaypoints, onChange }: LoopTaskFormProps) 
               newValue !== null &&
               onChange({
                 ...taskDesc,
-                places: [taskDesc.places[0], newValue].filter(
-                  (el) => el, // filter null and empty str in places array
+                places: taskDesc.places.concat(newValue).filter(
+                  (el: string) => el, // filter null and empty str in places array
                 ),
               })
             }
             onBlur={(ev) =>
               onChange({
                 ...taskDesc,
-                places: [taskDesc.places[0], (ev.target as HTMLInputElement).value].filter(
-                  (el) => el, // filter null and empty str in places array
+                places: taskDesc.places.concat((ev.target as HTMLInputElement).value).filter(
+                  (el: string) => el, // filter null and empty str in places array
                 ),
               })
             }
-            renderInput={(params) => (
-              <TextField {...params} label="Location 2 (Optional)" margin="normal" />
-            )}
+            renderInput={(params) => <TextField {...params} label="Place Name" margin="normal" />}
           />
         </Grid>
         <Grid
@@ -479,6 +493,10 @@ function LoopTaskForm({ taskDesc, loopWaypoints, onChange }: LoopTaskFormProps) 
           />
         </Grid>
       </Grid>
+      <PlaceList
+        places={taskDesc && taskDesc.places ? taskDesc.places : []}
+        onClick={(places_index) => taskDesc.places.splice(places_index, 1)}
+      />
     </>
   );
 }

--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -52,7 +52,7 @@ function getShortDescription(taskRequest: TaskRequest): string {
       return `[Delivery] from [${taskRequest.description.pickup.place}] to [${taskRequest.description.dropoff.place}]`;
     }
     case 'patrol': {
-      return `[Loop] from [${taskRequest.description.places[0]}] to [${taskRequest.description.places[1]}]`;
+      return `[Patrol] [${taskRequest.description.places[0]}] to [${taskRequest.description.places[1]}]`;
     }
     default:
       return `[Unknown] type "${taskRequest.category}"`;
@@ -410,18 +410,21 @@ function LoopTaskForm({ taskDesc, loopWaypoints, onChange }: LoopTaskFormProps) 
         freeSolo
         fullWidth
         options={loopWaypoints}
-        value={taskDesc.places[0]}
         onChange={(_ev, newValue) =>
           newValue !== null &&
           onChange({
             ...taskDesc,
-            places: [newValue, taskDesc.places[1]],
+            places: [newValue, taskDesc.places[1]].filter(
+              (el) => el, // filter null and empty str in places array
+            ),
           })
         }
         onBlur={(ev) =>
           onChange({
             ...taskDesc,
-            places: [(ev.target as HTMLInputElement).value, taskDesc.places[1]],
+            places: [(ev.target as HTMLInputElement).value, taskDesc.places[1]].filter(
+              (el) => el, // filter null and empty str in places array
+            ),
           })
         }
         renderInput={(params) => <TextField {...params} label="Start Location" margin="normal" />}
@@ -433,18 +436,21 @@ function LoopTaskForm({ taskDesc, loopWaypoints, onChange }: LoopTaskFormProps) 
             freeSolo
             fullWidth
             options={loopWaypoints}
-            value={taskDesc.places[1]}
             onChange={(_ev, newValue) =>
               newValue !== null &&
               onChange({
                 ...taskDesc,
-                places: [taskDesc.places[0], newValue],
+                places: [taskDesc.places[0], newValue].filter(
+                  (el) => el, // filter null and empty str in places array
+                ),
               })
             }
             onBlur={(ev) =>
               onChange({
                 ...taskDesc,
-                places: [taskDesc.places[0], (ev.target as HTMLInputElement).value],
+                places: [taskDesc.places[0], (ev.target as HTMLInputElement).value].filter(
+                  (el) => el, // filter null and empty str in places array
+                ),
               })
             }
             renderInput={(params) => (
@@ -463,7 +469,7 @@ function LoopTaskForm({ taskDesc, loopWaypoints, onChange }: LoopTaskFormProps) 
             id="loops"
             label="Loops"
             margin="normal"
-            value={taskDesc.num_loops}
+            value={taskDesc.rounds}
             onChange={(_ev, val) => {
               onChange({
                 ...taskDesc,
@@ -513,7 +519,7 @@ function defaultCleanTask(): Record<string, any> {
 
 function defaultLoopsTask(): Record<string, any> {
   return {
-    places: ['', ''],
+    places: [],
     rounds: 1,
   };
 }

--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -427,7 +427,7 @@ function LoopTaskForm({ taskDesc, loopWaypoints, onChange }: LoopTaskFormProps) 
             ),
           })
         }
-        renderInput={(params) => <TextField {...params} label="Start Location" margin="normal" />}
+        renderInput={(params) => <TextField {...params} label="Location 1" margin="normal" />}
       />
       <Grid container wrap="nowrap">
         <Grid style={{ flex: '1 1 100%' }}>
@@ -454,7 +454,7 @@ function LoopTaskForm({ taskDesc, loopWaypoints, onChange }: LoopTaskFormProps) 
               })
             }
             renderInput={(params) => (
-              <TextField {...params} label="Finish Location" margin="normal" />
+              <TextField {...params} label="Location 2 (Optional)" margin="normal" />
             )}
           />
         </Grid>


### PR DESCRIPTION
PR originated from: https://github.com/open-rmf/rmf-web/pull/603

With the new `patrol` task (previously known as `Loop`), the task form accepts a list of places, instead of a pair of `start` and `end` places. Thus this form is to make the second place optional, helping dispatch the robot to a single location. Also, with the new `patrol` task, the number of loops is changed to `rounds`

![Screenshot from 2022-06-22 12-12-40](https://user-images.githubusercontent.com/32189404/174942340-39ab793d-d58e-4249-b03f-ddbf5dc83918.png)

