### PR TITLE
Doc/mention internal endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ cd packages/dashboard
 pnpm start
 ```
 
-This starts up the API server which sets up endpoints to communicate with an Open-RMF deployment, as well as begin compilation of the dashboard. Once completed, it can be viewed at [localhost:3000](http://localhost:3000).
+This starts up the API server (by default at port 8000) which sets up endpoints to communicate with an Open-RMF deployment, as well as begin compilation of the dashboard. Once completed, it can be viewed at [localhost:3000](http://localhost:3000).
 
 If presented with a login screen, use `user=admin password=admin`.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,11 @@ This starts up the API server which sets up endpoints to communicate with an Ope
 
 If presented with a login screen, use `user=admin password=admin`.
 
-Ensure that the Open-RMF deployment is configured to use the endpoints of the API server. By default it is `http://localhost:8000/_internal`.
+Ensure that the Open-RMF deployment is configured to use the endpoints of the API server. By default it is `http://localhost:8000/_internal`. Launching a simulation from `rmf_demos` for example, the command would be,
+
+```bash
+ros2 launch rmf_demos_gz office.launch.xml server_uri:="http://localhost:8000/_internal"
+```
 
 ### Optimized build
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ This starts up the API server which sets up endpoints to communicate with an Ope
 
 If presented with a login screen, use `user=admin password=admin`.
 
+Ensure that the Open-RMF deployment is configured to use the endpoints of the API server. By default it is `http://localhost:8000/_internal`.
+
 ### Optimized build
 
 The dashboard can also be built statically for better performance.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ This starts up the API server which sets up endpoints to communicate with an Ope
 
 If presented with a login screen, use `user=admin password=admin`.
 
-Ensure that the Open-RMF deployment is configured to use the endpoints of the API server. By default it is `http://localhost:8000/_internal`. Launching a simulation from `rmf_demos` for example, the command would be,
+Ensure that the fleet adapters in the Open-RMF deployment is configured to use the endpoints of the API server. By default it is `http://localhost:8000/_internal`. Launching a simulation from `rmf_demos_gz` for example, the command would be,
 
 ```bash
 ros2 launch rmf_demos_gz office.launch.xml server_uri:="http://localhost:8000/_internal"


### PR DESCRIPTION
## What's new

Mention default port of API server, and how Open-RMF fleet adapters can work with the endpoints. 

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test