### PR TITLE
Fix panning rotation issue

### DIFF
--- a/packages/dashboard/src/components/map-app.tsx
+++ b/packages/dashboard/src/components/map-app.tsx
@@ -401,7 +401,9 @@ export const MapApp = styled(
     );
     const [distance, setDistance] = React.useState<number>(0);
 
-    React.useMemo(() => setSceneBoundingBox(findSceneBoundingBox(currentLevel)), [currentLevel]);
+    React.useMemo(() => {
+      setSceneBoundingBox(findSceneBoundingBox(currentLevel));
+    }, [currentLevel]);
 
     React.useEffect(() => {
       if (!sceneBoundingBox) {
@@ -574,13 +576,21 @@ export const MapApp = styled(
             }
             const center = sceneBoundingBox.getCenter(new THREE.Vector3());
             camera.position.set(center.x, center.y, center.z + distance);
+            camera.zoom = 20;
             console.log(camera);
             camera.updateProjectionMatrix();
           }}
+          orthographic={true}
         >
           <OrbitControls
-            target={sceneBoundingBox?.getCenter(new THREE.Vector3())}
-            maxDistance={distance}
+            target={new THREE.Vector3(0, 0, -1000)}
+            enableRotate={false}
+            enableDamping={false}
+            mouseButtons={{
+              LEFT: THREE.MOUSE.PAN,
+              MIDDLE: undefined,
+              RIGHT: undefined,
+            }}
           />
           <BuildingCubes level={currentLevel} lifts={buildingMap.lifts} />
           {waypoints.map((place, index) => (


### PR DESCRIPTION
## What's new

Related to https://github.com/open-rmf/rmf-web/issues/734

* Use orthographic camera by default
* Target of orthographic camera set to 1km below origin, this fixes the re-orientation when we pan
* Changing left click to panning
* Disabling all other mouse interations (rotation and dolly)
* Using a fixed zoom of 20 for now, this should be configurable later on

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test