### PR TITLE
Clean tasks now submit a sequence of goto and perform_action

### DIFF
--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -49,8 +49,9 @@ const StyledConfirmationDialog = styled((props: ConfirmationDialogProps) => (
 
 function getShortDescription(taskRequest: TaskRequest): string {
   switch (taskRequest.category) {
-    case 'clean': {
-      return `[Clean] zone [${taskRequest.description.zone}]`;
+    case 'compose': {
+      // TODO(XY): update with the correct fields for compose tasks
+      return `[Clean] task [${taskRequest.description.zone}]`;
     }
     case 'delivery': {
       return `[Delivery] from [${taskRequest.description.pickup.place}] to [${taskRequest.description.dropoff.place}]`;
@@ -517,7 +518,7 @@ function CleanTaskForm({ taskDesc, cleaningZones, onChange }: CleanTaskFormProps
             defaultCleanTask(
               newValue,
               taskDesc.phases[0].activity.description.activities[1].description.description
-                .task_name,
+                .clean_task_name,
             ),
           )
         }
@@ -526,7 +527,7 @@ function CleanTaskForm({ taskDesc, cleaningZones, onChange }: CleanTaskFormProps
             defaultCleanTask(
               (ev.target as HTMLInputElement).value,
               taskDesc.phases[0].activity.description.activities[1].description.description
-                .task_name,
+                .clean_task_name,
             ),
           )
         }
@@ -618,7 +619,7 @@ function defaultDeliveryTask(): Record<string, any> {
 
 function defaultTaskDescription(taskCategory: string): TaskDescription | undefined {
   switch (taskCategory) {
-    case 'clean':
+    case 'compose':
       return defaultCleanTask();
     case 'patrol':
       return defaultLoopsTask();
@@ -692,12 +693,12 @@ export function CreateTaskForm({
 
   const renderTaskDescriptionForm = () => {
     switch (taskRequest.category) {
-      case 'clean':
+      case 'compose':
         return (
           <CleanTaskForm
             taskDesc={taskRequest.description as any}
             cleaningZones={cleaningZones}
-            onChange={(desc) => handleTaskDescriptionChange('clean', desc)}
+            onChange={(desc) => handleTaskDescriptionChange('compose', desc)}
           />
         );
       case 'patrol':
@@ -794,7 +795,7 @@ export function CreateTaskForm({
             value={taskRequest.category}
             onChange={handleTaskTypeChange}
           >
-            <MenuItem value="clean">Clean</MenuItem>
+            <MenuItem value="compose">Clean</MenuItem>
             <MenuItem value="patrol">Loop</MenuItem>
             <MenuItem value="delivery">Delivery</MenuItem>
           </TextField>

--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -505,29 +505,92 @@ interface CleanTaskFormProps {
 
 function CleanTaskForm({ taskDesc, cleaningZones, onChange }: CleanTaskFormProps) {
   return (
-    <Autocomplete
-      id="cleaning-zone"
-      freeSolo
-      fullWidth
-      options={cleaningZones}
-      value={taskDesc.zone}
-      onChange={(_ev, newValue) =>
-        newValue !== null &&
-        onChange({
-          ...taskDesc,
-          zone: newValue,
-        })
-      }
-      onBlur={(ev) => onChange({ ...taskDesc, zone: (ev.target as HTMLInputElement).value })}
-      renderInput={(params) => <TextField {...params} label="Cleaning Zone" margin="normal" />}
-    />
+    <>
+      <Autocomplete
+        id="clean-location"
+        freeSolo
+        fullWidth
+        options={cleaningZones}
+        onChange={(_ev, newValue) =>
+          newValue !== null &&
+          onChange(
+            defaultCleanTask(
+              newValue,
+              taskDesc.phases[0].activity.description.activities[1].description.description
+                .task_name,
+            ),
+          )
+        }
+        onBlur={(ev) =>
+          onChange(
+            defaultCleanTask(
+              (ev.target as HTMLInputElement).value,
+              taskDesc.phases[0].activity.description.activities[1].description.description
+                .task_name,
+            ),
+          )
+        }
+        renderInput={(params) => <TextField {...params} label="Clean Location" margin="normal" />}
+      />
+      <Autocomplete
+        id="cleaning-task"
+        freeSolo
+        fullWidth
+        options={[]}
+        value={taskDesc.zone}
+        onChange={(_ev, newValue) =>
+          newValue !== null &&
+          onChange(
+            defaultCleanTask(
+              taskDesc.phases[0].activity.description.activities[0].description,
+              newValue,
+            ),
+          )
+        }
+        onBlur={(ev) =>
+          onChange(
+            defaultCleanTask(
+              taskDesc.phases[0].activity.description.activities[0].description,
+              (ev.target as HTMLInputElement).value,
+            ),
+          )
+        }
+        renderInput={(params) => <TextField {...params} label="Cleaning Task" margin="normal" />}
+      />
+    </>
   );
 }
 
-function defaultCleanTask(): Record<string, any> {
+function defaultCleanTask(clean_location: string = '', clean_task_name = ''): Record<string, any> {
   return {
-    zone: '',
-    type: '',
+    category: 'clean',
+    phases: [
+      {
+        activity: {
+          category: 'sequence',
+          description: {
+            activities: [
+              {
+                category: 'go_to_place',
+                description: clean_location,
+              },
+              {
+                category: 'perform_action',
+                description: {
+                  // TODO(AA): To obtain accurate duration estimate.
+                  unix_millis_action_duration_estimate: 60000,
+                  category: 'clean',
+                  description: {
+                    clean_task_name: clean_task_name,
+                  },
+                  use_tool_sink: true,
+                },
+              },
+            ],
+          },
+        },
+      },
+    ],
   };
 }
 


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

Implements https://github.com/open-rmf/rmf-web/issues/639. This will require changes on other Open-RMF packages related to cleaning tasks.

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
