### PR TITLE
Show up robot summary when user click robot row

### DIFF
--- a/packages/dashboard/src/components/robots/robot-summary.tsx
+++ b/packages/dashboard/src/components/robots/robot-summary.tsx
@@ -230,7 +230,8 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
       maxWidth="sm"
     >
       <Grid container mb={1} alignItems="center" spacing={1}>
-        <Grid item xs={10}>
+        <Grid item xs={2}></Grid>
+        <Grid item xs={8}>
           <DialogTitle align="center">Robot Summary: {robotState?.name}</DialogTitle>
         </Grid>
         <Grid item xs={2}>

--- a/packages/dashboard/src/components/robots/robot-summary.tsx
+++ b/packages/dashboard/src/components/robots/robot-summary.tsx
@@ -172,11 +172,11 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
   const returnDialogContent = () => {
     const contents = [
       {
-        title: 'Assigned Tasks',
+        title: 'Assigned tasks',
         value: taskState ? taskState.booking.id : 'No task',
       },
       {
-        title: 'Est. End Time',
+        title: 'Est. end time',
         value: taskState?.unix_millis_finish_time
           ? `${new Date(taskState?.unix_millis_finish_time).toLocaleString()}`
           : '-',
@@ -237,7 +237,7 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
       <Grid container mb={1} alignItems="center" spacing={1}>
         <Grid item xs={2}></Grid>
         <Grid item xs={8}>
-          <DialogTitle align="center">Robot Summary: {robotState?.name}</DialogTitle>
+          <DialogTitle align="center">Robot summary: {robotState?.name}</DialogTitle>
         </Grid>
         <Grid item xs={2}>
           <Grid container justifyContent="flex-end">
@@ -253,10 +253,10 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
       <Divider />
       {taskProgress && (
         <>
-          <Typography variant="h6" fontWeight="bold" align="center">
-            Task Progress
+          <Typography variant="body2" fontWeight="bold" ml={3} mt={1}>
+            Task progress
           </Typography>
-          <Box sx={{ width: '90%', ml: 3 }}>
+          <Box sx={{ width: '95%', ml: 3 }}>
             <LinearProgressWithLabel value={taskProgress * 100} />
           </Box>
         </>

--- a/packages/dashboard/src/components/robots/robot-summary.tsx
+++ b/packages/dashboard/src/components/robots/robot-summary.tsx
@@ -20,10 +20,18 @@ import { RobotTableData, base } from 'react-components';
 import { RobotState, Status2, TaskState } from 'api-client';
 import { EMPTY, combineLatest, mergeMap, of } from 'rxjs';
 import { TaskInspector } from '../tasks/task-inspector';
-import BatteryFullIcon from '@mui/icons-material/BatteryFull';
-import Battery60Icon from '@mui/icons-material/Battery60';
-import Battery20Icon from '@mui/icons-material/Battery20';
-import BatteryChargingFullIcon from '@mui/icons-material/BatteryChargingFull';
+import {
+  Battery0Bar,
+  Battery1Bar,
+  Battery2Bar,
+  Battery3Bar,
+  Battery4Bar,
+  Battery5Bar,
+  Battery6Bar,
+  BatteryFull,
+  BatteryChargingFull,
+  BatteryUnknown,
+} from '@mui/icons-material';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -75,24 +83,28 @@ interface RobotSummaryProps {
 
 const showBatteryIcon = (robot: RobotState, robotBattery: number) => {
   if (robot.status === Status2.Charging) {
-    return <BatteryChargingFullIcon />;
+    return <BatteryChargingFull />;
   }
 
-  const batteryIcons: Record<string, JSX.Element> = {
-    '0': <Battery20Icon />,
-    '40': <Battery20Icon />,
-    '80': <Battery60Icon />,
-    '100': <BatteryFullIcon />,
+  const batteryIcons: Record<number, JSX.Element> = {
+    0: <Battery0Bar />,
+    16: <Battery1Bar />,
+    32: <Battery2Bar />,
+    48: <Battery3Bar />,
+    64: <Battery4Bar />,
+    80: <Battery5Bar />,
+    96: <Battery6Bar />,
+    100: <BatteryFull />,
   };
 
-  for (let i = 0; i < Object.keys(batteryIcons).length; i++) {
-    const level = Object.keys(batteryIcons)[i];
-    if (robotBattery <= parseInt(level)) {
+  for (const level in batteryIcons) {
+    if (robotBattery >= parseInt(level)) {
+      continue;
+    } else {
       return batteryIcons[level];
     }
   }
-
-  return null;
+  return <BatteryUnknown />;
 };
 
 export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) => {

--- a/packages/dashboard/src/components/robots/robot-summary.tsx
+++ b/packages/dashboard/src/components/robots/robot-summary.tsx
@@ -1,0 +1,199 @@
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  LinearProgress,
+  LinearProgressProps,
+  TextField,
+  Theme,
+  Typography,
+} from '@mui/material';
+import { makeStyles, createStyles } from '@mui/styles';
+import React from 'react';
+import { RmfAppContext } from '../rmf-app';
+import { RobotTableData, base } from 'react-components';
+import { RobotState, Status2, TaskState } from 'api-client';
+import { EMPTY, combineLatest, mergeMap, of } from 'rxjs';
+import { TaskInspector } from '../tasks/task-inspector';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    textField: {
+      background: theme.palette.background.default,
+      '&:hover': {
+        backgroundColor: theme.palette.background.default,
+      },
+    },
+  }),
+);
+
+const setTaskDialogColor = (robotStatus: Status2 | undefined) => {
+  if (!robotStatus) {
+    return base.palette.background.default;
+  }
+
+  switch (robotStatus) {
+    case Status2.Error:
+      return base.palette.error.dark;
+
+    case Status2.Working:
+      return base.palette.success.dark;
+
+    default:
+      return base.palette.warning.main;
+  }
+};
+
+const LinearProgressWithLabel = (props: LinearProgressProps & { value: number }) => {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center' }}>
+      <Box sx={{ width: '100%', mr: 1 }}>
+        <LinearProgress variant="determinate" {...props} />
+      </Box>
+      <Box sx={{ minWidth: 35 }}>
+        <Typography variant="body2" color="text.secondary">{`${Math.round(
+          props.value,
+        )}%`}</Typography>
+      </Box>
+    </Box>
+  );
+};
+
+interface RobotSummaryProps {
+  onClose: () => void;
+  robot: RobotTableData;
+}
+export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) => {
+  const classes = useStyles();
+  const rmf = React.useContext(RmfAppContext);
+
+  const [isOpen, setIsOpen] = React.useState(true);
+  const [robotState, setRobotState] = React.useState<RobotState | null>(null);
+  const [taskState, setTaskState] = React.useState<TaskState | null>(null);
+  const [openTaskDetailsLogs, setOpenTaskDetailsLogs] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!rmf) {
+      return;
+    }
+    const sub = rmf
+      .getFleetStateObs(robot.fleet)
+      .pipe(
+        mergeMap((fleetState) => {
+          const robotState = fleetState?.robots?.[robot.name];
+          const taskObs = robotState?.task_id ? rmf.getTaskStateObs(robotState.task_id) : of(null);
+          return robotState ? combineLatest([of(robotState), taskObs]) : EMPTY;
+        }),
+      )
+      .subscribe(([robotState, taskState]) => {
+        setRobotState(robotState);
+        setTaskState(taskState);
+      });
+    return () => sub.unsubscribe();
+  }, [rmf, robot.fleet, robot.name]);
+
+  const taskProgress = React.useMemo(() => {
+    if (
+      !taskState ||
+      !taskState.estimate_millis ||
+      !taskState.unix_millis_start_time ||
+      !taskState.unix_millis_finish_time
+    ) {
+      console.log(`Can't calculate task progress`);
+      return undefined;
+    }
+
+    return Math.min(
+      1.0 -
+        taskState.estimate_millis /
+          (taskState.unix_millis_finish_time - taskState.unix_millis_start_time),
+      1,
+    );
+  }, [taskState]);
+
+  const returnDialogContent = () => {
+    const contents = [
+      {
+        title: 'Assigned Tasks',
+        value: taskState ? taskState.booking.id : 'No task',
+      },
+      {
+        title: 'Location',
+        value: robotState ? robotState.location?.map : '',
+      },
+      {
+        title: 'Est. End Time',
+        value: taskState?.unix_millis_finish_time
+          ? `${new Date(taskState?.unix_millis_finish_time).toLocaleString()}`
+          : '-',
+      },
+    ];
+
+    return (
+      <>
+        {contents.map((message, index) => (
+          <div key={index}>
+            <TextField
+              label={message.title}
+              id="standard-size-small"
+              size="small"
+              variant="filled"
+              InputProps={{ readOnly: true, className: classes.textField }}
+              fullWidth={true}
+              multiline
+              maxRows={4}
+              margin="dense"
+              value={message.value}
+            />
+          </div>
+        ))}
+      </>
+    );
+  };
+
+  return (
+    <Dialog
+      PaperProps={{
+        style: {
+          backgroundColor: setTaskDialogColor(robotState?.status),
+          boxShadow: 'none',
+        },
+      }}
+      open={isOpen}
+      onClose={() => {
+        setIsOpen(false);
+        onClose();
+      }}
+      fullWidth
+      maxWidth="sm"
+    >
+      <DialogTitle align="center">{robotState?.name}</DialogTitle>
+      <Divider />
+      <DialogTitle align="center">Robot State</DialogTitle>
+      {taskProgress && (
+        <Box sx={{ width: '90%', ml: 3 }}>
+          <LinearProgressWithLabel value={taskProgress * 100} />
+        </Box>
+      )}
+      <DialogContent>{returnDialogContent()}</DialogContent>
+      <DialogActions sx={{ justifyContent: 'center' }}>
+        <Button
+          size="small"
+          variant="contained"
+          onClick={() => setOpenTaskDetailsLogs(true)}
+          autoFocus
+          disabled={taskState === null}
+        >
+          Inspect Task
+        </Button>
+      </DialogActions>
+      {openTaskDetailsLogs && taskState && (
+        <TaskInspector task={taskState} onClose={() => setOpenTaskDetailsLogs(false)} />
+      )}
+    </Dialog>
+  );
+});

