### PR TITLE
Migrate lift table to datagrid

### DIFF
--- a/packages/dashboard/src/components/lifts-app.tsx
+++ b/packages/dashboard/src/components/lifts-app.tsx
@@ -1,13 +1,13 @@
 import { BuildingMap } from 'api-client';
 import React from 'react';
-import { LiftData, LiftDataGridTable } from 'react-components';
+import { LiftTableData, LiftDataGridTable } from 'react-components';
 import { createMicroApp } from './micro-app';
 import { RmfAppContext } from './rmf-app';
 
 export const LiftsApp = createMicroApp('Lifts', () => {
   const rmf = React.useContext(RmfAppContext);
   const [buildingMap, setBuildingMap] = React.useState<BuildingMap | null>(null);
-  const [data, setData] = React.useState<Record<string, LiftData[]>>({});
+  const [data, setData] = React.useState<Record<string, LiftTableData[]>>({});
 
   React.useEffect(() => {
     if (!rmf) {
@@ -40,7 +40,6 @@ export const LiftsApp = createMicroApp('Lifts', () => {
                 motion_state: liftState.motion_state,
                 lift: lift,
                 onRequestSubmit: (_ev, doorState, requestType, destination) => {
-                  console.log(lift.name);
                   return rmf?.liftsApi.postLiftRequestLiftsLiftNameRequestPost(lift.name, {
                     destination,
                     door_mode: doorState,

--- a/packages/dashboard/src/components/lifts-app.tsx
+++ b/packages/dashboard/src/components/lifts-app.tsx
@@ -1,140 +1,60 @@
-import {
-  SxProps,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
-  Typography,
-  useTheme,
-} from '@mui/material';
-import { BuildingMap, Lift, LiftState } from 'api-client';
-import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
-import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import { BuildingMap } from 'api-client';
 import React from 'react';
-import { LiftControls, doorStateToString, motionStateToString } from 'react-components';
+import { LiftData, LiftDataGridTable } from 'react-components';
 import { createMicroApp } from './micro-app';
 import { RmfAppContext } from './rmf-app';
-import { LiftState as LiftStateModel } from 'rmf-models';
-
-interface LiftTableRowProps {
-  lift: Lift;
-}
-
-const LiftTableRow = ({ lift }: LiftTableRowProps) => {
-  const rmf = React.useContext(RmfAppContext);
-  const [liftState, setLiftState] = React.useState<LiftState | null>(null);
-
-  React.useEffect(() => {
-    if (!rmf) {
-      return;
-    }
-    const sub = rmf.getLiftStateObs(lift.name).subscribe(setLiftState);
-    return () => sub.unsubscribe();
-  }, [rmf, lift.name]);
-
-  const theme = useTheme();
-  const currMotion = motionStateToString(liftState?.motion_state);
-  const motionArrowActiveStyle: SxProps = {
-    color: theme.palette.primary.main,
-  };
-  const motionArrowIdleStyle: SxProps = {
-    color: theme.palette.action.disabled,
-    opacity: theme.palette.action.disabledOpacity,
-  };
-  const currDoorMotion = doorStateToString(liftState?.door_state);
-
-  const doorStateLabelStyle: SxProps = (() => {
-    switch (liftState?.door_state) {
-      case LiftStateModel.DOOR_OPEN:
-        return {
-          color: theme.palette.success.main,
-        };
-      case LiftStateModel.DOOR_CLOSED:
-        return {
-          color: theme.palette.error.main,
-        };
-      case LiftStateModel.DOOR_MOVING:
-        return {
-          color: theme.palette.warning.main,
-        };
-      default:
-        return {
-          color: theme.palette.action.disabledBackground,
-        };
-    }
-  })();
-
-  return (
-    <TableRow key={lift.name}>
-      <TableCell>{lift.name}</TableCell>
-      <TableCell>{liftState?.current_floor || 'N/A'}</TableCell>
-      <TableCell>{liftState?.destination_floor || 'N/A'}</TableCell>
-      <TableCell sx={doorStateLabelStyle}>
-        <Typography
-          component="p"
-          sx={{
-            marginRight: liftState?.door_state === LiftStateModel.DOOR_OPEN ? 4 : 2,
-            fontWeight: 'bold',
-            fontSize: 14,
-            display: 'inline-block',
-          }}
-        >
-          {currDoorMotion}
-        </Typography>
-        <ArrowUpwardIcon sx={currMotion === 'Up' ? motionArrowActiveStyle : motionArrowIdleStyle} />
-        <ArrowDownwardIcon
-          sx={currMotion === 'Down' ? motionArrowActiveStyle : motionArrowIdleStyle}
-        />
-      </TableCell>
-      <TableCell align="right" sx={{ marginRight: 1, padding: 0, paddingRight: 1 }}>
-        <LiftControls
-          availableLevels={lift.levels}
-          currentLevel={liftState?.current_floor}
-          onRequestSubmit={(_ev, doorState, requestType, destination) =>
-            rmf?.liftsApi.postLiftRequestLiftsLiftNameRequestPost(lift.name, {
-              destination,
-              door_mode: doorState,
-              request_type: requestType,
-            })
-          }
-        />
-      </TableCell>
-    </TableRow>
-  );
-};
 
 export const LiftsApp = createMicroApp('Lifts', () => {
   const rmf = React.useContext(RmfAppContext);
   const [buildingMap, setBuildingMap] = React.useState<BuildingMap | null>(null);
+  const [data, setData] = React.useState<Record<string, LiftData[]>>({});
 
   React.useEffect(() => {
     if (!rmf) {
       return;
     }
+
     const sub = rmf.buildingMapObs.subscribe((newMap) => {
       setBuildingMap(newMap);
     });
     return () => sub.unsubscribe();
   }, [rmf]);
 
-  return (
-    <Table stickyHeader size="small" aria-label="door-table" style={{ tableLayout: 'fixed' }}>
-      <TableHead>
-        <TableRow>
-          <TableCell>Name</TableCell>
-          <TableCell>Current floor</TableCell>
-          <TableCell>Destination floor</TableCell>
-          <TableCell>Door state</TableCell>
-          <TableCell></TableCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        {buildingMap &&
-          buildingMap.lifts.map((lift) => {
-            return <LiftTableRow key={lift.name} lift={lift} />;
-          })}
-      </TableBody>
-    </Table>
-  );
+  React.useEffect(() => {
+    if (!rmf) {
+      return;
+    }
+
+    buildingMap?.lifts.map((lift, i) => {
+      const sub = rmf.getLiftStateObs(lift.name).subscribe((liftState) => {
+        setData((prev) => {
+          return {
+            ...prev,
+            [lift.name]: [
+              {
+                index: i,
+                name: lift.name,
+                current_floor: liftState.current_floor,
+                destination_floor: liftState.destination_floor,
+                door_state: liftState.door_state,
+                motion_state: liftState.motion_state,
+                lift: lift,
+                onRequestSubmit: (_ev, doorState, requestType, destination) => {
+                  console.log(lift.name);
+                  return rmf?.liftsApi.postLiftRequestLiftsLiftNameRequestPost(lift.name, {
+                    destination,
+                    door_mode: doorState,
+                    request_type: requestType,
+                  });
+                },
+              },
+            ],
+          };
+        });
+      });
+      return () => sub.unsubscribe();
+    });
+  }, [rmf, buildingMap]);
+
+  return <LiftDataGridTable lifts={Object.values(data).flatMap((r) => r)} />;
 });

--- a/packages/react-components/lib/lifts/index.ts
+++ b/packages/react-components/lib/lifts/index.ts
@@ -2,3 +2,4 @@ export * from './lift-card';
 export * from './lift-controls';
 export * from './lift-request-dialog';
 export * from './lift-utils';
+export * from './lift-table-datagrid';

--- a/packages/react-components/lib/lifts/lift-table-datagrid.spec.tsx
+++ b/packages/react-components/lib/lifts/lift-table-datagrid.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { LiftDataGridTable, LiftTableData } from './lift-table-datagrid';
 import { LiftState as RmfLiftState } from 'rmf-models';
 import { makeLift } from './test-utils.spec';

--- a/packages/react-components/lib/lifts/lift-table-datagrid.spec.tsx
+++ b/packages/react-components/lib/lifts/lift-table-datagrid.spec.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LiftDataGridTable, LiftTableData } from './lift-table-datagrid';
+import { LiftState as RmfLiftState } from 'rmf-models';
+import { makeLift } from './test-utils.spec';
+
+describe('LiftDataGridTable', () => {
+  const lift = makeLift();
+  const mockLifts: LiftTableData[] = [
+    {
+      index: 1,
+      name: 'Lift1',
+      current_floor: 'L1',
+      destination_floor: 'L2',
+      door_state: RmfLiftState.DOOR_OPEN,
+      motion_state: RmfLiftState.MOTION_DOWN,
+      lift: lift,
+    },
+  ];
+
+  it('renders lift data correctly', () => {
+    const root = render(<LiftDataGridTable lifts={mockLifts} />);
+
+    const liftName = root.getByText('Lift1');
+    const currentFloor = root.getByText('L1');
+    const destinationFloor = root.getByText('L2');
+    const doorState = root.getByText('OPEN');
+
+    expect(liftName).toBeTruthy();
+    expect(currentFloor).toBeTruthy();
+    expect(destinationFloor).toBeTruthy();
+    expect(doorState).toBeTruthy();
+  });
+
+  it('shows the correct number of rows', () => {
+    const root = render(<LiftDataGridTable lifts={mockLifts} />);
+    const allRows = root.container.querySelectorAll('.MuiDataGrid-row').length;
+    expect(allRows).toBe(1);
+  });
+
+  it('shows titles correctly', () => {
+    const root = render(<LiftDataGridTable lifts={mockLifts} />);
+    expect(root.queryByText('Name')).toBeTruthy();
+    expect(root.queryByText('Current floor')).toBeTruthy();
+    expect(root.queryByText('Destination floor')).toBeTruthy();
+    expect(root.queryByText('Door state')).toBeTruthy();
+  });
+});

--- a/packages/react-components/lib/lifts/lift-table-datagrid.stories.tsx
+++ b/packages/react-components/lib/lifts/lift-table-datagrid.stories.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { LiftDataGridTable, LiftTableData } from './lift-table-datagrid';
+import { makeLift } from './test-utils.spec';
+import { LiftState as RmfLiftState } from 'rmf-models';
+
+const lift = makeLift();
+const mockLifts: LiftTableData[] = [
+  {
+    index: 1,
+    name: 'Lift1',
+    current_floor: 'L1',
+    destination_floor: 'L2',
+    door_state: RmfLiftState.DOOR_OPEN,
+    motion_state: RmfLiftState.MOTION_DOWN,
+    lift: lift,
+    onRequestSubmit: action('onRequestSubmit'),
+  },
+];
+
+storiesOf('LiftDataGridTable', module)
+  .add('Default', () => <LiftDataGridTable lifts={mockLifts} />)
+  .add('Empty', () => <LiftDataGridTable lifts={[]} />);

--- a/packages/react-components/lib/lifts/lift-table-datagrid.tsx
+++ b/packages/react-components/lib/lifts/lift-table-datagrid.tsx
@@ -1,5 +1,5 @@
 import { DataGrid, GridColDef, GridValueGetterParams, GridCellParams } from '@mui/x-data-grid';
-import { Box, SxProps, Typography, styled, useTheme } from '@mui/material';
+import { Box, SxProps, Typography, useTheme } from '@mui/material';
 import * as React from 'react';
 import { Lift } from 'api-client';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
@@ -8,36 +8,7 @@ import { LiftState as LiftStateModel } from 'rmf-models';
 import { doorStateToString, motionStateToString } from './lift-utils';
 import { LiftControls } from './lift-controls';
 
-const classes = {
-  robotErrorCell: 'MuiDataGrid-cell-error-cell',
-  robotChargingCell: 'MuiDataGrid-cell-charging-cell',
-  robotWorkingCell: 'MuiDataGrid-cell-working-cell',
-  robotIdleCell: 'MuiDataGrid-cell-idle-cell',
-  robotOfflineCell: 'MuiDataGrid-cell-offline-cell',
-  robotShutdownCell: 'MuiDataGrid-cell-shutdown-cell',
-  robotDefaultCell: 'MuiDataGrid-cell-defautl-cell',
-};
-
-const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
-  [`& .${classes.robotErrorCell}`]: {
-    backgroundColor: theme.palette.error.main,
-    color: theme.palette.getContrastText(theme.palette.success.light),
-  },
-  [`& .${classes.robotChargingCell}`]: {
-    backgroundColor: theme.palette.info.main,
-    color: theme.palette.getContrastText(theme.palette.grey[500]),
-  },
-  [`& .${classes.robotWorkingCell}`]: {
-    backgroundColor: theme.palette.success.main,
-    color: theme.palette.getContrastText(theme.palette.info.light),
-  },
-  [`& .${classes.robotDefaultCell}`]: {
-    backgroundColor: theme.palette.warning.main,
-    color: theme.palette.getContrastText(theme.palette.warning.main),
-  },
-}));
-
-export interface LiftData {
+export interface LiftTableData {
   index: number;
   name: string;
   current_floor?: string;
@@ -54,7 +25,7 @@ export interface LiftData {
 }
 
 export interface LiftDataGridTableProps {
-  lifts: LiftData[];
+  lifts: LiftTableData[];
 }
 
 export function LiftDataGridTable({ lifts }: LiftDataGridTableProps): JSX.Element {
@@ -63,9 +34,11 @@ export function LiftDataGridTable({ lifts }: LiftDataGridTableProps): JSX.Elemen
   const DoorState = (params: GridCellParams): React.ReactNode => {
     const currDoorMotion = doorStateToString(params.row?.door_state);
     const currMotion = motionStateToString(params.row?.motion_state);
+
     const motionArrowActiveStyle: SxProps = {
       color: theme.palette.primary.main,
     };
+
     const motionArrowIdleStyle: SxProps = {
       color: theme.palette.action.disabled,
       opacity: theme.palette.action.disabledOpacity,
@@ -174,7 +147,7 @@ export function LiftDataGridTable({ lifts }: LiftDataGridTableProps): JSX.Elemen
 
   return (
     <div style={{ height: '100%', width: '100%' }}>
-      <StyledDataGrid
+      <DataGrid
         autoHeight={true}
         getRowId={(l) => l.index}
         rows={lifts}

--- a/packages/react-components/lib/lifts/lift-table-datagrid.tsx
+++ b/packages/react-components/lib/lifts/lift-table-datagrid.tsx
@@ -1,0 +1,188 @@
+import { DataGrid, GridColDef, GridValueGetterParams, GridCellParams } from '@mui/x-data-grid';
+import { Box, SxProps, Typography, styled, useTheme } from '@mui/material';
+import * as React from 'react';
+import { Lift } from 'api-client';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import { LiftState as LiftStateModel } from 'rmf-models';
+import { doorStateToString, motionStateToString } from './lift-utils';
+import { LiftControls } from './lift-controls';
+
+const classes = {
+  robotErrorCell: 'MuiDataGrid-cell-error-cell',
+  robotChargingCell: 'MuiDataGrid-cell-charging-cell',
+  robotWorkingCell: 'MuiDataGrid-cell-working-cell',
+  robotIdleCell: 'MuiDataGrid-cell-idle-cell',
+  robotOfflineCell: 'MuiDataGrid-cell-offline-cell',
+  robotShutdownCell: 'MuiDataGrid-cell-shutdown-cell',
+  robotDefaultCell: 'MuiDataGrid-cell-defautl-cell',
+};
+
+const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
+  [`& .${classes.robotErrorCell}`]: {
+    backgroundColor: theme.palette.error.main,
+    color: theme.palette.getContrastText(theme.palette.success.light),
+  },
+  [`& .${classes.robotChargingCell}`]: {
+    backgroundColor: theme.palette.info.main,
+    color: theme.palette.getContrastText(theme.palette.grey[500]),
+  },
+  [`& .${classes.robotWorkingCell}`]: {
+    backgroundColor: theme.palette.success.main,
+    color: theme.palette.getContrastText(theme.palette.info.light),
+  },
+  [`& .${classes.robotDefaultCell}`]: {
+    backgroundColor: theme.palette.warning.main,
+    color: theme.palette.getContrastText(theme.palette.warning.main),
+  },
+}));
+
+export interface LiftData {
+  index: number;
+  name: string;
+  current_floor?: string;
+  destination_floor?: string;
+  door_state: number;
+  motion_state: number;
+  lift: Lift;
+  onRequestSubmit?(
+    event: React.FormEvent,
+    doorState: number,
+    requestType: number,
+    destination: string,
+  ): void;
+}
+
+export interface LiftDataGridTableProps {
+  lifts: LiftData[];
+}
+
+export function LiftDataGridTable({ lifts }: LiftDataGridTableProps): JSX.Element {
+  const theme = useTheme();
+
+  const renderDoorState = (params: GridCellParams): React.ReactNode => {
+    const currDoorMotion = doorStateToString(params.row?.door_state);
+    const currMotion = motionStateToString(params.row?.motion_state);
+    const motionArrowActiveStyle: SxProps = {
+      color: theme.palette.primary.main,
+    };
+    const motionArrowIdleStyle: SxProps = {
+      color: theme.palette.action.disabled,
+      opacity: theme.palette.action.disabledOpacity,
+    };
+
+    const doorStateLabelStyle: SxProps = (() => {
+      switch (params.row?.door_state) {
+        case LiftStateModel.DOOR_OPEN:
+          return {
+            color: theme.palette.success.main,
+          };
+        case LiftStateModel.DOOR_CLOSED:
+          return {
+            color: theme.palette.error.main,
+          };
+        case LiftStateModel.DOOR_MOVING:
+          return {
+            color: theme.palette.warning.main,
+          };
+        default:
+          return {
+            color: theme.palette.action.disabledBackground,
+          };
+      }
+    })();
+
+    return (
+      <Box sx={doorStateLabelStyle}>
+        <Typography
+          component="p"
+          sx={{
+            marginRight: params.row?.door_state === LiftStateModel.DOOR_OPEN ? 4 : 2,
+            fontWeight: 'bold',
+            fontSize: 14,
+            display: 'inline-block',
+          }}
+        >
+          {currDoorMotion}
+        </Typography>
+        <ArrowUpwardIcon sx={currMotion === 'Up' ? motionArrowActiveStyle : motionArrowIdleStyle} />
+        <ArrowDownwardIcon
+          sx={currMotion === 'Down' ? motionArrowActiveStyle : motionArrowIdleStyle}
+        />
+      </Box>
+    );
+  };
+
+  const renderLiftControl = (params: GridCellParams): React.ReactNode => {
+    return (
+      <LiftControls
+        availableLevels={params.row.lift.levels}
+        currentLevel={params.row?.current_floor}
+        onRequestSubmit={params.row?.test}
+      />
+    );
+  };
+
+  const columns: GridColDef[] = [
+    {
+      field: 'name',
+      headerName: 'Name',
+      width: 90,
+      valueGetter: (params: GridValueGetterParams) => params.row.name,
+      flex: 1,
+      filterable: true,
+    },
+    {
+      field: 'current_floor',
+      headerName: 'Current floor',
+      width: 150,
+      editable: false,
+      valueGetter: (params: GridValueGetterParams) =>
+        params.row.current_floor ? params.row.current_floor : 'N/A',
+      flex: 1,
+      filterable: true,
+    },
+    {
+      field: 'destination_floor',
+      headerName: 'Destination floor',
+      width: 150,
+      editable: false,
+      valueGetter: (params: GridValueGetterParams) =>
+        params.row.destination_floor ? params.row.destination_floor : 'N/A',
+      flex: 1,
+      filterable: true,
+    },
+    {
+      field: 'door_state',
+      headerName: 'Door state',
+      width: 150,
+      editable: false,
+      flex: 1,
+      renderCell: renderDoorState,
+      filterable: true,
+    },
+    {
+      field: '-',
+      headerName: '',
+      width: 150,
+      editable: false,
+      flex: 1,
+      renderCell: renderLiftControl,
+      filterable: true,
+    },
+  ];
+
+  return (
+    <div style={{ height: '100%', width: '100%' }}>
+      <StyledDataGrid
+        autoHeight={true}
+        getRowId={(l) => l.index}
+        rows={lifts}
+        pageSize={5}
+        rowHeight={38}
+        columns={columns}
+        rowsPerPageOptions={[5]}
+      />
+    </div>
+  );
+}

--- a/packages/react-components/lib/lifts/lift-table-datagrid.tsx
+++ b/packages/react-components/lib/lifts/lift-table-datagrid.tsx
@@ -60,7 +60,7 @@ export interface LiftDataGridTableProps {
 export function LiftDataGridTable({ lifts }: LiftDataGridTableProps): JSX.Element {
   const theme = useTheme();
 
-  const renderDoorState = (params: GridCellParams): React.ReactNode => {
+  const DoorState = (params: GridCellParams): React.ReactNode => {
     const currDoorMotion = doorStateToString(params.row?.door_state);
     const currMotion = motionStateToString(params.row?.motion_state);
     const motionArrowActiveStyle: SxProps = {
@@ -113,12 +113,12 @@ export function LiftDataGridTable({ lifts }: LiftDataGridTableProps): JSX.Elemen
     );
   };
 
-  const renderLiftControl = (params: GridCellParams): React.ReactNode => {
+  const LiftControl = (params: GridCellParams): React.ReactNode => {
     return (
       <LiftControls
         availableLevels={params.row.lift.levels}
         currentLevel={params.row?.current_floor}
-        onRequestSubmit={params.row?.test}
+        onRequestSubmit={params.row?.onRequestSubmit}
       />
     );
   };
@@ -158,7 +158,7 @@ export function LiftDataGridTable({ lifts }: LiftDataGridTableProps): JSX.Elemen
       width: 150,
       editable: false,
       flex: 1,
-      renderCell: renderDoorState,
+      renderCell: DoorState,
       filterable: true,
     },
     {
@@ -167,7 +167,7 @@ export function LiftDataGridTable({ lifts }: LiftDataGridTableProps): JSX.Elemen
       width: 150,
       editable: false,
       flex: 1,
-      renderCell: renderLiftControl,
+      renderCell: LiftControl,
       filterable: true,
     },
   ];


### PR DESCRIPTION
## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->
- Migrate lift table to datagrid mui
- New test file was added
- New storybook file was added
- Removed the use of the basic table and instead used mui's datagrid.

[chrome-capture-2023-5-5.webm](https://github.com/open-rmf/rmf-web/assets/37310205/f33c30a8-ed52-4150-b940-b488b9276870)

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
