### PR TITLE
api-server: fix fastio to work with newer uvicorn

### DIFF
--- a/packages/api-server/api_server/fast_io/__init__.py
+++ b/packages/api-server/api_server/fast_io/__init__.py
@@ -155,7 +155,7 @@ class FastIO(FastAPI):
     ):
         super().__init__(*args, **kwargs)
         self.sio = socketio.AsyncServer(
-            async_mode="asgi", cors_allowed_origins="*", serializer=FastIOPacket
+            async_mode="asgi", cors_allowed_origins=[], serializer=FastIOPacket
         )
         self.sio.on("connect", socketio_connect)
         self.sio.on("subscribe", self._on_subscribe)
@@ -199,13 +199,8 @@ The message must be of the form:
         )
         self.routes.append(self._sio_route)
 
-        self._sio_app = socketio.ASGIApp(
-            self.sio, super().__call__, socketio_path=socketio_path
-        )
-
-    async def __call__(self, scope, receive, send):
-        # Make the sio the "primary" app because fastapi does not support mounting a single path.
-        return await self._sio_app(scope, receive, send)
+        self._sio_app = socketio.ASGIApp(self.sio, socketio_path="")
+        self.mount(socketio_path, self._sio_app)
 
     def include_router(self, router: APIRouter, *args, prefix: str = "", **kwargs):
         super().include_router(router, *args, prefix=prefix, **kwargs)


### PR DESCRIPTION
## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

Since upgrading uvicorn (probably from #617), you may get `tortoise.exceptions.ConfigurationError: No DB associated to model` errors. This is due to the app startup not being called at all, while I'm not sure of the root cause, switching the main asgi app to fastapi fixes it.

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
