### PR TITLE
Deletes all existing building map entries if the id does not match the current served map, before saving

### DIFF
--- a/packages/api-server/api_server/models/building_map.py
+++ b/packages/api-server/api_server/models/building_map.py
@@ -21,7 +21,7 @@ class BuildingMap(rmf_building_map_msgs.BuildingMap):
 
     async def save(self) -> None:
         existing_maps = await ttm.BuildingMap.all()
-        for map in existing_maps:
-            if map.id_ != self.name:
-                await map.delete()
+        for m in existing_maps:
+            if m.id_ != self.name:
+                await m.delete()
         await ttm.BuildingMap.update_or_create({"data": self.dict()}, id_=self.name)

--- a/packages/api-server/api_server/models/building_map.py
+++ b/packages/api-server/api_server/models/building_map.py
@@ -20,4 +20,8 @@ class BuildingMap(rmf_building_map_msgs.BuildingMap):
         return BuildingMap(**tortoise.data)
 
     async def save(self) -> None:
+        existing_maps = await ttm.BuildingMap.all()
+        for map in existing_maps:
+            if map.id_ != self.name:
+                await map.delete()
         await ttm.BuildingMap.update_or_create({"data": self.dict()}, id_=self.name)


### PR DESCRIPTION
## What's new

Ensures that the map saved in db is always the one that is currently being served by the building map server.

This can be tested by starting an api-server instance, and changing the building map server,

```
# start api-server in a terminal
pnpm start

# serve office map, Ctrl+C, serve airport terminal map, repeat
ros2 run rmf_building_map_tools building_map_server WORKSPACE_DIR/install/rmf_demos_maps/share/rmf_demos_maps/office/office.building.yaml
ros2 run rmf_building_map_tools building_map_server WORKSPACE_DIR/install/rmf_demos_maps/share/rmf_demos_maps/airport_terminal/airport_terminal.building.yaml
```

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test
