### PR TITLE
fix wrong version of `datamodel-codegen` being used

### DIFF
--- a/packages/api-server/generate-models.sh
+++ b/packages/api-server/generate-models.sh
@@ -6,12 +6,14 @@ RMF_BUILDING_MAP_MSGS_VER=c5e0352e2dfd3d11e4d292a1c2901cad867c1441
 RMF_INTERNAL_MSGS_VER=0c237e1758872917661879975d7dc0acf5fa518c
 RMF_API_MSGS_VER=91295892192d24ec73c9a1c6fa54334963586784
 RMF_ROS2_VER=bf038461b5b0fb7d4594461a724bc9e5e7cb97c6
-CODEGEN_VER=$(datamodel-codegen --version)
+CODEGEN_VER=$(pipenv run datamodel-codegen --version)
 
 cd "$(dirname $0)"
-source ../../scripts/rmf-helpers.sh
 
-check_rmf_not_sourced
+if [[ $ROS_DISTRO != 'humble' ]]; then
+  echo 'Unable to find ros humble, please make sure that it is sourced.'
+  exit 1
+fi
 
 function fetch_sources {
   url=$1
@@ -70,7 +72,7 @@ generate_from_json_schema() {
 
   rm -rf "$output"
   mkdir -p "$output"
-  bash -c "datamodel-codegen --disable-timestamp --input-file-type jsonschema --enum-field-as-literal one --input "$input" --output \"$output\""
+  pipenv run datamodel-codegen --disable-timestamp --input-file-type jsonschema --enum-field-as-literal one --input "$input" --output "$output"
   cat << EOF > "$output/version.py"
 # THIS FILE IS GENERATED
 version = {

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -12,7 +12,7 @@
     "test:cov": "../../scripts/pipenv run python -m coverage run scripts/test.py",
     "test:report": "../../scripts/pipenv run python -m coverage html && xdg-open htmlcov/index.html",
     "lint": "../../scripts/pipenv run pyright && ../../scripts/pipenv run pylint api_server --ignore=ros_pydantic,rmf_api",
-    "generate-models": "../../scripts/pipenv run generate-models.sh"
+    "generate-models": "./generate-models.sh"
   },
   "devDependencies": {
     "pipenv-install": "workspace:*"


### PR DESCRIPTION
## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

fix wrong version of `datamodel-codegen` being used. Also removed the check that rmf is not sourced, the check is added due to colcon's "include pollution bug/feature" which is now largely mitigated as rmf is using "isolated" include dir (e.g. `/opt/ros/humble/include/rmf_door_msgs/rmf_door_msgs`).

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
