### PR TITLE
runtime configure dashboard env vars

### DIFF
--- a/packages/dashboard/public/env.js
+++ b/packages/dashboard/public/env.js
@@ -1,0 +1,15 @@
+// public/env.js
+window.ENV = {
+  REACT_APP_TRAJECTORY_SERVER: 'ws://localhost:8006',
+  // REACT_APP_AUTH_PROVIDER: "keycloak",
+  // REACT_APP_KEYCLOAK_CONFIG: '{"realm": "rmf-web", "clientId": "dashboard", "url" : "https://localhost:8000/auth"}',
+  REACT_APP_RMF_SERVER: 'http://localhost:8000',
+  PUBLIC_URL: '/dashboard',
+};
+
+// ARG DOMAIN_URL="rmf-deployment-template.open-rmf.org"
+// ENV PUBLIC_URL="/dashboard"
+// ENV REACT_APP_TRAJECTORY_SERVER="wss://${DOMAIN_URL}/trajectory"
+// ENV REACT_APP_RMF_SERVER="https://${DOMAIN_URL}/rmf/api/v1"
+// ENV REACT_APP_AUTH_PROVIDER="keycloak"
+// ENV REACT_APP_KEYCLOAK_CONFIG='{"realm": "rmf-web", "clientId": "dashboard", "url" : "https://'${DOMAIN_URL}'/auth"}'

--- a/packages/dashboard/public/index.html
+++ b/packages/dashboard/public/index.html
@@ -11,6 +11,8 @@
     />
     <link rel="shortcut icon" type="image/x-icon" href="favicon.ico" />
 
+    <script type="text/javascript" src="%PUBLIC_URL%/env.js"></script>
+
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/packages/dashboard/src/app-config.ts
+++ b/packages/dashboard/src/app-config.ts
@@ -11,27 +11,33 @@ export interface AppConfig {
   appResourcesFactory: () => Promise<ResourceManager | undefined>;
 }
 
+declare global {
+  interface Window {
+    ENV: any;
+  }
+}
+
 export const appConfig: AppConfig = (() => {
-  const trajServer = process.env.REACT_APP_TRAJECTORY_SERVER;
+  const trajServer = window.ENV.REACT_APP_TRAJECTORY_SERVER;
   if (!trajServer) {
     throw new Error('REACT_APP_TRAJECTORY_SERVER env variable is needed but not defined');
   }
 
   const authenticator = (() => {
-    if (!process.env.REACT_APP_AUTH_PROVIDER) {
+    if (!window.ENV.REACT_APP_AUTH_PROVIDER) {
       return new StubAuthenticator();
     }
     // it is important that we do not do any processing on REACT_APP_AUTH_PROVIDER so that webpack
     // can remove dead code, we DO NOT want the output to have the stub authenticator even if
     // it is not used.
-    const provider = process.env.REACT_APP_AUTH_PROVIDER;
+    const provider = window.ENV.REACT_APP_AUTH_PROVIDER;
     switch (provider) {
       case 'keycloak':
-        if (!process.env.REACT_APP_KEYCLOAK_CONFIG) {
+        if (!window.ENV.REACT_APP_KEYCLOAK_CONFIG) {
           throw new Error('missing REACT_APP_KEYCLOAK_CONFIG');
         }
         return new KeycloakAuthenticator(
-          JSON.parse(process.env.REACT_APP_KEYCLOAK_CONFIG),
+          JSON.parse(window.ENV.REACT_APP_KEYCLOAK_CONFIG),
           `${window.location.origin}${BasePath}/silent-check-sso.html`,
         );
       case 'stub':
@@ -41,7 +47,7 @@ export const appConfig: AppConfig = (() => {
     }
   })();
 
-  if (!process.env.REACT_APP_RMF_SERVER) {
+  if (!window.ENV.REACT_APP_RMF_SERVER) {
     throw new Error('REACT_APP_RMF_SERVER is required');
   }
 
@@ -49,7 +55,7 @@ export const appConfig: AppConfig = (() => {
     authenticator,
     appResourcesFactory: ResourceManager.defaultResourceManager,
     trajServerUrl: trajServer,
-    rmfServerUrl: process.env.REACT_APP_RMF_SERVER,
+    rmfServerUrl: window.ENV.REACT_APP_RMF_SERVER,
   } as AppConfig;
 })();
 


### PR DESCRIPTION
Currently, when building the `dashboard.Dockerfile`, we will need to specify the URL during build time. When we wish have containers with different URLs, this requires us to build multiple images with their own respective URL. Hence, having a `public/env.js`, which can be edited during runtime enables us to share one single dashboard docker image.

This command can be executed during runtime
```bash
echo "$(cat <<EOM
window.ENV =
{
  PUBLIC_URL:"/dashboard",
  REACT_APP_TRAJECTORY_SERVER:"wss://${DOMAIN_URL}/trajectory",
  REACT_APP_RMF_SERVER:"https://${DOMAIN_URL}/rmf/api/v1",
  REACT_APP_AUTH_PROVIDER:"keycloak",
  REACT_APP_KEYCLOAK_CONFIG='{"realm": "rmf-web", "clientId": "dashboard", "url" : "https://${DOMAIN_URL}/auth"}',
}
EOM
)" > $ENV_CONFIG_FILE_PATH
```

the `ENV_CONFIG_FILE_PATH` is located in `dashboard/build/env.js`

Referred to https://stackoverflow.com/questions/51653931/react-configuration-file-for-post-deployment-settings/51663697#51663697
