### PR TITLE
Add numpy to pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ coverage = "~=5.5"
 api-server = {editable = true, path = "./packages/api-server"}
 requests = "~=2.25"
 asyncpg = "~=0.25.0"
+numpy = "~=1.23.1"
 websocket-client = "~=1.2.3"
 # reporting-server
 reporting-server = {editable = true, path = "./packages/reporting-server"}


### PR DESCRIPTION
This PR adds numpy as one of the packages to install. Without it I got a `ModuleNotFoundEror: No module named 'numpy'` and is unable to launch rmf-web