### PR TITLE
Retry on dashboard e2e workflows

### DIFF
--- a/.github/workflows/dashboard-e2e.yml
+++ b/.github/workflows/dashboard-e2e.yml
@@ -39,8 +39,8 @@ jobs:
       - name: test
         uses: nick-fields/retry@v2
         with:
+          timeout_minutes: 20
           max_attempts: 3
-          retry_on: error
           command: |
             . /rmf_demos_ws/install/setup.bash
             pnpm test

--- a/.github/workflows/dashboard-e2e.yml
+++ b/.github/workflows/dashboard-e2e.yml
@@ -43,7 +43,9 @@ jobs:
           max_attempts: 3
           command: |
             . /rmf_demos_ws/install/setup.bash
+            cd packages/dashboard-e2e
             pnpm test
+          shell: bash
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/dashboard-e2e.yml
+++ b/.github/workflows/dashboard-e2e.yml
@@ -37,9 +37,13 @@ jobs:
           package: rmf-dashboard-e2e
           skip-build: true
       - name: test
-        run: |
-          . /rmf_demos_ws/install/setup.bash
-          pnpm test
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: |
+            . /rmf_demos_ws/install/setup.bash
+            pnpm test
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,9 +45,13 @@ jobs:
           package: rmf-dashboard-e2e
           skip-build: true
       - name: test
-        run: |
-          . /rmf_demos_ws/install/setup.bash
-          pnpm test
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: |
+            . /rmf_demos_ws/install/setup.bash
+            pnpm test
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,8 +47,8 @@ jobs:
       - name: test
         uses: nick-fields/retry@v2
         with:
+          timeout_minutes: 20
           max_attempts: 3
-          retry_on: error
           command: |
             . /rmf_demos_ws/install/setup.bash
             pnpm test

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,7 +51,9 @@ jobs:
           max_attempts: 3
           command: |
             . /rmf_demos_ws/install/setup.bash
+            cd packages/dashboard-e2e
             pnpm test
+          shell: bash
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         if: always()


### PR DESCRIPTION
## What's new

Using `nick-fields/retry@v2` for flaky `dashboard-e2e` workflow tests.

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

The proper fix should be resolving what is making the e2e tests flaky, keeping this as a draft for consideration while we continue down our roadmap.
