### PR TITLE
Fix starting with psql

### DIFF
--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -7,6 +7,7 @@
     "prepack": "../../scripts/nws.sh build -d && pipenv run python setup.py bdist_wheel",
     "restart": "../../scripts/nws.sh build -d && RMF_API_SERVER_CONFIG=sqlite_local_config.py pipenv run python -m api_server",
     "start": "../../scripts/nws.sh build -d && rm -rf run && mkdir -p run && RMF_API_SERVER_CONFIG=sqlite_local_config.py pipenv run python -m api_server",
+    "start:psql": "../../scripts/nws.sh build -d && rm -rf run && mkdir -p run && RMF_API_SERVER_CONFIG=psql_local_config.py pipenv run python -m api_server",
     "test": "../../scripts/nws.sh build -d && pipenv run python scripts/test.py",
     "test:cov": "../../scripts/nws.sh build -d && pipenv run python -m coverage run scripts/test.py",
     "test:report": "pipenv run python -m coverage html && xdg-open htmlcov/index.html",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -11,7 +11,7 @@
     "start:react": "react-scripts start",
     "start:rmf": "node scripts/start-rmf.js",
     "start:rmf-server": "RMF_SERVER_USE_SIM_TIME=true npm --prefix ../api-server start",
-    "start:rmf-server:psql": "RMF_API_SERVER_CONFIG=../api-server/psql_local_config.py RMF_SERVER_USE_SIM_TIME=true npm --prefix ../api-server start",
+    "start:rmf-server:psql": "RMF_SERVER_USE_SIM_TIME=true npm run --prefix ../api-server start:psql",
     "build": "../../scripts/nws.sh build -d && react-scripts build",
     "test": "../../scripts/nws.sh build -d && react-scripts test",
     "test:coverage": "npm run test -- --coverage --watchAll=false",


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

Running `start:psql` in `packages/dashboard` still runs with `RMF_API_SERVER_CONFIG=sqlite_local_config.py`, this changes it to the correct `psql_local_config.py`
