### PR TITLE
Bumping rx to reactivex 4.0.4

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -848,13 +848,13 @@
             "markers": "python_version < '3.11' and platform_python_implementation == 'CPython'",
             "version": "==0.2.6"
         },
-        "rx": {
+        "reactivex": {
             "hashes": [
-                "sha256:922c5f4edb3aa1beaa47bf61d65d5380011ff6adcd527f26377d05cb73ed8ec8",
-                "sha256:b657ca2b45aa485da2f7dcfd09fac2e554f7ac51ff3c2f8f2ff962ecd963d91c"
+                "sha256:0004796c420bd9e68aad8e65627d85a8e13f293de76656165dffbcb3a0e3fb6a",
+                "sha256:e912e6591022ab9176df8348a653fe8c8fa7a301f26f9931c9d8c78a650e04e8"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.2.0"
+            "index": "pypi",
+            "version": "==4.0.4"
         },
         "semver": {
             "hashes": [

--- a/packages/api-server/api_server/fast_io/__init__.py
+++ b/packages/api-server/api_server/fast_io/__init__.py
@@ -21,7 +21,7 @@ import socketio.packet
 from fastapi import APIRouter, FastAPI
 from fastapi.exceptions import HTTPException
 from fastapi.routing import APIRoute
-from rx.core.observable.observable import Observable
+from reactivex.observable import Observable
 from starlette.routing import compile_path
 
 from api_server.logger import logger

--- a/packages/api-server/api_server/rmf_io/book_keeper.py
+++ b/packages/api-server/api_server/rmf_io/book_keeper.py
@@ -4,8 +4,8 @@ import logging
 from collections import namedtuple
 from typing import Coroutine, List, Optional
 
-from rx.core.typing import Disposable
-from rx.subject.subject import Subject
+from reactivex.disposable import Disposable
+from reactivex.subject.subject import Subject
 
 from api_server.models import (
     BuildingMap,

--- a/packages/api-server/api_server/rmf_io/book_keeper.py
+++ b/packages/api-server/api_server/rmf_io/book_keeper.py
@@ -4,7 +4,7 @@ import logging
 from collections import namedtuple
 from typing import Coroutine, List, Optional
 
-from reactivex.disposable import Disposable
+from reactivex.abc import DisposableBase as Disposable
 from reactivex.subject.subject import Subject
 
 from api_server.models import (

--- a/packages/api-server/api_server/rmf_io/events.py
+++ b/packages/api-server/api_server/rmf_io/events.py
@@ -1,5 +1,5 @@
-from rx.subject.behaviorsubject import BehaviorSubject
-from rx.subject.subject import Subject
+from reactivex.subject.behaviorsubject import BehaviorSubject
+from reactivex.subject.subject import Subject
 
 
 class RmfEvents:

--- a/packages/api-server/api_server/rmf_io/events.py
+++ b/packages/api-server/api_server/rmf_io/events.py
@@ -1,4 +1,3 @@
-from reactivex.subject.behaviorsubject import BehaviorSubject
 from reactivex.subject.subject import Subject
 
 
@@ -15,7 +14,7 @@ class RmfEvents:
         self.ingestor_health = Subject()  # IngestorHealth
         self.fleet_states = Subject()  # FleetState
         self.robot_health = Subject()  # RobotHealth
-        self.building_map = BehaviorSubject(None)  # Optional[BuildingMap]
+        self.building_map = Subject()  # BuildingMap
 
 
 rmf_events = RmfEvents()

--- a/packages/api-server/api_server/rmf_io/health_watchdog.py
+++ b/packages/api-server/api_server/rmf_io/health_watchdog.py
@@ -1,16 +1,16 @@
 import logging
 from typing import Any, Dict, List, Optional, cast
 
+from reactivex import compose
+from reactivex import operators as ops
+from reactivex.disposable import Disposable
+from reactivex.observable import Observable
+from reactivex.scheduler.scheduler import Scheduler
+from reactivex.subject.behaviorsubject import BehaviorSubject
 from rmf_dispenser_msgs.msg import DispenserState as RmfDispenserState
 from rmf_door_msgs.msg import DoorMode as RmfDoorMode
 from rmf_ingestor_msgs.msg import IngestorState as RmfIngestorState
 from rmf_lift_msgs.msg import LiftState as RmfLiftState
-from rx import operators as ops
-from rx.core.observable.observable import Observable
-from rx.core.pipe import pipe
-from rx.core.typing import Disposable
-from rx.scheduler.scheduler import Scheduler
-from rx.subject.behaviorsubject import BehaviorSubject
 
 from api_server.models import (
     BuildingMap,
@@ -63,7 +63,7 @@ class HealthWatchdog:
 
         :param obs: Sequence[rx.Observable[BasicHealthModel]]
         """
-        return pipe(
+        return compose(
             ops.timestamp(),
             ops.combine_latest(*[x.pipe(ops.timestamp()) for x in obs]),
             most_critical(),

--- a/packages/api-server/api_server/rmf_io/operators/grouped_sample.py
+++ b/packages/api-server/api_server/rmf_io/operators/grouped_sample.py
@@ -1,9 +1,9 @@
 from datetime import timedelta
 from typing import Any, Callable, TypeVar, Union, cast
 
-from rx import operators as ops
-from rx.core.observable.observable import Observable
-from rx.core.pipe import pipe
+from reactivex import compose
+from reactivex import operators as ops
+from reactivex.observable import Observable
 
 T = TypeVar("T")
 
@@ -17,7 +17,7 @@ def grouped_sample(
     "key_mapper" function, maps the resulting observable sequences with the "sample" operator
     and flatten it into a single observable sequence.
     """
-    return pipe(
+    return compose(
         ops.group_by(cast(Any, key_mapper)),
         ops.flat_map(
             cast(Any, lambda x: (cast(Observable, x).pipe(ops.sample(sampler))))

--- a/packages/api-server/api_server/rmf_io/operators/health.py
+++ b/packages/api-server/api_server/rmf_io/operators/health.py
@@ -1,8 +1,8 @@
 from typing import Any, Sequence, cast
 
-from rx import operators as ops
-from rx.core.operators.timestamp import Timestamp
-from rx.core.pipe import pipe
+from reactivex import compose
+from reactivex import operators as ops
+from reactivex.operators._timestamp import Timestamp
 
 from api_server.models import HealthStatus
 
@@ -45,4 +45,4 @@ def most_critical():
                     most_crit = health
         return most_crit.value
 
-    return pipe(ops.map(cast(Any, get_most_critical)))
+    return compose(ops.map(cast(Any, get_most_critical)))

--- a/packages/api-server/api_server/rmf_io/operators/heartbeat.py
+++ b/packages/api-server/api_server/rmf_io/operators/heartbeat.py
@@ -1,9 +1,9 @@
 from typing import Any, Callable, cast
 
-from rx.core.observable.observable import Observable
-from rx.core.pipe import pipe
-from rx.operators import buffer_with_time_or_count, distinct_until_changed
-from rx.operators import map as rx_map
+from reactivex import compose
+from reactivex.observable import Observable
+from reactivex.operators import buffer_with_time_or_count, distinct_until_changed
+from reactivex.operators import map as rx_map
 
 
 def heartbeat(liveliness) -> Callable[[Observable], Observable]:
@@ -15,7 +15,7 @@ def heartbeat(liveliness) -> Callable[[Observable], Observable]:
         considered alive. Note that an observable may stay alive for up to 2x liveliness between
         each event as this operator checks for items emitted between this window.
     """
-    return pipe(
+    return compose(
         buffer_with_time_or_count(liveliness, 1),
         rx_map(cast(Any, lambda items: len(items) > 0)),
         distinct_until_changed(),

--- a/packages/api-server/api_server/rmf_io/operators/test_grouped_sample.py
+++ b/packages/api-server/api_server/rmf_io/operators/test_grouped_sample.py
@@ -1,7 +1,7 @@
 import unittest
 
-from rx.scheduler.historicalscheduler import HistoricalScheduler
-from rx.subject.subject import Subject
+from reactivex.scheduler.historicalscheduler import HistoricalScheduler
+from reactivex.subject.subject import Subject
 
 from .grouped_sample import grouped_sample
 

--- a/packages/api-server/api_server/rmf_io/operators/test_health.py
+++ b/packages/api-server/api_server/rmf_io/operators/test_health.py
@@ -2,9 +2,9 @@ import unittest
 from datetime import datetime
 from typing import Optional, cast
 
-import rx
-from rx import operators as ops
-from rx.scheduler.historicalscheduler import HistoricalScheduler
+import reactivex as rx
+from reactivex import operators as ops
+from reactivex.scheduler.historicalscheduler import HistoricalScheduler
 
 from api_server.models import BaseBasicHealth, HealthStatus
 

--- a/packages/api-server/api_server/routes/building_map.py
+++ b/packages/api-server/api_server/routes/building_map.py
@@ -1,5 +1,5 @@
 from fastapi import Depends, HTTPException
-from rx import operators as rxops
+from reactivex import operators as rxops
 
 from api_server.fast_io import FastIORouter, SubscriptionRequest
 from api_server.models import BuildingMap

--- a/packages/api-server/api_server/routes/dispensers.py
+++ b/packages/api-server/api_server/routes/dispensers.py
@@ -1,7 +1,7 @@
 from typing import List, cast
 
 from fastapi import Depends, HTTPException
-from rx import operators as rxops
+from reactivex import operators as rxops
 
 from api_server.dependencies import sio_user
 from api_server.fast_io import FastIORouter, SubscriptionRequest

--- a/packages/api-server/api_server/routes/doors.py
+++ b/packages/api-server/api_server/routes/doors.py
@@ -1,7 +1,7 @@
 from typing import List, cast
 
 from fastapi import Depends, HTTPException
-from rx import operators as rxops
+from reactivex import operators as rxops
 
 from api_server.dependencies import sio_user
 from api_server.fast_io import FastIORouter, SubscriptionRequest

--- a/packages/api-server/api_server/routes/fleets.py
+++ b/packages/api-server/api_server/routes/fleets.py
@@ -1,7 +1,7 @@
 from typing import List, Tuple, cast
 
 from fastapi import Depends, HTTPException
-from rx import operators as rxops
+from reactivex import operators as rxops
 
 from api_server.dependencies import between_query, sio_user
 from api_server.fast_io import FastIORouter, SubscriptionRequest

--- a/packages/api-server/api_server/routes/ingestors.py
+++ b/packages/api-server/api_server/routes/ingestors.py
@@ -1,7 +1,7 @@
 from typing import List, cast
 
 from fastapi import Depends, HTTPException
-from rx import operators as rxops
+from reactivex import operators as rxops
 
 from api_server.dependencies import sio_user
 from api_server.fast_io import FastIORouter, SubscriptionRequest

--- a/packages/api-server/api_server/routes/lifts.py
+++ b/packages/api-server/api_server/routes/lifts.py
@@ -1,7 +1,7 @@
 from typing import List, cast
 
 from fastapi import Depends, HTTPException
-from rx import operators as rxops
+from reactivex import operators as rxops
 
 from api_server.dependencies import sio_user
 from api_server.fast_io import FastIORouter, SubscriptionRequest

--- a/packages/api-server/api_server/routes/tasks/tasks.py
+++ b/packages/api-server/api_server/routes/tasks/tasks.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import List, Optional, Tuple, cast
 
 from fastapi import Body, Depends, HTTPException, Path, Query
-from rx import operators as rxops
+from reactivex import operators as rxops
 
 from api_server import models as mdl
 from api_server.dependencies import between_query, pagination_query, sio_user

--- a/packages/api-server/setup.py
+++ b/packages/api-server/setup.py
@@ -22,7 +22,7 @@ setup(
         "aiofiles~=0.8.0",
         "uvicorn[standard]~=0.18.2",
         "python-socketio~=5.7",
-        "rx~=3.2",
+        "reactivex~=4.0.4",
         "tortoise-orm~=0.18.1",
         "pyjwt[crypto]~=2.4",
         "pydantic~=1.9",


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

Bumps `rx` to `reactivex`, 4.0.4, made changes based on https://rxpy.readthedocs.io/en/latest/migration.html.

This is required by https://github.com/open-rmf/rmf-web/pull/647.

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test
