### PR TITLE
Migrate door table to datagrid 

### DIFF
--- a/packages/dashboard/src/components/doors-app.tsx
+++ b/packages/dashboard/src/components/doors-app.tsx
@@ -1,116 +1,9 @@
-import { Button, SxProps, Typography, useTheme } from '@mui/material';
-import { BuildingMap, DoorState } from 'api-client';
+import { BuildingMap } from 'api-client';
 import React from 'react';
-import {
-  DoorDataGridTable,
-  DoorTableData,
-  doorModeToString,
-  doorTypeToString,
-} from 'react-components';
-import { DoorMode, DoorMode as RmfDoorMode } from 'rmf-models';
+import { DoorDataGridTable, DoorTableData } from 'react-components';
+import { DoorMode as RmfDoorMode } from 'rmf-models';
 import { createMicroApp } from './micro-app';
 import { RmfAppContext } from './rmf-app';
-import Table from '@mui/material/Table';
-import TableBody from '@mui/material/TableBody';
-import TableCell from '@mui/material/TableCell';
-import TableHead from '@mui/material/TableHead';
-import TableRow from '@mui/material/TableRow';
-
-interface DoorTableRowProps {
-  doorName: string;
-  levelName: string;
-  doorType: number;
-}
-
-const DoorTableRow = ({ doorName, levelName, doorType }: DoorTableRowProps) => {
-  const theme = useTheme();
-  const rmf = React.useContext(RmfAppContext);
-  const [doorState, setDoorState] = React.useState<DoorState | null>(null);
-
-  React.useEffect(() => {
-    if (!rmf) {
-      return;
-    }
-    const sub = rmf.getDoorStateObs(doorName).subscribe(setDoorState);
-    return () => sub.unsubscribe();
-  }, [rmf, doorName]);
-
-  const labelStyle = React.useMemo<SxProps>(() => {
-    const { current_mode } = doorState ?? {};
-    const mode = current_mode?.value;
-
-    const disabled = {
-      color: theme.palette.action.disabledBackground,
-    };
-    const open = {
-      color: theme.palette.success.main,
-    };
-    const closed = {
-      color: theme.palette.error.main,
-    };
-    const moving = {
-      color: theme.palette.warning.main,
-    };
-
-    switch (mode) {
-      case DoorMode.MODE_OPEN:
-        return open;
-      case DoorMode.MODE_CLOSED:
-        return closed;
-      case DoorMode.MODE_MOVING:
-        return moving;
-      default:
-        return disabled;
-    }
-  }, [theme, doorState]);
-
-  return (
-    <TableRow key={doorName}>
-      <TableCell>{doorName}</TableCell>
-      <TableCell>{levelName}</TableCell>
-      <TableCell>{doorTypeToString(doorType)}</TableCell>
-      <TableCell sx={labelStyle}>
-        <Typography
-          data-testid="door-state"
-          component="p"
-          sx={{
-            fontWeight: 'bold',
-            fontSize: 14,
-          }}
-        >
-          {doorState ? doorModeToString(doorState.current_mode.value) : -1}
-        </Typography>
-      </TableCell>
-      <TableCell align="right" sx={{ margin: 0, padding: 0, paddingRight: 1 }}>
-        <Button
-          variant="contained"
-          size="small"
-          aria-label="open"
-          sx={{ marginRight: 2 }}
-          onClick={() =>
-            rmf?.doorsApi.postDoorRequestDoorsDoorNameRequestPost(doorName, {
-              mode: RmfDoorMode.MODE_OPEN,
-            })
-          }
-        >
-          Open
-        </Button>
-        <Button
-          variant="contained"
-          size="small"
-          aria-label="close"
-          onClick={() =>
-            rmf?.doorsApi.postDoorRequestDoorsDoorNameRequestPost(doorName, {
-              mode: RmfDoorMode.MODE_CLOSED,
-            })
-          }
-        >
-          Close
-        </Button>
-      </TableCell>
-    </TableRow>
-  );
-};
 
 export const DoorsApp = createMicroApp('Doors', () => {
   const rmf = React.useContext(RmfAppContext);
@@ -143,6 +36,14 @@ export const DoorsApp = createMicroApp('Doors', () => {
                   levelName: level.name,
                   doorType: door.door_type,
                   doorState: doorState,
+                  onClickOpen: () =>
+                    rmf?.doorsApi.postDoorRequestDoorsDoorNameRequestPost(door.name, {
+                      mode: RmfDoorMode.MODE_OPEN,
+                    }),
+                  onClickClose: () =>
+                    rmf?.doorsApi.postDoorRequestDoorsDoorNameRequestPost(door.name, {
+                      mode: RmfDoorMode.MODE_CLOSED,
+                    }),
                 },
               ],
             };
@@ -153,32 +54,5 @@ export const DoorsApp = createMicroApp('Doors', () => {
     );
   }, [rmf, buildingMap]);
 
