### PR TITLE
Ends on scheduling recurrences

### DIFF
--- a/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
+++ b/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
@@ -68,7 +68,9 @@ class ScheduledTaskSchedule(Model):
             job = schedule.every()
         if self.until is not None:
             # schedule uses `datetime.now()`, which is tz naive
-            job = job.until(datetime.fromtimestamp(self.until.timestamp()))
+            # Assuming self.until is a datetime object with timezone information
+            # Convert the timestamp to datetime without changing the timezone
+            job = job.until(datetime.utcfromtimestamp(self.until.timestamp()))
 
         if self.period in (
             ScheduledTaskSchedule.Period.Monday,

--- a/packages/dashboard/src/components/appbar.tsx
+++ b/packages/dashboard/src/components/appbar.tsx
@@ -123,16 +123,17 @@ function toApiSchedule(taskRequest: TaskRequest, schedule: Schedule): PostSchedu
   const apiSchedules: PostScheduledTaskRequest['schedules'] = [];
   const date = new Date(start);
   const start_from = start.toISOString();
+  const until = schedule.until?.toISOString();
   const hours = date.getHours().toString().padStart(2, '0');
   const minutes = date.getMinutes().toString().padStart(2, '0');
   const at = `${hours}:${minutes}`;
-  schedule.days[0] && apiSchedules.push({ period: 'monday', start_from, at });
-  schedule.days[1] && apiSchedules.push({ period: 'tuesday', start_from, at });
-  schedule.days[2] && apiSchedules.push({ period: 'wednesday', start_from, at });
-  schedule.days[3] && apiSchedules.push({ period: 'thursday', start_from, at });
-  schedule.days[4] && apiSchedules.push({ period: 'friday', start_from, at });
-  schedule.days[5] && apiSchedules.push({ period: 'saturday', start_from, at });
-  schedule.days[6] && apiSchedules.push({ period: 'sunday', start_from, at });
+  schedule.days[0] && apiSchedules.push({ period: 'monday', start_from, at, until });
+  schedule.days[1] && apiSchedules.push({ period: 'tuesday', start_from, at, until });
+  schedule.days[2] && apiSchedules.push({ period: 'wednesday', start_from, at, until });
+  schedule.days[3] && apiSchedules.push({ period: 'thursday', start_from, at, until });
+  schedule.days[4] && apiSchedules.push({ period: 'friday', start_from, at, until });
+  schedule.days[5] && apiSchedules.push({ period: 'saturday', start_from, at, until });
+  schedule.days[6] && apiSchedules.push({ period: 'sunday', start_from, at, until });
   return {
     task_request: taskRequest,
     schedules: apiSchedules,

--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -19,7 +19,6 @@ import {
   FormControl,
   FormControlLabel,
   FormHelperText,
-  FormLabel,
   Grid,
   IconButton,
   List,

--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -18,6 +18,7 @@ import {
   Divider,
   FormControl,
   FormControlLabel,
+  FormHelperText,
   FormLabel,
   Grid,
   IconButton,
@@ -1278,46 +1279,41 @@ export function CreateTaskForm({
             </Grid>
           </Grid>
           <Grid container marginTop={theme.spacing(1)} marginLeft={theme.spacing(0)}>
-            <FormControl>
-              <FormLabel id="controlled-radio-buttons-group">Ends</FormLabel>
+            <FormControl fullWidth={true}>
+              <FormHelperText>Ends</FormHelperText>
               <RadioGroup
                 aria-labelledby="controlled-radio-buttons-group"
                 name="controlled-radio-buttons-group"
                 value={scheduleUntilValue}
                 onChange={handleScheduleUntilValue}
+                row
               >
-                <FormControlLabel
-                  value={ScheduleUntilValue.NEVER}
-                  control={<Radio />}
-                  label="Never"
-                />
-                <Grid container direction="row" alignItems="center" spacing={2}>
-                  <Grid item xs={6}>
-                    <FormControlLabel
-                      value={ScheduleUntilValue.ON}
-                      control={<Radio />}
-                      label="On"
-                    />
-                  </Grid>
-                  <Grid item xs={6}>
-                    <DatePicker
-                      value={
-                        scheduleUntilValue === ScheduleUntilValue.NEVER
-                          ? new Date()
-                          : schedule.until
-                      }
-                      onChange={(date) =>
-                        date &&
-                        setSchedule((prev) => {
-                          date.setHours(23);
-                          date.setMinutes(59);
-                          return { ...prev, until: date };
-                        })
-                      }
-                      disabled={scheduleUntilValue !== ScheduleUntilValue.ON}
-                      renderInput={(props) => <TextField {...props} fullWidth />}
-                    />
-                  </Grid>
+                <Grid item xs={6} paddingLeft={theme.spacing(1)}>
+                  <FormControlLabel
+                    value={ScheduleUntilValue.NEVER}
+                    control={<Radio />}
+                    label="Never"
+                  />
+                </Grid>
+                <Grid item xs={2} paddingLeft={theme.spacing(1)}>
+                  <FormControlLabel value={ScheduleUntilValue.ON} control={<Radio />} label="On" />
+                </Grid>
+                <Grid item xs={4}>
+                  <DatePicker
+                    value={
+                      scheduleUntilValue === ScheduleUntilValue.NEVER ? new Date() : schedule.until
+                    }
+                    onChange={(date) =>
+                      date &&
+                      setSchedule((prev) => {
+                        date.setHours(23);
+                        date.setMinutes(59);
+                        return { ...prev, until: date };
+                      })
+                    }
+                    disabled={scheduleUntilValue !== ScheduleUntilValue.ON}
+                    renderInput={(props) => <TextField {...props} fullWidth />}
+                  />
                 </Grid>
               </RadioGroup>
             </FormControl>


### PR DESCRIPTION
## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->
- End date added for recurring tasks
- Ending date is inclusive

#### How test it?
- Create a scheduled task. 
- Choose the ON option under "Ends" and set an until date.
- The scheduling screen should show only tasks up to the chosen date. 

[chrome-capture-2023-6-21.webm](https://github.com/open-rmf/rmf-web/assets/37310205/9f265ad0-12c1-4181-8631-8230d1aa60e1)


## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
