### PR TITLE
Migrate robot table to datagrid

### DIFF
--- a/packages/dashboard/src/components/robots/robots-app.tsx
+++ b/packages/dashboard/src/components/robots/robots-app.tsx
@@ -1,7 +1,7 @@
 import { TableContainer } from '@mui/material';
 import { TaskState } from 'api-client';
 import React from 'react';
-import { RobotDataGridTable, RobotTableData, RobotTable } from 'react-components';
+import { RobotDataGridTable, RobotTableData } from 'react-components';
 import { AppEvents } from '../app-events';
 import { createMicroApp } from '../micro-app';
 import { RmfAppContext } from '../rmf-app';
@@ -97,15 +97,6 @@ export const RobotsApp = createMicroApp('Robots', () => {
           setSelectedRobot(robot);
         }}
       />
-      {/* <RobotTable
-        robots={Object.values(robots).flatMap((r) => r)}
-        onRobotClick={(_ev, robot) => {
-          setOpenRobotSummary(true);
-          AppEvents.robotSelect.next([robot.fleet, robot.name]);
-          setSelectedRobot(robot);
-        }}
-      /> */}
-
       {openRobotSummary && selectedRobot && (
         <RobotSummary robot={selectedRobot} onClose={() => setOpenRobotSummary(false)} />
       )}

--- a/packages/dashboard/src/components/robots/robots-app.tsx
+++ b/packages/dashboard/src/components/robots/robots-app.tsx
@@ -1,7 +1,7 @@
 import { TableContainer } from '@mui/material';
 import { TaskState } from 'api-client';
 import React from 'react';
-import { RobotTable, RobotTableData } from 'react-components';
+import { RobotTableDataList, RobotDataGridTable, RobotTableData } from 'react-components';
 import { AppEvents } from '../app-events';
 import { createMicroApp } from '../micro-app';
 import { RmfAppContext } from '../rmf-app';