--- a/packages/dashboard/src/components/robots/robot-summary.tsx
+++ b/packages/dashboard/src/components/robots/robot-summary.tsx
@@ -6,6 +6,7 @@ import {
   DialogContent,
   DialogTitle,
   Divider,
+  Grid,
   LinearProgress,
   LinearProgressProps,
   TextField,
@@ -19,6 +20,7 @@ import { RobotTableData, base } from 'react-components';
 import { RobotState, Status2, TaskState } from 'api-client';
 import { EMPTY, combineLatest, mergeMap, of } from 'rxjs';
 import { TaskInspector } from '../tasks/task-inspector';
+import Battery80Icon from '@mui/icons-material/Battery80';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -172,17 +174,29 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
       fullWidth
       maxWidth="sm"
     >
-      <DialogTitle align="center">{robotState?.name}</DialogTitle>
-
-      <Typography variant="h6" align="center">{`${
-        robotState?.battery ? (robotState?.battery * 100).toFixed(2) : 0
-      }%`}</Typography>
+      <Grid container mb={1} alignItems="center" spacing={1}>
+        <Grid item xs={10}>
+          <DialogTitle align="center">Robot Summary: {robotState?.name}</DialogTitle>
+        </Grid>
+        <Grid item xs={2}>
+          <Grid container justifyContent="flex-end">
+            <Typography variant="subtitle1">{`${
+              robotState?.battery ? robotState?.battery * 100 : 0
+            }%`}</Typography>
+            <Battery80Icon />
+          </Grid>
+        </Grid>
+      </Grid>
       <Divider />
-      <DialogTitle align="center">Robot State</DialogTitle>
       {taskProgress && (
-        <Box sx={{ width: '90%', ml: 3 }}>
-          <LinearProgressWithLabel value={taskProgress * 100} />
-        </Box>
+        <>
+          <Typography variant="h6" fontWeight="bold" align="center">
+            Task Progress
+          </Typography>
+          <Box sx={{ width: '90%', ml: 3 }}>
+            <LinearProgressWithLabel value={taskProgress * 100} />
+          </Box>
+        </>
       )}
       <DialogContent>{returnDialogContent()}</DialogContent>
       <DialogActions sx={{ justifyContent: 'center' }}>

--- a/packages/dashboard/src/components/robots/robot-summary.tsx
+++ b/packages/dashboard/src/components/robots/robot-summary.tsx
@@ -181,11 +181,11 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
     if (taskState) {
       contents.push(
         {
-          title: 'Location',
+          title: 'Navigation start',
           value: location,
         },
         {
-          title: 'Destination',
+          title: 'Navigation destination',
           value: destination,
         },
       );

--- a/packages/dashboard/src/components/robots/robot-summary.tsx
+++ b/packages/dashboard/src/components/robots/robot-summary.tsx
@@ -98,8 +98,8 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
   const [robotState, setRobotState] = React.useState<RobotState | null>(null);
   const [taskState, setTaskState] = React.useState<TaskState | null>(null);
   const [openTaskDetailsLogs, setOpenTaskDetailsLogs] = React.useState(false);
-  const [location, setLocation] = React.useState('');
-  const [destination, setDestination] = React.useState('');
+  const [navigationStart, setNavigationStart] = React.useState('-');
+  const [navigationDestination, setNavigationDestination] = React.useState('-');
 
   React.useEffect(() => {
     if (!rmf) {
@@ -142,8 +142,8 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
 
   React.useEffect(() => {
     if (!taskState || !taskState.phases || !taskState.active) {
-      setLocation('Failed to retrieve current location');
-      setDestination('Failed to retrieve robot destination');
+      setNavigationStart('-');
+      setNavigationDestination('-');
       return;
     }
 
@@ -159,8 +159,13 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
       while ((match = regex.exec(message.toString()))) {
         waypoints.push(match[1]);
       }
-      setLocation(waypoints[0]);
-      setDestination(waypoints[1]);
+
+      setNavigationStart(waypoints[0]);
+      setNavigationDestination(waypoints[1]);
+    } else {
+      setNavigationStart('-');
+      setNavigationDestination('-');
+      console.log('Failed to retrieve robot navigation');
     }
   }, [taskState]);
 
@@ -182,11 +187,11 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
       contents.push(
         {
           title: 'Navigation start',
-          value: location,
+          value: navigationStart,
         },
         {
           title: 'Navigation destination',
-          value: destination,
+          value: navigationDestination,
         },
       );
     }

--- a/packages/dashboard/src/components/robots/robot-summary.tsx
+++ b/packages/dashboard/src/components/robots/robot-summary.tsx
@@ -85,7 +85,7 @@ const showBatteryIcon = (robot: RobotState, robotBattery: number) => {
     '0': <Battery20Icon />,
   };
 
-  const key = Object.keys(batteryIcons).find((level) => 40 <= parseInt(level));
+  const key = Object.keys(batteryIcons).find((level) => robotBattery <= parseInt(level));
 
   return key ? batteryIcons[key] : null;
 };

--- a/packages/dashboard/src/components/robots/robot-summary.tsx
+++ b/packages/dashboard/src/components/robots/robot-summary.tsx
@@ -20,7 +20,10 @@ import { RobotTableData, base } from 'react-components';
 import { RobotState, Status2, TaskState } from 'api-client';
 import { EMPTY, combineLatest, mergeMap, of } from 'rxjs';
 import { TaskInspector } from '../tasks/task-inspector';
-import Battery80Icon from '@mui/icons-material/Battery80';
+import BatteryFullIcon from '@mui/icons-material/BatteryFull';
+import Battery60Icon from '@mui/icons-material/Battery60';
+import Battery20Icon from '@mui/icons-material/Battery20';
+import BatteryChargingFullIcon from '@mui/icons-material/BatteryChargingFull';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -69,6 +72,23 @@ interface RobotSummaryProps {
   onClose: () => void;
   robot: RobotTableData;
 }
+
+const showBatteryIcon = (robot: RobotState, robotBattery: number) => {
+  if (robot.status === Status2.Charging) {
+    return <BatteryChargingFullIcon />;
+  }
+
+  const batteryIcons: Record<string, JSX.Element> = {
+    '100': <BatteryFullIcon />,
+    '80': <Battery60Icon />,
+    '40': <Battery20Icon />,
+    '0': <Battery20Icon />,
+  };
+
+  const key = Object.keys(batteryIcons).find((level) => 40 <= parseInt(level));
+
+  return key ? batteryIcons[key] : null;
+};
 
 export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) => {
   const classes = useStyles();
@@ -218,7 +238,9 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
             <Typography variant="subtitle1">{`${
               robotState?.battery ? robotState?.battery * 100 : 0
             }%`}</Typography>
-            <Battery80Icon />
+            {robotState && (
+              <>{showBatteryIcon(robot, robotState.battery ? robotState?.battery * 100 : 0)}</>
+            )}
           </Grid>
         </Grid>
       </Grid>

--- a/packages/dashboard/src/components/robots/robot-summary.tsx
+++ b/packages/dashboard/src/components/robots/robot-summary.tsx
@@ -67,6 +67,7 @@ interface RobotSummaryProps {
   onClose: () => void;
   robot: RobotTableData;
 }
+
 export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) => {
   const classes = useStyles();
   const rmf = React.useContext(RmfAppContext);
@@ -172,6 +173,10 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
       maxWidth="sm"
     >
       <DialogTitle align="center">{robotState?.name}</DialogTitle>
+
+      <Typography variant="h6" align="center">{`${
+        robotState?.battery ? (robotState?.battery * 100).toFixed(2) : 0
+      }%`}</Typography>
       <Divider />
       <DialogTitle align="center">Robot State</DialogTitle>
       {taskProgress && (

--- a/packages/dashboard/src/components/robots/robot-summary.tsx
+++ b/packages/dashboard/src/components/robots/robot-summary.tsx
@@ -98,8 +98,8 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
   const [robotState, setRobotState] = React.useState<RobotState | null>(null);
   const [taskState, setTaskState] = React.useState<TaskState | null>(null);
   const [openTaskDetailsLogs, setOpenTaskDetailsLogs] = React.useState(false);
-  const [navigationStart, setNavigationStart] = React.useState('-');
-  const [navigationDestination, setNavigationDestination] = React.useState('-');
+  const [navigationStart, setNavigationStart] = React.useState<string | null>(null);
+  const [navigationDestination, setNavigationDestination] = React.useState<string | null>(null);
 
   React.useEffect(() => {
     if (!rmf) {
@@ -142,8 +142,8 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
 
   React.useEffect(() => {
     if (!taskState || !taskState.phases || !taskState.active) {
-      setNavigationStart('-');
-      setNavigationDestination('-');
+      setNavigationStart(null);
+      setNavigationDestination(null);
       return;
     }
 
@@ -165,7 +165,7 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
     } else {
       setNavigationStart('-');
       setNavigationDestination('-');
-      console.log('Failed to retrieve robot navigation');
+      console.error("Failed to retrieve robot's current navigation start and destination.");
     }
   }, [taskState]);
 
@@ -187,11 +187,11 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
       contents.push(
         {
           title: 'Navigation start',
-          value: navigationStart,
+          value: navigationStart ? navigationStart : '-',
         },
         {
           title: 'Navigation destination',
-          value: navigationDestination,
+          value: navigationDestination ? navigationDestination : '-',
         },
       );
     }

--- a/packages/dashboard/src/components/robots/robot-summary.tsx
+++ b/packages/dashboard/src/components/robots/robot-summary.tsx
@@ -79,15 +79,20 @@ const showBatteryIcon = (robot: RobotState, robotBattery: number) => {
   }
 
   const batteryIcons: Record<string, JSX.Element> = {
-    '100': <BatteryFullIcon />,
-    '80': <Battery60Icon />,
-    '40': <Battery20Icon />,
     '0': <Battery20Icon />,
+    '40': <Battery20Icon />,
+    '80': <Battery60Icon />,
+    '100': <BatteryFullIcon />,
   };
 
-  const key = Object.keys(batteryIcons).find((level) => robotBattery <= parseInt(level));
+  for (let i = 0; i < Object.keys(batteryIcons).length; i++) {
+    const level = Object.keys(batteryIcons)[i];
+    if (robotBattery <= parseInt(level)) {
+      return batteryIcons[level];
+    }
+  }
 
-  return key ? batteryIcons[key] : null;
+  return null;
 };
 
 export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) => {
@@ -242,7 +247,7 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
         <Grid item xs={2}>
           <Grid container justifyContent="flex-end">
             <Typography variant="subtitle1">{`${
-              robotState?.battery ? robotState?.battery * 100 : 0
+              robotState?.battery ? (robotState.battery * 100).toFixed(0) : 0
             }%`}</Typography>
             {robotState && (
               <>{showBatteryIcon(robot, robotState.battery ? robotState?.battery * 100 : 0)}</>

--- a/packages/dashboard/src/components/robots/robots-app.tsx
+++ b/packages/dashboard/src/components/robots/robots-app.tsx
@@ -5,12 +5,15 @@ import { RobotTable, RobotTableData } from 'react-components';
 import { AppEvents } from '../app-events';
 import { createMicroApp } from '../micro-app';
 import { RmfAppContext } from '../rmf-app';
+import { RobotSummary } from './robot-summary';
 
 export const RobotsApp = createMicroApp('Robots', () => {
   const rmf = React.useContext(RmfAppContext);
 
   const [fleets, setFleets] = React.useState<string[]>([]);
   const [robots, setRobots] = React.useState<Record<string, RobotTableData[]>>({});
+  const [openRobotSummary, setOpenRobotSummary] = React.useState(false);
+  const [selectedRobot, setSelectedRobot] = React.useState<RobotTableData>();
   React.useEffect(() => {
     if (!rmf) {
       return;
@@ -88,9 +91,15 @@ export const RobotsApp = createMicroApp('Robots', () => {
       <RobotTable
         robots={Object.values(robots).flatMap((r) => r)}
         onRobotClick={(_ev, robot) => {
+          setOpenRobotSummary(true);
           AppEvents.robotSelect.next([robot.fleet, robot.name]);
+          setSelectedRobot(robot);
         }}
       />
+
+      {openRobotSummary && selectedRobot && (
+        <RobotSummary robot={selectedRobot} onClose={() => setOpenRobotSummary(false)} />
+      )}
     </TableContainer>
   );
 });

--- a/packages/dashboard/src/components/robots/robots-workspace.tsx
+++ b/packages/dashboard/src/components/robots/robots-workspace.tsx
@@ -2,13 +2,11 @@ import { WorkspaceState } from '../workspace';
 
 export const robotsWorkspace: WorkspaceState = {
   layout: [
-    { i: 'robots', x: 2, y: 0, w: 6, h: 12 },
-    { i: 'robots-info', x: 8, y: 0, w: 2, h: 6 },
-    { i: 'map', x: 8, y: 6, w: 2, h: 6 },
+    { i: 'robots', x: 0, y: 0, w: 7, h: 12 },
+    { i: 'map', x: 8, y: 0, w: 5, h: 12 },
   ],
   windows: [
     { key: 'robots', appName: 'Robots' },
-    { key: 'robots-info', appName: 'Robot Info' },
     { key: 'map', appName: 'Map' },
   ],
 };


### PR DESCRIPTION
## What's new
Popup dialog to show robot summary

- Removed micro app (Robot info) from the top right of the robot section

- Added a robot summary with the most relevant data

- Robot summary popup has a button to show  Task Inspector

- The map is shown on the right

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

[chrome-capture-2023-3-27.webm](https://user-images.githubusercontent.com/37310205/234994779-71149660-9c90-4277-8da5-fede07776b4e.webm)



<!-- Describe your changes.


  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
