### PR TITLE
Feature/display adhooc or scheduled

### DIFF
--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -884,8 +884,10 @@ export function CreateTaskForm({
       return;
     }
 
+    const requester = scheduling ? `${user}__scheduled` : user;
+
     for (const t of taskRequests) {
-      t.requester = user;
+      t.requester = requester;
       t.unix_millis_request_time = Date.now();
     }
 

--- a/packages/react-components/lib/tasks/task-table-datagrid.tsx
+++ b/packages/react-components/lib/tasks/task-table-datagrid.tsx
@@ -11,9 +11,10 @@ import {
   GridFilterModel,
   GridSortModel,
 } from '@mui/x-data-grid';
-import { styled, TextField } from '@mui/material';
+import { styled, TextField, Stack, Typography } from '@mui/material';
 import * as React from 'react';
 import { TaskState, Status } from 'api-client';
+import { InsertInvitation as ScheduleIcon, Person as UserIcon } from '@mui/icons-material/';
 
 const classes = {
   taskActiveCell: 'MuiDataGrid-cell-active-cell',
@@ -134,11 +135,24 @@ export function TaskDataGridTable({
     {
       field: 'requester',
       headerName: 'Requester',
-      width: 150,
+      minWidth: 160,
       editable: false,
-      valueGetter: (params: GridValueGetterParams) =>
-        params.row.booking.requester ? params.row.booking.requester : 'unknown',
-      flex: 1,
+      renderCell: (cellValues) => {
+        return (
+          <Stack direction="row" alignItems="center" gap={1}>
+            {cellValues.row.booking.requester &&
+            cellValues.row.booking.requester.includes('scheduled') ? (
+              <ScheduleIcon />
+            ) : (
+              <UserIcon />
+            )}
+            <Typography variant="body1">
+              {cellValues.row.booking.requester ? cellValues.row.booking.requester : 'unknown'}
+            </Typography>
+          </Stack>
+        );
+      },
+      flex: 2,
       filterOperators: getMinimalStringFilterOperators,
       filterable: true,
     },


### PR DESCRIPTION
## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

- Display on task queue whether task was scheduled or ad-hoc
- For now, automatic robot tasks do not have a distinct icon due we have not a way to differential it from real users since the name is the ROS 2 node name

![chrome-capture-2023-6-31](https://github.com/open-rmf/rmf-web/assets/37310205/479cab93-180d-412a-9965-3bbc4a9c86c3)


<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
