### PR TITLE
Resolving permissions issue when cleaning up github runner workspace

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,9 @@ jobs:
     name: Push Docker images to GitHub Packages
     runs-on: self-hosted
     steps:
+      - name: Chown user
+        run: |
+          sudo chown -R $USER:$USER $GITHUB_WORKSPACE
       - uses: actions/checkout@v2
       - name: Push e2e image to GitHub Packages
         uses: docker/build-push-action@v1


### PR DESCRIPTION
## What's new

Fix nightly failure due to denied permissions during cleanup of workspace, similar to https://github.com/actions/checkout/issues/211.

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test