-  return <DoorDataGridTable doors={Object.values(doorTableData).flatMap((r) => r)} />;
-
-  // return (
-  //   <Table stickyHeader size="small" aria-label="door-table" style={{ tableLayout: 'fixed' }}>
-  //     <TableHead>
-  //       <TableRow>
-  //         <TableCell>Name</TableCell>
-  //         <TableCell>Level</TableCell>
-  //         <TableCell>Type</TableCell>
-  //         <TableCell>Door State</TableCell>
-  //         <TableCell></TableCell>
-  //       </TableRow>
-  //     </TableHead>
-  //     <TableBody>
-  //       {buildingMap &&
-  //         buildingMap.levels.flatMap((level) =>
-  //           level.doors.map((door) => (
-  //             <DoorTableRow
-  //               key={door.name}
-  //               doorName={door.name}
-  //               levelName={level.name}
-  //               doorType={door.door_type}
-  //             />
-  //           )),
-  //         )}
-  //     </TableBody>
-  //   </Table>
-  // );
+  return <DoorDataGridTable doors={Object.values(doorTableData).flatMap((d) => d)} />;
 });

--- a/packages/react-components/lib/doors/door-table-datagrid.spec.tsx
+++ b/packages/react-components/lib/doors/door-table-datagrid.spec.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { DoorTableData, DoorDataGridTable } from './door-table-datagrid';
+import { Door as RmfDoor, DoorMode as RmfDoorMode } from 'rmf-models';
+import { makeDoorState } from './test-utils.spec';
+
+describe('DoorDataGridTable', () => {
+  const mockDoors: DoorTableData[] = [
+    {
+      index: 1,
+      doorName: 'L3_door2',
+      levelName: 'L3',
+      doorType: RmfDoor.DOOR_TYPE_SINGLE_SWING,
+      doorState: makeDoorState({
+        door_name: 'L3_door2',
+        current_mode: { value: RmfDoorMode.MODE_MOVING },
+      }),
+    },
+  ];
+
+  it('renders doors data correctly', () => {
+    const root = render(<DoorDataGridTable doors={mockDoors} />);
+    const doorName = root.getByText('L3_door2');
+    const levelName = root.getByText('L3');
+    const doorType = root.getByText('Single Swing');
+    const doorState = root.getByText('MOVING');
+
+    expect(doorName).toBeTruthy();
+    expect(levelName).toBeTruthy();
+    expect(doorType).toBeTruthy();
+    expect(doorState).toBeTruthy();
+  });
+
+  it('shows the correct number of rows', () => {
+    const root = render(<DoorDataGridTable doors={mockDoors} />);
+    const allRows = root.container.querySelectorAll('.MuiDataGrid-row').length;
+    expect(allRows).toBe(1);
+  });
+
+  it('shows titles correctly', () => {
+    const root = render(<DoorDataGridTable doors={mockDoors} />);
+    expect(root.queryByText('Name')).toBeTruthy();
+    expect(root.queryByText('Current floor')).toBeTruthy();
+    expect(root.queryByText('Type')).toBeTruthy();
+    expect(root.queryByText('Door state')).toBeTruthy();
+  });
+});

