### PR TITLE
Fix/request date export

### DIFF
--- a/packages/api-server/api_server/repositories/tasks.py
+++ b/packages/api-server/api_server/repositories/tasks.py
@@ -28,15 +28,12 @@ class TaskRepository:
         self.user = user
 
     async def save_task_state(self, task_state: TaskState) -> None:
-        task_exists = await DbTaskState.exists(id_=task_state.booking.id)
-
-        if task_exists:
-            previous_task_state = await DbTaskState.get(id_=task_state.booking.id)
+        db_task_state = await DbTaskState.get_or_none(id_=task_state.booking.id)
+        if db_task_state is not None:
             task_state.booking.unix_millis_request_time = (
-                int(round(previous_task_state.unix_millis_request_time.timestamp()))
-                * 1000
+                int(round(db_task_state.unix_millis_request_time.timestamp())) * 1000
             )
-            await ttm.TaskState.update_or_create(
+            db_task_state.update_from_dict(
                 {
                     "data": task_state.json(),
                     "category": task_state.category.__root__
@@ -54,32 +51,24 @@ class TaskRepository:
                         task_state.unix_millis_finish_time / 1000
                     ),
                     "status": task_state.status if task_state.status else None,
-                },
-                id_=task_state.booking.id,
+                }
             )
+            await db_task_state.save()
         else:
             task_state.booking.unix_millis_request_time = round(time.time() * 1000)
-            await ttm.TaskState.update_or_create(
-                {
-                    "data": task_state.json(),
-                    "category": task_state.category.__root__
-                    if task_state.category
-                    else None,
-                    "assigned_to": task_state.assigned_to.name
-                    if task_state.assigned_to
-                    else None,
-                    "unix_millis_start_time": task_state.unix_millis_start_time
-                    and datetime.fromtimestamp(
-                        task_state.unix_millis_start_time / 1000
-                    ),
-                    "unix_millis_finish_time": task_state.unix_millis_finish_time
-                    and datetime.fromtimestamp(
-                        task_state.unix_millis_finish_time / 1000
-                    ),
-                    "status": task_state.status if task_state.status else None,
-                    "unix_millis_request_time": datetime.now(),
-                },
+            await ttm.TaskState.create(
                 id_=task_state.booking.id,
+                data=task_state.json(),
+                category=task_state.category.__root__ if task_state.category else None,
+                assigned_to=task_state.assigned_to.name
+                if task_state.assigned_to
+                else None,
+                unix_millis_start_time=task_state.unix_millis_start_time
+                and datetime.fromtimestamp(task_state.unix_millis_start_time / 1000),
+                unix_millis_finish_time=task_state.unix_millis_finish_time
+                and datetime.fromtimestamp(task_state.unix_millis_finish_time / 1000),
+                status=task_state.status if task_state.status else None,
+                unix_millis_request_time=datetime.now(),
             )
 
     async def query_task_states(

--- a/packages/dashboard/src/components/tasks/utils.ts
+++ b/packages/dashboard/src/components/tasks/utils.ts
@@ -48,10 +48,13 @@ export function downloadCsvFull(timestamp: Date, allTasks: TaskState[]) {
 export function downloadCsvMinimal(timestamp: Date, allTasks: TaskState[]) {
   const columnSeparator = ';';
   const rowSeparator = '\n';
-  const keys = ['ID', 'Category', 'Assignee', 'Start Time', 'End Time', 'State'];
+  const keys = ['Date', 'ID', 'Category', 'Assignee', 'Start Time', 'End Time', 'State'];
   let csvContent = keys.join(columnSeparator) + rowSeparator;
   allTasks.forEach((task) => {
     const values = [
+      task.booking.unix_millis_request_time
+        ? `${new Date(task.booking.unix_millis_request_time).toLocaleDateString()}`
+        : 'unknown',
       task.booking.id,
       task.category ? task.category : 'unknown',
       task.assigned_to ? task.assigned_to.name : 'unknown',


### PR DESCRIPTION
## What's new

Related to https://github.com/open-rmf/rmf-web/pull/689

* Adds Date column to minimal export
* Refactored task repository `save_task_state`
  * creating a new task state model explicitly setting request time, if it is a new task
  * updating all other fields when task already exists, leaving out request time and ID

To check exports, go to download button and select minimal export

To check if the request time stays the same, add these lines after [here, outside of the else scope](https://github.com/open-rmf/rmf-web/pull/690/files#diff-6e62b347b0bbff536cbf2a85cf360c53355a713c6f5bf02ef4aa1519b56db94bR72)

```python
        # debug
        debug_task_state = await DbTaskState.get_or_none(id_=task_state.booking.id)
        if debug_task_state is None:
            print('oh no something went wrong')
        else:
            print('request_time: {}'.format(debug_task_state.unix_millis_request_time))
```

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test