### PR TITLE
Rollback setuptools to 65.6.3 to avoid PEP440 issues with >=66.0.0

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -974,11 +974,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:a78d01d1e2c175c474884671dde039962c9d74c7223db7369771fcf6e29ceeab",
-                "sha256:bd6eb2d6722568de6d14b87c44a96fac54b2a45ff5e940e639979a3d1792adb6"
+                "sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54",
+                "sha256:a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==66.0.0"
+            "version": "==65.6.3"
         },
         "six": {
             "hashes": [


### PR DESCRIPTION
## What's new

First step of https://github.com/open-rmf/rmf-web/issues/695

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [x] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [x] I tested the behavior of the components that interact with the backend, with an e2e test
