### PR TITLE
Allow different zoom settings, when events happen

### DIFF
--- a/packages/dashboard/src/components/map-app.tsx
+++ b/packages/dashboard/src/components/map-app.tsx
@@ -237,6 +237,7 @@ export const MapApp = styled(
     const [imageUrl, setImageUrl] = React.useState<string | null>(null);
     const [bounds, setBounds] = React.useState<L.LatLngBoundsLiteral | null>(null);
     const [center, setCenter] = React.useState<L.LatLngTuple>([0, 0]);
+    const [zoom, setZoom] = React.useState<number>(5);
     React.useEffect(() => {
       if (!currentLevel?.images[0]) {
         setImageUrl(null);
@@ -365,6 +366,7 @@ export const MapApp = styled(
           }
           return newCenter;
         });
+        setZoom(6);
       });
       return () => sub.unsubscribe();
     }, [robotLocations, bounds]);
@@ -388,7 +390,7 @@ export const MapApp = styled(
         zoomDelta={0.5}
         zoomSnap={0.5}
         center={center}
-        zoom={6}
+        zoom={zoom}
         bounds={bounds}
         maxBounds={bounds}
         onbaselayerchange={({ name }: L.LayersControlEvent) => {


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

## What's new

* sets zoom level as a state
* changes default zoom level to 5
* when a robot is selected the default zoom level is 6

This allows us to set different preferred zoom settings for different map sizes/deployments.