### PR TITLE
Fix/get health status description

### DIFF
--- a/packages/react-components/lib/doors/door-card.tsx
+++ b/packages/react-components/lib/doors/door-card.tsx
@@ -1,7 +1,7 @@
 import { Card, CardContent, CardProps, Grid, SxProps, Typography, useTheme } from '@mui/material';
 import React from 'react';
 import { DoorMode } from 'rmf-models';
-import { doorModeToString, doorTypeToString } from './utils';
+import { doorModeToString, doorTypeToString } from './door-utils';
 
 export interface DoorCardProps extends CardProps {
   name: string;

--- a/packages/react-components/lib/doors/door-table-datagrid.tsx
+++ b/packages/react-components/lib/doors/door-table-datagrid.tsx
@@ -3,12 +3,8 @@ import { Box, Button, SxProps, Typography, useTheme } from '@mui/material';
 import * as React from 'react';
 import { DoorState } from 'api-client';
 import { DoorMode } from 'rmf-models';
-import {
-  HealthStatus,
-  doorModeToString,
-  doorTypeToString,
-  getHealthStatusDescription,
-} from './utils';
+import { doorModeToString, doorTypeToString } from './door-utils';
+import { HealthStatus, healthStatusToOpMode } from '../utils';
 
 export interface DoorTableData {
   index: number;
@@ -65,7 +61,7 @@ export function DoorDataGridTable({ doors }: DoorDataGridTableProps): JSX.Elemen
             fontSize: 14,
           }}
         >
-          {getHealthStatusDescription(params.row.opMode)}
+          {healthStatusToOpMode(params.row.opMode)}
         </Typography>
       </Box>
     );

--- a/packages/react-components/lib/doors/door-utils.ts
+++ b/packages/react-components/lib/doors/door-utils.ts
@@ -20,13 +20,6 @@ export enum DoorMode {
   Moving = RmfDoorMode.MODE_MOVING,
 }
 
-// Using an enum because the api client has not generated the HealthStatus
-export enum HealthStatus {
-  Healthy = 'Healthy',
-  Unhealthy = 'Unhealthy',
-  Dead = 'Dead',
-}
-
 export interface DoorData {
   level: string;
   door: RmfDoor;
@@ -64,18 +57,5 @@ export function doorTypeToString(doorType: number): string {
       return 'Single Telescope';
     default:
       return `Unknown (${doorType})`;
-  }
-}
-
-export function getHealthStatusDescription(healthStatus: string): string {
-  switch (healthStatus) {
-    case HealthStatus.Healthy:
-      return 'ONLINE';
-    case HealthStatus.Unhealthy:
-      return 'UNSTABLE';
-    case HealthStatus.Dead:
-      return 'OFFLINE';
-    default:
-      return `Unknown ${healthStatus}`;
   }
 }

--- a/packages/react-components/lib/doors/index.ts
+++ b/packages/react-components/lib/doors/index.ts
@@ -1,4 +1,4 @@
 export * from './door-card';
 export * from './door-controls';
-export * from './utils';
+export * from './door-utils';
 export * from './door-table-datagrid';

--- a/packages/react-components/lib/lifts/lift-table-datagrid.spec.tsx
+++ b/packages/react-components/lib/lifts/lift-table-datagrid.spec.tsx
@@ -43,6 +43,6 @@ describe('LiftDataGridTable', () => {
     expect(root.queryByText('Name')).toBeTruthy();
     expect(root.queryByText('Current Floor')).toBeTruthy();
     expect(root.queryByText('Destination Floor')).toBeTruthy();
-    expect(root.queryByText('Door State')).toBeTruthy();
+    expect(root.queryByText('Lift State')).toBeTruthy();
   });
 });

--- a/packages/react-components/lib/lifts/lift-table-datagrid.tsx
+++ b/packages/react-components/lib/lifts/lift-table-datagrid.tsx
@@ -76,7 +76,7 @@ export function LiftDataGridTable({ lifts }: LiftDataGridTableProps): JSX.Elemen
     );
   };
 
