### PR TITLE
dashboard: Add sort by date to tasks table

### DIFF
--- a/packages/dashboard/src/components/tasks/tasks-app.tsx
+++ b/packages/dashboard/src/components/tasks/tasks-app.tsx
@@ -65,6 +65,11 @@ export const TasksApp = React.memo(
       const [page, setPage] = React.useState(0);
       const [hasMore, setHasMore] = React.useState(true);
 
+      /**
+       * This state, if toggled, reverts the chronological order of the tasks listed in the tasks table.
+       */
+      const [chronologicalOrder, setChronologicalOrder] = React.useState<boolean>(true);
+
       const [placeNames, setPlaceNames] = React.useState<string[]>([]);
       React.useEffect(() => {
         if (!rmf) {
@@ -99,7 +104,7 @@ export const TasksApp = React.memo(
             undefined,
             11,
             page * 10,
-            '-unix_millis_start_time',
+            chronologicalOrder ? '-unix_millis_start_time' : 'unix_millis_start_time',
             undefined,
           );
           const results = resp.data as TaskState[];
@@ -123,7 +128,7 @@ export const TasksApp = React.memo(
           );
         })();
         return () => subs.forEach((s) => s.unsubscribe());
-      }, [rmf, page, forceRefresh]);
+      }, [rmf, page, forceRefresh, chronologicalOrder]);
 
       const submitTasks = React.useCallback<Required<CreateTaskFormProps>['submitTasks']>(
         async (taskRequests) => {
@@ -173,6 +178,7 @@ export const TasksApp = React.memo(
                 <TaskTable
                   tasks={Object.values(taskStates)}
                   onTaskClick={(_ev, task) => AppEvents.taskSelect.next(task)}
+                  onDateTitleClick={(_ev) => setChronologicalOrder((prev) => !prev)}
                 />
               </TableContainer>
             </Grid>

--- a/packages/react-components/lib/tasks/task-table.tsx
+++ b/packages/react-components/lib/tasks/task-table.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   styled,
   Table,
   TableBody,
@@ -6,7 +7,6 @@ import {
   TableHead,
   TableProps,
   TableRow,
-  Button,
 } from '@mui/material';
 import { Status, TaskState } from 'api-client';
 import clsx from 'clsx';

--- a/packages/react-components/lib/tasks/task-table.tsx
+++ b/packages/react-components/lib/tasks/task-table.tsx
@@ -6,6 +6,7 @@ import {
   TableHead,
   TableProps,
   TableRow,
+  Button,
 } from '@mui/material';
 import { Status, TaskState } from 'api-client';
 import clsx from 'clsx';
@@ -137,14 +138,32 @@ export interface TaskTableProps {
    */
   tasks: TaskState[];
   onTaskClick?(ev: React.MouseEvent<HTMLDivElement>, task: TaskState): void;
+
+  /**
+   * Handles the event when clicking the date title and reverts the chronological order of the list.
+   * @param ev Mouse event click.
+   */
+  onDateTitleClick?(ev: React.MouseEvent<HTMLButtonElement>): void;
 }
 
-export function TaskTable({ tasks, onTaskClick }: TaskTableProps): JSX.Element {
+export function TaskTable({ tasks, onTaskClick, onDateTitleClick }: TaskTableProps): JSX.Element {
   return (
     <StyledTable stickyHeader size="small">
       <TableHead>
         <TableRow>
-          <TableCell>Date</TableCell>
+          <TableCell>
+            <Button
+              variant="text"
+              onClick={(ev) => onDateTitleClick && onDateTitleClick(ev)}
+              sx={{
+                color: 'inherit',
+                textTransform: 'none',
+              }}
+            >
+              Date
+            </Button>
+          </TableCell>
+
           <TableCell>Task Id</TableCell>
           <TableCell>Category</TableCell>
           <TableCell>Assignee</TableCell>


### PR DESCRIPTION
## What's new
This PR adds a basic sort by date feature to the tasks task table in the UI. <br>
The changes affect only the react app leaving the FastAPi as it was till now.<br>
![sortTasksByDate](https://user-images.githubusercontent.com/61993763/188517685-73a1d5cf-fdbd-4a93-bfb1-985acc4ee668.gif)





<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [x] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [x] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
