### PR TITLE
safe check internal ws msg 'type' field

### DIFF
--- a/packages/api-server/api_server/routes/internal.py
+++ b/packages/api-server/api_server/routes/internal.py
@@ -16,11 +16,12 @@ task_repo = TaskRepository(user)
 
 async def process_msg(msg: Dict[str, Any], fleet_repo: FleetRepository) -> None:
     if "type" not in msg:
-        logger.debug("Ignoring message, 'type' must include in msg field")
+        logger.warn(msg)
+        logger.warn("Ignoring message, 'type' must include in msg field")
         return
     payload_type: str = msg["type"]
     if not isinstance(payload_type, str):
-        logger.error("error processing message, 'type' must be a string")
+        logger.warn("error processing message, 'type' must be a string")
         return
     logger.debug(msg)
 

--- a/packages/api-server/api_server/routes/internal.py
+++ b/packages/api-server/api_server/routes/internal.py
@@ -15,6 +15,9 @@ task_repo = TaskRepository(user)
 
 
 async def process_msg(msg: Dict[str, Any], fleet_repo: FleetRepository) -> None:
+    if "type" not in msg:
+        logger.debug("Ignoring message, 'type' must include in msg field")
+        return
     payload_type: str = msg["type"]
     if not isinstance(payload_type, str):
         logger.error("error processing message, 'type' must be a string")


### PR DESCRIPTION
For some instance when running rmf_demos, i will get this error:
```
    await dependant.call(**values)
  File "/usr/local/lib/python3.8/dist-packages/api_server/routes/internal.py", line 49, in rmf_gateway
    await process_msg(msg, fleet_repo)
  File "/usr/local/lib/python3.8/dist-packages/api_server/routes/internal.py", line 18, in process_msg
    payload_type: str = msg["type"]
TypeError: list indices must be integers or slices, not str
```

I noticed some client is sending in an msg data with empty array `[]`, which is not compatible to the rmf msg. This requires further investigation to fix this. Meanwhile, the api server should also be robust enough to pick up incompatible msg, thus a simple safe check to ensure 'type' exists in the msg field.