--- a/packages/react-components/lib/doors/door-table-datagrid.stories.tsx
+++ b/packages/react-components/lib/doors/door-table-datagrid.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { DoorTableData, DoorDataGridTable } from './door-table-datagrid';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { Door as RmfDoor, DoorMode as RmfDoorMode } from 'rmf-models';
+import { makeDoorState } from './test-utils.spec';
+
+const mockDoors: DoorTableData[] = [
+  {
+    index: 1,
+    doorName: 'L3_door2',
+    levelName: 'L3',
+    doorType: RmfDoor.DOOR_TYPE_SINGLE_SWING,
+    doorState: makeDoorState({
+      door_name: 'L3_door2',
+      current_mode: { value: RmfDoorMode.MODE_MOVING },
+    }),
+    onClickOpen: action('onClickOpen'),
+    onClickClose: action('onClickClose'),
+  },
+];
+
+storiesOf('DoorDataGridTable', module)
+  .add('Default', () => <DoorDataGridTable doors={mockDoors} />)
+  .add('Empty', () => <DoorDataGridTable doors={[]} />);

--- a/packages/react-components/lib/doors/door-table-datagrid.tsx
+++ b/packages/react-components/lib/doors/door-table-datagrid.tsx
@@ -1,5 +1,5 @@
 import { DataGrid, GridColDef, GridValueGetterParams, GridCellParams } from '@mui/x-data-grid';
-import { Box, SxProps, Typography, useTheme } from '@mui/material';
+import { Box, Button, SxProps, Typography, useTheme } from '@mui/material';
 import * as React from 'react';
 import { DoorState } from 'api-client';
 import { DoorMode } from 'rmf-models';
@@ -11,12 +11,8 @@ export interface DoorTableData {
   levelName: string;
   doorType: number;
   doorState?: DoorState;
-  onRequestSubmit?(
-    event: React.FormEvent,
-    doorState: number,
-    requestType: number,
-    destination: string,
-  ): void;
+  onClickOpen?(): void;
+  onClickClose?(): void;
 }
 
 export interface DoorDataGridTableProps {
@@ -25,6 +21,7 @@ export interface DoorDataGridTableProps {
 
 export function DoorDataGridTable({ doors }: DoorDataGridTableProps): JSX.Element {
   const theme = useTheme();
+
   const DoorState = (params: GridCellParams): React.ReactNode => {
     const labelStyle: SxProps = React.useMemo<SxProps>(() => {
       const disabled = {
@@ -64,6 +61,30 @@ export function DoorDataGridTable({ doors }: DoorDataGridTableProps): JSX.Elemen
         >
           {params.row.doorState ? doorModeToString(params.row.doorState.current_mode.value) : -1}
         </Typography>
+      </Box>
+    );
+  };
+
+  const OpenCloseButtons = (params: GridCellParams): React.ReactNode => {
+    return (
+      <Box sx={{ margin: 0, padding: 0, paddingRight: 1 }}>
+        <Button
+          variant="contained"
+          size="small"
+          aria-label="open"
+          sx={{ marginRight: 2 }}
+          onClick={params.row.onClickOpen}
+        >
+          Open
+        </Button>
+        <Button
+          variant="contained"
+          size="small"
+          aria-label="close"
+          onClick={params.row.onClickClose}
+        >
+          Close
+        </Button>
       </Box>
     );
   };
@@ -109,6 +130,7 @@ export function DoorDataGridTable({ doors }: DoorDataGridTableProps): JSX.Elemen
       headerName: '',
       width: 150,
       editable: false,
+      renderCell: OpenCloseButtons,
       flex: 1,
       filterable: true,
     },

--- a/packages/react-components/lib/doors/index.ts
+++ b/packages/react-components/lib/doors/index.ts
@@ -1,3 +1,4 @@
 export * from './door-card';
 export * from './door-controls';
 export * from './utils';
+export * from './door-table-datagrid';


### PR DESCRIPTION
## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->
- Migrate door table to datagrid mui
- New test file was added
- New storybook file was added
- Removed the use of the basic table and instead used mui's datagrid.

[chrome-capture-2023-5-6.webm](https://github.com/open-rmf/rmf-web/assets/37310205/7dc77d0b-338e-4cbd-a19a-87d2c4f0bc61)


## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