@@ -14,6 +14,15 @@ export const RobotsApp = createMicroApp('Robots', () => {
   const [robots, setRobots] = React.useState<Record<string, RobotTableData[]>>({});
   const [openRobotSummary, setOpenRobotSummary] = React.useState(false);
   const [selectedRobot, setSelectedRobot] = React.useState<RobotTableData>();
+
+  const [robotTableDataList, setRobotTableDataList] = React.useState<RobotTableDataList>({
+    isLoading: true,
+    records: {},
+    total: 0,
+    page: 1,
+    pageSize: 10,
+  });
+
   React.useEffect(() => {
     if (!rmf) {
       return;
@@ -60,42 +69,85 @@ export const RobotsApp = createMicroApp('Robots', () => {
               )
             : {};
 
-        setRobots((prev) => {
+        setRobotTableDataList((prev) => {
           if (!fleet.name) {
             return prev;
           }
           return {
             ...prev,
-            [fleet.name]: fleet.robots
-              ? Object.entries(fleet.robots).map<RobotTableData>(([name, robot]) => ({
-                  fleet: fleet.name || '',
-                  name,
-                  battery: robot.battery && +robot.battery.toFixed(2),
-                  status: robot.status,
-                  estFinishTime:
-                    robot.task_id && tasks[robot.task_id]
-                      ? tasks[robot.task_id].unix_millis_finish_time
-                      : undefined,
-                  lastUpdateTime: robot.unix_millis_time ? robot.unix_millis_time : undefined,
-                }))
-              : [],
+            isLoading: false,
+            records: {
+              [fleet.name]: fleet.robots
+                ? Object.entries(fleet.robots).map<RobotTableData>(([name, robot]) => ({
+                    fleet: fleet.name || '',
+                    name,
+                    battery: robot.battery && +robot.battery.toFixed(2),
+                    status: robot.status,
+                    estFinishTime:
+                      robot.task_id && tasks[robot.task_id]
+                        ? tasks[robot.task_id].unix_millis_finish_time
+                        : undefined,
+                    lastUpdateTime: robot.unix_millis_time ? robot.unix_millis_time : undefined,
+                  }))
+                : [],
+            },
+            total:
+              Object.keys(fleet.robots ? fleet.robots : 0).length === 10
+                ? robotTableDataList.page * 10 + 1
+                : robotTableDataList.page * 10 - 9,
           };
         });
+
+        // setRobots((prev) => {
+        //   if (!fleet.name) {
+        //     return prev;
+        //   }
+        //   return {
+        //     ...prev,
+        //     [fleet.name]: fleet.robots
+        //       ? Object.entries(fleet.robots).map<RobotTableData>(([name, robot]) => ({
+        //         fleet: fleet.name || '',
+        //         name,
+        //         battery: robot.battery && +robot.battery.toFixed(2),
+        //         status: robot.status,
+        //         estFinishTime:
+        //           robot.task_id && tasks[robot.task_id]
+        //             ? tasks[robot.task_id].unix_millis_finish_time
+        //             : undefined,
+        //         lastUpdateTime: robot.unix_millis_time ? robot.unix_millis_time : undefined,
+        //       }))
+        //       : [],
+        //   };
+        // });
       }),
     );
     return () => subs.forEach((sub) => sub.unsubscribe());
-  }, [rmf, fleets]);
+  }, [rmf, fleets, robotTableDataList.page]);
 
   return (
     <TableContainer>
-      <RobotTable
+      <RobotDataGridTable
+        robotTableDataList={robotTableDataList}
+        onRobotClick={(_ev, robot) => {
+          setOpenRobotSummary(true);
+          AppEvents.robotSelect.next([robot.fleet, robot.name]);
+          setSelectedRobot(robot);
+        }}
+        onPageChange={(newPage: number) =>
+          setRobotTableDataList((old) => ({ ...old, page: newPage + 1 }))
+        }
+        onPageSizeChange={(newPageSize: number) =>
+          setRobotTableDataList((old) => ({ ...old, pageSize: newPageSize }))
+        }
+      />
+      {/* <RobotTable
         robots={Object.values(robots).flatMap((r) => r)}
         onRobotClick={(_ev, robot) => {
           setOpenRobotSummary(true);
           AppEvents.robotSelect.next([robot.fleet, robot.name]);
           setSelectedRobot(robot);
         }}
-      />
+      /> */}
 
       {openRobotSummary && selectedRobot && (
         <RobotSummary robot={selectedRobot} onClose={() => setOpenRobotSummary(false)} />

--- a/packages/react-components/lib/robots/index.ts
+++ b/packages/react-components/lib/robots/index.ts
@@ -1,3 +1,4 @@
 export * from './robot-info';
 export * from './robot-table';
+export * from './robot-table-datagrid';
 export * from './utils';

--- a/packages/react-components/lib/robots/robot-table-datagrid.spec.tsx
+++ b/packages/react-components/lib/robots/robot-table-datagrid.spec.tsx
@@ -1,0 +1,83 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Status2 as RobotStatus } from 'api-client';
+import React from 'react';
+import { RobotTableData } from './robot-table';
+import { makeRobot } from './test-utils.spec';
+import { RobotDataGridTable } from './robot-table-datagrid';
+
+const allStatuses = Object.values(RobotStatus) as RobotStatus[];
+
+describe('RobotTable', () => {
+  it('shows all robots', () => {
+    const robots = [makeRobot({ name: 'test_robot1' }), makeRobot({ name: 'test_robot2' })];
+    const tableData: RobotTableData[] = robots.map((robot) => ({
+      fleet: 'test_fleet',
+      name: robot.name,
+    }));
+    const root = render(<RobotDataGridTable robots={tableData} />);
+    expect(root.getByText('test_robot1')).toBeTruthy();
+    expect(root.getByText('test_robot2')).toBeTruthy();
+  });
+
+  it('smoke test for different robot status', () => {
+    const robots = allStatuses.map((status) => makeRobot({ name: `${status}_robot`, status }));
+    render(
+      <RobotDataGridTable
+        robots={robots.map((robot) => ({
+          fleet: 'test_fleet',
+          name: robot.name,
+          status: robot.status,
+        }))}
+      />,
+    );
+  });
+
+  it('onRobotClick is called when row is clicked', () => {
+    const onRobotClick = jasmine.createSpy();
+    const root = render(
+      <RobotDataGridTable
+        robots={[{ fleet: 'test_fleet', name: 'test_robot' }]}
+        onRobotClick={onRobotClick}
+      />,
+    );
+    const robot = root.getByText('test_robot');
+    userEvent.click(robot);
+    expect(onRobotClick).toHaveBeenCalled();
+  });
+
+  it('finish time is shown when it is available', () => {
+    const root = render(
+      <RobotDataGridTable
+        robots={[
+          { fleet: 'test_fleet', name: 'test_robot', estFinishTime: 1000, lastUpdateTime: 900 },
+        ]}
+      />,
+    );
+    // TODO: use a less convoluted test when
+    // https://github.com/testing-library/react-testing-library/issues/1160
+    // is resolved.
+    expect(() =>
+      root.getByText((_, node) => {
+        if (!node) {
+          return false;
+        }
+        const hasText = (node) => node.textContent === new Date(1000).toLocaleString();
+        const nodeHasText = hasText(node);
+        const childrenDontHaveText = Array.from(node.children).every((child) => !hasText(child));
+        return nodeHasText && childrenDontHaveText;
+      }),
+    ).not.toThrow();
+    expect(() =>
+      root.getByText((_, node) => {
+        if (!node) {
+          return false;
+        }
+        const hasText = (node) => node.textContent === new Date(900).toLocaleString();
+        const nodeHasText = hasText(node);
+        const childrenDontHaveText = Array.from(node.children).every((child) => !hasText(child));
+        return nodeHasText && childrenDontHaveText;
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/react-components/lib/robots/robot-table-datagrid.stories.tsx
+++ b/packages/react-components/lib/robots/robot-table-datagrid.stories.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { RobotDataGridTable } from './robot-table-datagrid';
+import { Status2 as RobotStatus } from 'api-client';
+import { RobotTableData } from './robot-table';
+
+// Define the stories
+storiesOf('Components/RobotDataGridTable', module).add('Default', () => {
+  const robots: RobotTableData[] = [
+    {
+      fleet: 'Fleet A',
+      name: 'Robot 1',
+      estFinishTime: new Date('2023-05-01T09:00:00').getTime(),
+      battery: 0.8,
+      lastUpdateTime: new Date('2023-05-01T08:30:00').getTime(),
+      status: RobotStatus.Working,
+    },
+    {
+      fleet: 'Fleet B',
+      name: 'Robot 2',
+      estFinishTime: new Date('2023-05-01T10:30:00').getTime(),
+      battery: 0.6,
+      lastUpdateTime: new Date('2023-05-01T10:00:00').getTime(),
+      status: RobotStatus.Charging,
+    },
+    {
+      fleet: 'Fleet A',
+      name: 'Robot 3',
+      estFinishTime: new Date('2023-05-01T11:45:00').getTime(),
+      battery: 0.9,
+      lastUpdateTime: new Date('2023-05-01T11:30:00').getTime(),
+      status: RobotStatus.Idle,
+    },
+  ];
+
+  return <RobotDataGridTable robots={robots} />;
+});

--- a/packages/react-components/lib/robots/robot-table-datagrid.tsx
+++ b/packages/react-components/lib/robots/robot-table-datagrid.tsx
@@ -41,27 +41,12 @@ const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
   },
 }));
 
-export interface RobotTableDataList {
-  isLoading: boolean;
-  records: Record<string, RobotTableData[]>;
-  total: number;
-  page: number;
-  pageSize: number;
-}
-
 export interface RobotDataGridTableProps {
   onRobotClick?(ev: MuiEvent<React.MouseEvent<HTMLElement>>, robotName: RobotTableData): void;
-  onPageChange: (newPage: number) => void;
-  onPageSizeChange: (newPageSize: number) => void;
-  robotTableDataList: RobotTableDataList;
+  robots: RobotTableData[];
 }
 
-export function RobotDataGridTable({
-  onRobotClick,
-  onPageChange,
-  onPageSizeChange,
-  robotTableDataList,
-}: RobotDataGridTableProps): JSX.Element {
+export function RobotDataGridTable({ onRobotClick, robots }: RobotDataGridTableProps): JSX.Element {
   const handleEvent: GridEventListener<'rowClick'> = (
     params: GridRowParams,
     event: MuiEvent<React.MouseEvent<HTMLElement>>,
@@ -130,19 +115,12 @@ export function RobotDataGridTable({
   return (
     <div style={{ height: '100%', width: '100%' }}>
       <StyledDataGrid
-        autoHeight
+        autoHeight={true}
         getRowId={(r) => r.name}
-        rows={Object.values(robotTableDataList.records).flatMap((r) => r)}
-        rowCount={robotTableDataList.total}
-        loading={robotTableDataList.isLoading}
-        pageSize={robotTableDataList.pageSize}
-        rowsPerPageOptions={[10]}
-        pagination
-        paginationMode="server"
-        filterMode="server"
-        page={robotTableDataList.page - 1}
-        onPageChange={onPageChange}
-        onPageSizeChange={onPageSizeChange}
+        rows={robots}
+        pageSize={5}
+        rowHeight={38}
+        rowsPerPageOptions={[100]}
         columns={columns}
         onRowClick={handleEvent}
         getCellClassName={(params: GridCellParams<string>) => {

--- a/packages/react-components/lib/robots/robot-table-datagrid.tsx
+++ b/packages/react-components/lib/robots/robot-table-datagrid.tsx
@@ -121,6 +121,7 @@ export function RobotDataGridTable({ onRobotClick, robots }: RobotDataGridTableP
         pageSize={5}
         rowHeight={38}
         columns={columns}
+        rowsPerPageOptions={[5]}
         onRowClick={handleEvent}
         getCellClassName={(params: GridCellParams<string>) => {
           if (params.field === 'status') {

--- a/packages/react-components/lib/robots/robot-table-datagrid.tsx
+++ b/packages/react-components/lib/robots/robot-table-datagrid.tsx
@@ -1,0 +1,171 @@
+import {
+  DataGrid,
+  GridColDef,
+  GridEventListener,
+  GridValueGetterParams,
+  MuiEvent,
+  GridRowParams,
+  GridCellParams,
+} from '@mui/x-data-grid';
+import { styled } from '@mui/material';
+import * as React from 'react';
+import { Status2 } from 'api-client';
+import { RobotTableData } from './robot-table';
+
+const classes = {
+  robotErrorCell: 'MuiDataGrid-cell-error-cell',
+  robotChargingCell: 'MuiDataGrid-cell-charging-cell',
+  robotWorkingCell: 'MuiDataGrid-cell-working-cell',
+  robotIdleCell: 'MuiDataGrid-cell-idle-cell',
+  robotOfflineCell: 'MuiDataGrid-cell-offline-cell',
+  robotShutdownCell: 'MuiDataGrid-cell-shutdown-cell',
+  robotDefaultCell: 'MuiDataGrid-cell-defautl-cell',
+};
+
+const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
+  [`& .${classes.robotErrorCell}`]: {
+    backgroundColor: theme.palette.error.main,
+    color: theme.palette.getContrastText(theme.palette.success.light),
+  },
+  [`& .${classes.robotChargingCell}`]: {
+    backgroundColor: theme.palette.info.main,
+    color: theme.palette.getContrastText(theme.palette.grey[500]),
+  },
+  [`& .${classes.robotWorkingCell}`]: {
+    backgroundColor: theme.palette.success.main,
+    color: theme.palette.getContrastText(theme.palette.info.light),
+  },
+  [`& .${classes.robotDefaultCell}`]: {
+    backgroundColor: theme.palette.warning.main,
+    color: theme.palette.getContrastText(theme.palette.warning.main),
+  },
+}));
+
+export interface RobotTableDataList {
+  isLoading: boolean;
+  records: Record<string, RobotTableData[]>;
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+export interface RobotDataGridTableProps {
+  onRobotClick?(ev: MuiEvent<React.MouseEvent<HTMLElement>>, robotName: RobotTableData): void;
+  onPageChange: (newPage: number) => void;
+  onPageSizeChange: (newPageSize: number) => void;
+  robotTableDataList: RobotTableDataList;
+}
+
+export function RobotDataGridTable({
+  onRobotClick,
+  onPageChange,
+  onPageSizeChange,
+  robotTableDataList,
+}: RobotDataGridTableProps): JSX.Element {
+  const handleEvent: GridEventListener<'rowClick'> = (
+    params: GridRowParams,
+    event: MuiEvent<React.MouseEvent<HTMLElement>>,
+  ) => {
+    if (onRobotClick) {
+      onRobotClick(event, params.row);
+    }
+  };
+
+  const columns: GridColDef[] = [
+    {
+      field: 'fleet',
+      headerName: 'Fleet',
+      width: 90,
+      valueGetter: (params: GridValueGetterParams) => params.row.fleet,
+      flex: 1,
+      filterable: true,
+    },
+    {
+      field: 'name',
+      headerName: 'Robot Name',
+      width: 150,
+      editable: false,
+      valueGetter: (params: GridValueGetterParams) => params.row.name,
+      flex: 1,
+      filterable: true,
+    },
+    {
+      field: 'estFinishTime',
+      headerName: 'Est. Task Finish Time',
+      width: 150,
+      editable: false,
+      valueGetter: (params: GridValueGetterParams) =>
+        params.row.estFinishTime ? new Date(params.row.estFinishTime).toLocaleString() : '-',
+      flex: 1,
+      filterable: true,
+    },
+    {
+      field: 'battery',
+      headerName: 'Battery',
+      width: 150,
+      editable: false,
+      valueGetter: (params: GridValueGetterParams) => (params.row.battery * 100).toFixed(2),
+      flex: 1,
+      filterable: true,
+    },
+    {
+      field: 'lastUpdateTime',
+      headerName: 'Last Updated',
+      width: 150,
+      editable: false,
+      valueGetter: (params: GridValueGetterParams) =>
+        params.row.lastUpdateTime ? new Date(params.row.lastUpdateTime).toLocaleString() : '-',
+      flex: 1,
+      filterable: true,
+    },
+    {
+      field: 'status',
+      headerName: 'Status',
+      editable: false,
+      flex: 1,
+      filterable: true,
+    },
+  ];
+
+  return (
+    <div style={{ height: '100%', width: '100%' }}>
+      <StyledDataGrid
+        autoHeight
+        getRowId={(r) => r.name}
+        rows={Object.values(robotTableDataList.records).flatMap((r) => r)}
+        rowCount={robotTableDataList.total}
+        loading={robotTableDataList.isLoading}
+        pageSize={robotTableDataList.pageSize}
+        rowsPerPageOptions={[10]}
+        pagination
+        paginationMode="server"
+        filterMode="server"
+        page={robotTableDataList.page - 1}
+        onPageChange={onPageChange}
+        onPageSizeChange={onPageSizeChange}
+        columns={columns}
+        onRowClick={handleEvent}
+        getCellClassName={(params: GridCellParams<string>) => {
+          if (params.field === 'status') {
+            switch (params.value) {
+              case Status2.Error:
+                return classes.robotErrorCell;
+              case Status2.Charging:
+                return classes.robotChargingCell;
+              case Status2.Working:
+                return classes.robotWorkingCell;
+              case Status2.Idle:
+              case Status2.Offline:
+              case Status2.Shutdown:
+              case Status2.Uninitialized:
+                return classes.robotDefaultCell;
+              default:
+                return classes.robotDefaultCell;
+            }
+          }
+          return '';
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/react-components/lib/robots/robot-table-datagrid.tsx
+++ b/packages/react-components/lib/robots/robot-table-datagrid.tsx
@@ -120,7 +120,6 @@ export function RobotDataGridTable({ onRobotClick, robots }: RobotDataGridTableP
         rows={robots}
         pageSize={5}
         rowHeight={38}
-        rowsPerPageOptions={[100]}
         columns={columns}
         onRowClick={handleEvent}
         getCellClassName={(params: GridCellParams<string>) => {


### PR DESCRIPTION
## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

- Migrate robot table to datagrid mui
- New test file was added
- New storybook file was added
- Removed the use of the basic table and instead used mui's datagrid. 
- Allow the frontend to do all the sorting and filtering since we do not need to handle pagination.

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->


[chrome-capture-2023-5-1.webm](https://github.com/open-rmf/rmf-web/assets/37310205/8ff970ff-b541-4290-acdb-5d62e816b0bb)

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
