### PR TITLE
Update installation steps in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Refer to the following documentations:
 
 ## Install dependencies
 
+For Debian/Ubuntu systems, you may need to install `python3-venv` first.
+```bash
+sudo apt install python3-venv
+```
+
+Run
 ```bash
 pnpm install
 ```
@@ -76,7 +82,7 @@ sudo -u postgres bash -c "dropdb postgres; createdb postgres"
 Before running the commands, make sure that rmf is sourced.
 ```bash
 cd packages/dashboard
-npm start
+pnpm start
 ```
 When presented with a login screen, use `user=admin password=admin`.
 


### PR DESCRIPTION
This PR adds an installation step in the README to install `python3-venv` for Ubuntu/Debian systems. It also corrects the launch instructions from `npm install` to `pnpm install`