### PR TITLE
Add hover tooltips

### DIFF
--- a/packages/dashboard/src/components/appbar.tsx
+++ b/packages/dashboard/src/components/appbar.tsx
@@ -385,16 +385,18 @@ export const AppBar = React.memo(({ extraToolbarItems }: AppBarProps): React.Rea
             <AddOutlined />
             New Task
           </Button>
-          <IconButton
-            id="alert-list-button"
-            aria-label="alert-list-button"
-            color="inherit"
-            onClick={handleOpenAlertList}
-          >
-            <Badge badgeContent={unacknowledgedAlertsNum} color="secondary">
-              <Notifications />
-            </Badge>
-          </IconButton>
+          <Tooltip title="Notifications">
+            <IconButton
+              id="alert-list-button"
+              aria-label="alert-list-button"
+              color="inherit"
+              onClick={handleOpenAlertList}
+            >
+              <Badge badgeContent={unacknowledgedAlertsNum} color="secondary">
+                <Notifications />
+              </Badge>
+            </IconButton>
+          </Tooltip>
           <Menu
             anchorEl={alertListAnchor}
             open={!!alertListAnchor}
@@ -451,14 +453,16 @@ export const AppBar = React.memo(({ extraToolbarItems }: AppBarProps): React.Rea
           <Divider orientation="vertical" sx={{ marginLeft: 1, marginRight: 2 }} />
           <Typography variant="caption">Powered by Open-RMF</Typography>
           {extraToolbarItems}
-          <IconButton
-            id="show-settings-btn"
-            aria-label="settings"
-            color="inherit"
-            onClick={(ev) => setSettingsAnchor(ev.currentTarget)}
-          >
-            <Settings />
-          </IconButton>
+          <Tooltip title="Settings">
+            <IconButton
+              id="show-settings-btn"
+              aria-label="settings"
+              color="inherit"
+              onClick={(ev) => setSettingsAnchor(ev.currentTarget)}
+            >
+              <Settings />
+            </IconButton>
+          </Tooltip>
           <Tooltip title="Help">
             <IconButton
               id="show-help-btn"
@@ -481,14 +485,16 @@ export const AppBar = React.memo(({ extraToolbarItems }: AppBarProps): React.Rea
           </Tooltip>
           {profile && (
             <>
-              <IconButton
-                id="user-btn"
-                aria-label={'user-btn'}
-                color="inherit"
-                onClick={(event) => setAnchorEl(event.currentTarget)}
-              >
-                <AccountCircle />
-              </IconButton>
+              <Tooltip title="Profile">
+                <IconButton
+                  id="user-btn"
+                  aria-label={'user-btn'}
+                  color="inherit"
+                  onClick={(event) => setAnchorEl(event.currentTarget)}
+                >
+                  <AccountCircle />
+                </IconButton>
+              </Tooltip>
               <Menu
                 anchorEl={anchorEl}
                 anchorOrigin={{

--- a/packages/dashboard/src/components/tasks/tasks-app.tsx
+++ b/packages/dashboard/src/components/tasks/tasks-app.tsx
@@ -178,16 +178,18 @@ export const TasksApp = React.memo(
           toolbar={
             <Toolbar variant="dense">
               <div>
-                <IconButton
-                  id="export-button"
-                  aria-controls={openExportMenu ? 'export-menu' : undefined}
-                  aria-haspopup="true"
-                  aria-expanded={openExportMenu ? 'true' : undefined}
-                  onClick={handleClickExportMenu}
-                  color="inherit"
-                >
-                  <DownloadIcon />
-                </IconButton>
+                <Tooltip title="Download" placement="top">
+                  <IconButton
+                    id="export-button"
+                    aria-controls={openExportMenu ? 'export-menu' : undefined}
+                    aria-haspopup="true"
+                    aria-expanded={openExportMenu ? 'true' : undefined}
+                    onClick={handleClickExportMenu}
+                    color="inherit"
+                  >
+                    <DownloadIcon />
+                  </IconButton>
+                </Tooltip>
                 <Menu
                   id="export-menu"
                   MenuListProps={{


### PR DESCRIPTION
## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

- Hover tooltips were added in appbar and taskapp

[chrome-capture-2023-5-15.webm](https://github.com/open-rmf/rmf-web/assets/37310205/e47c48c6-7c29-475f-af94-1cc977f03716)



## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