-  const DoorState = (params: GridCellParams): React.ReactNode => {
+  const LiftState = (params: GridCellParams): React.ReactNode => {
     const currDoorMotion = doorStateToString(params.row?.doorState);
     const currMotion = motionStateToString(params.row?.motionState);
 
@@ -179,12 +179,12 @@ export function LiftDataGridTable({ lifts }: LiftDataGridTableProps): JSX.Elemen
       filterable: true,
     },
     {
-      field: 'doorState',
-      headerName: 'Door State',
+      field: 'liftState',
+      headerName: 'Lift State',
       width: 150,
       editable: false,
       flex: 1,
-      renderCell: DoorState,
+      renderCell: LiftState,
       filterable: true,
     },
     {

--- a/packages/react-components/lib/lifts/lift-table-datagrid.tsx
+++ b/packages/react-components/lib/lifts/lift-table-datagrid.tsx
@@ -5,12 +5,8 @@ import { Lift } from 'api-client';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import { LiftState as LiftStateModel } from 'rmf-models';
-import {
-  HealthStatus,
-  doorStateToString,
-  getHealthStatusDescription,
-  motionStateToString,
-} from './lift-utils';
+import { doorStateToString, motionStateToString } from './lift-utils';
+import { HealthStatus, healthStatusToOpMode } from '../utils';
 import { LiftControls } from './lift-controls';
 
 export interface LiftTableData {
@@ -74,7 +70,7 @@ export function LiftDataGridTable({ lifts }: LiftDataGridTableProps): JSX.Elemen
             fontSize: 14,
           }}
         >
-          {getHealthStatusDescription(params.row.opMode)}
+          {healthStatusToOpMode(params.row.opMode)}
         </Typography>
       </Box>
     );

--- a/packages/react-components/lib/lifts/lift-utils.ts
+++ b/packages/react-components/lib/lifts/lift-utils.ts
@@ -1,12 +1,5 @@
 import { LiftRequest as RmfLiftRequest, LiftState as RmfLiftState } from 'rmf-models';
 
-// Using an enum because the api client has not generated the HealthStatus
-export enum HealthStatus {
-  Healthy = 'Healthy',
-  Unhealthy = 'Unhealthy',
-  Dead = 'Dead',
-}
-
 export function liftModeToString(liftMode?: number): string {
   if (liftMode === undefined) {
     return `Unknown (${liftMode})`;
@@ -24,19 +17,6 @@ export function liftModeToString(liftMode?: number): string {
       return 'Offline';
     default:
       return `Unknown (${liftMode})`;
-  }
-}
-
-export function getHealthStatusDescription(healthStatus: string): string {
-  switch (healthStatus) {
-    case HealthStatus.Healthy:
-      return 'ONLINE';
-    case HealthStatus.Unhealthy:
-      return 'UNSTABLE';
-    case HealthStatus.Dead:
-      return 'OFFLINE';
-    default:
-      return `Unknown ${healthStatus}`;
   }
 }
 

--- a/packages/react-components/lib/utils/health.ts
+++ b/packages/react-components/lib/utils/health.ts
@@ -1,0 +1,29 @@
+/**
+ * Health status as an enum as the api-client does not generate and expose
+ * HealthStatus.
+ * TODO(AA): Generate unexposed enums for api-client to reduce duplicated
+ * declarations.
+ */
+export enum HealthStatus {
+  Healthy = 'Healthy',
+  Unhealthy = 'Unhealthy',
+  Dead = 'Dead',
+}
+
+/**
+ * Returns the Op Mode based on the health status.
+ * @param healthStatus The enum strings from HealthStatus
+ * @returns Op mode
+ */
+export function healthStatusToOpMode(healthStatus: string): string {
+  switch (healthStatus) {
+    case HealthStatus.Healthy:
+      return 'ONLINE';
+    case HealthStatus.Unhealthy:
+      return 'UNSTABLE';
+    case HealthStatus.Dead:
+      return 'OFFLINE';
+    default:
+      return `Unknown ${healthStatus}`;
+  }
+}

--- a/packages/react-components/lib/utils/index.ts
+++ b/packages/react-components/lib/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './geometry';
-export * from './misc';
+export * from './health';
 export * from './item-table';
+export * from './misc';


### PR DESCRIPTION
## What's new

* Fixes duplicated declarations of health status/op mode related calls. Moved to common health utils
* Renamed Door State to Lift State for lift datagrid column 


## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
