### PR TITLE
Fixing missing handler delivery task description

### DIFF
--- a/packages/react-components/lib/place.ts
+++ b/packages/react-components/lib/place.ts
@@ -7,35 +7,13 @@ const DEFAULT_CLEANING_ZONE_PARAM_NAME = 'is_cleaning_zone';
 export interface Place {
   level: string;
   vertex: GraphNode;
-}
-
-export interface NamedPlaces {
-  places: Place[];
-  pickupPoints: Place[];
-  dropoffPoints: Place[];
-  cleaningZones: Place[];
+  pickupHandler?: string;
+  dropoffHandler?: string;
+  cleaningZone?: boolean;
 }
 
 export function getPlaces(buildingMap: BuildingMap): Place[] {
-  const places: Place[] = [];
-  for (const level of buildingMap.levels) {
-    for (const graphs of level.nav_graphs) {
-      for (const vertex of graphs.vertices) {
-        if (vertex.name) {
-          places.push({ level: level.name, vertex });
-        }
-      }
-    }
-  }
-  return places;
-}
-
-export function getNamedPlaces(buildingMap: BuildingMap): NamedPlaces {
   const places = new Map<string, Place>();
-  const pickupPoints = new Map<string, Place>();
-  const dropoffPoints = new Map<string, Place>();
-  const cleaningZones = new Map<string, Place>();
-
   for (const level of buildingMap.levels) {
     for (const graphs of level.nav_graphs) {
       for (const vertex of graphs.vertices) {
@@ -45,23 +23,18 @@ export function getNamedPlaces(buildingMap: BuildingMap): NamedPlaces {
         const place: Place = { level: level.name, vertex };
         for (const p of vertex.params) {
           if (p.name === DEFAULT_PICKUP_POINT_PARAM_NAME) {
-            pickupPoints.set(vertex.name, place);
+            place.pickupHandler = p.value_string;
           }
           if (p.name === DEFAULT_DROPOFF_POINT_PARAM_NAME) {
-            dropoffPoints.set(vertex.name, place);
+            place.dropoffHandler = p.value_string;
           }
           if (p.name === DEFAULT_CLEANING_ZONE_PARAM_NAME) {
-            cleaningZones.set(vertex.name, place);
+            place.cleaningZone = true;
           }
         }
         places.set(vertex.name, place);
       }
     }
   }
-  return {
-    places: Array.from(places.values()),
-    pickupPoints: Array.from(pickupPoints.values()),
-    dropoffPoints: Array.from(dropoffPoints.values()),
-    cleaningZones: Array.from(cleaningZones.values()),
-  };
+  return Array.from(places.values());
 }

--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -170,17 +170,17 @@ function DeliveryTaskForm({
               },
             })
           }
-          onBlur={(ev) => {
+          onBlur={(ev) =>
             pickupPoints[(ev.target as HTMLInputElement).value] &&
-              onChange({
-                ...taskDesc,
-                pickup: {
-                  ...taskDesc.pickup,
-                  place: (ev.target as HTMLInputElement).value,
-                  handler: pickupPoints[(ev.target as HTMLInputElement).value],
-                },
-              });
-          }}
+            onChange({
+              ...taskDesc,
+              pickup: {
+                ...taskDesc.pickup,
+                place: (ev.target as HTMLInputElement).value,
+                handler: pickupPoints[(ev.target as HTMLInputElement).value],
+              },
+            })
+          }
           renderInput={(params) => <TextField {...params} label="Pickup Location" />}
         />
       </Grid>
@@ -273,17 +273,17 @@ function DeliveryTaskForm({
               },
             })
           }
-          onBlur={(ev) => {
+          onBlur={(ev) =>
             dropoffPoints[(ev.target as HTMLInputElement).value] &&
-              onChange({
-                ...taskDesc,
-                dropoff: {
-                  ...taskDesc.dropoff,
-                  place: (ev.target as HTMLInputElement).value,
-                  handler: dropoffPoints[(ev.target as HTMLInputElement).value],
-                },
-              });
-          }}
+            onChange({
+              ...taskDesc,
+              dropoff: {
+                ...taskDesc.dropoff,
+                place: (ev.target as HTMLInputElement).value,
+                handler: dropoffPoints[(ev.target as HTMLInputElement).value],
+              },
+            })
+          }
           renderInput={(params) => <TextField {...params} label="Dropoff Location" />}
         />
       </Grid>

--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -45,6 +45,7 @@ import { PositiveIntField } from '../form-inputs';
 interface DeliveryTaskDescription {
   pickup: {
     place: string;
+    handler: string;
     payload: {
       sku: string;
       quantity: number;
@@ -52,6 +53,7 @@ interface DeliveryTaskDescription {
   };
   dropoff: {
     place: string;
+    handler: string;
     payload: {
       sku: string;
       quantity: number;
@@ -134,15 +136,15 @@ function FormToolbar({ onSelectFileClick }: FormToolbarProps) {
 
 interface DeliveryTaskFormProps {
   taskDesc: DeliveryTaskDescription;
-  pickupPoints: string[];
-  dropoffPoints: string[];
+  pickupPoints: Record<string, string>;
+  dropoffPoints: Record<string, string>;
   onChange(taskDesc: TaskDescription): void;
 }
 
 function DeliveryTaskForm({
   taskDesc,
-  pickupPoints,
-  dropoffPoints,
+  pickupPoints = {},
+  dropoffPoints = {},
   onChange,
 }: DeliveryTaskFormProps) {
   const theme = useTheme();
@@ -154,27 +156,31 @@ function DeliveryTaskForm({
           id="pickup-location"
           freeSolo
           fullWidth
-          options={pickupPoints}
+          options={Object.keys(pickupPoints)}
           value={taskDesc.pickup.place}
           onChange={(_ev, newValue) =>
             newValue !== null &&
+            pickupPoints[newValue] &&
             onChange({
               ...taskDesc,
               pickup: {
                 ...taskDesc.pickup,
                 place: newValue,
+                handler: pickupPoints[newValue],
               },
             })
           }
-          onBlur={(ev) =>
-            onChange({
-              ...taskDesc,
-              pickup: {
-                ...taskDesc.pickup,
-                place: (ev.target as HTMLInputElement).value,
-              },
-            })
-          }
+          onBlur={(ev) => {
+            pickupPoints[(ev.target as HTMLInputElement).value] &&
+              onChange({
+                ...taskDesc,
+                pickup: {
+                  ...taskDesc.pickup,
+                  place: (ev.target as HTMLInputElement).value,
+                  handler: pickupPoints[(ev.target as HTMLInputElement).value],
+                },
+              });
+          }}
           renderInput={(params) => <TextField {...params} label="Pickup Location" />}
         />
       </Grid>
@@ -202,7 +208,7 @@ function DeliveryTaskForm({
             onChange({
               ...taskDesc,
               pickup: {
-                ...taskDesc.dropoff,
+                ...taskDesc.pickup,
                 payload: {
                   ...taskDesc.pickup.payload,
                   sku: (ev.target as HTMLInputElement).value,
@@ -253,27 +259,31 @@ function DeliveryTaskForm({
           id="dropoff-location"
           freeSolo
           fullWidth
-          options={dropoffPoints}
+          options={Object.keys(dropoffPoints)}
           value={taskDesc.dropoff.place}
           onChange={(_ev, newValue) =>
             newValue !== null &&
+            dropoffPoints[newValue] &&
             onChange({
               ...taskDesc,
               dropoff: {
                 ...taskDesc.dropoff,
                 place: newValue,
+                handler: dropoffPoints[newValue],
               },
             })
           }
-          onBlur={(ev) =>
-            onChange({
-              ...taskDesc,
-              dropoff: {
-                ...taskDesc.dropoff,
-                place: (ev.target as HTMLInputElement).value,
-              },
-            })
-          }
+          onBlur={(ev) => {
+            dropoffPoints[(ev.target as HTMLInputElement).value] &&
+              onChange({
+                ...taskDesc,
+                dropoff: {
+                  ...taskDesc.dropoff,
+                  place: (ev.target as HTMLInputElement).value,
+                  handler: dropoffPoints[(ev.target as HTMLInputElement).value],
+                },
+              });
+          }}
           renderInput={(params) => <TextField {...params} label="Dropoff Location" />}
         />
       </Grid>
@@ -548,6 +558,7 @@ function defaultDeliveryTask(): DeliveryTaskDescription {
   return {
     pickup: {
       place: '',
+      handler: '',
       payload: {
         sku: '',
         quantity: 1,
@@ -555,6 +566,7 @@ function defaultDeliveryTask(): DeliveryTaskDescription {
     },
     dropoff: {
       place: '',
+      handler: '',
       payload: {
         sku: '',
         quantity: 1,
@@ -665,8 +677,8 @@ export interface CreateTaskFormProps
   allowBatch?: boolean;
   cleaningZones?: string[];
   patrolWaypoints?: string[];
-  pickupPoints?: string[];
-  dropoffPoints?: string[];
+  pickupPoints?: Record<string, string>;
+  dropoffPoints?: Record<string, string>;
   favoritesTasks: TaskFavorite[];
   submitTasks?(tasks: TaskRequest[], schedule: Schedule | null): Promise<void>;
   tasksFromFile?(): Promise<TaskRequest[]> | TaskRequest[];
@@ -684,8 +696,8 @@ export function CreateTaskForm({
   user,
   cleaningZones = [],
   patrolWaypoints = [],
-  pickupPoints = [],
-  dropoffPoints = [],
+  pickupPoints = {},
+  dropoffPoints = {},
   favoritesTasks = [],
   submitTasks,
   tasksFromFile,
@@ -1009,15 +1021,7 @@ export function CreateTaskForm({
                       >
                         Patrol
                       </MenuItem>
-                      <MenuItem
-                        value="delivery"
-                        disabled={
-                          !pickupPoints ||
-                          pickupPoints.length === 0 ||
-                          !dropoffPoints ||
-                          dropoffPoints.length === 0
-                        }
-                      >
+                      <MenuItem value="delivery" disabled={Object.keys(pickupPoints).length === 0}>
                         Delivery
                       </MenuItem>
                     </TextField>

--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -1021,7 +1021,13 @@ export function CreateTaskForm({
                       >
                         Patrol
                       </MenuItem>
-                      <MenuItem value="delivery" disabled={Object.keys(pickupPoints).length === 0}>
+                      <MenuItem
+                        value="delivery"
+                        disabled={
+                          Object.keys(pickupPoints).length === 0 ||
+                          Object.keys(dropoffPoints).length === 0
+                        }
+                      >
                         Delivery
                       </MenuItem>
                     </TextField>


### PR DESCRIPTION
## What's new

Fixes to broken delivery task request
* re-introduced the `handler` field for pickup and dropoff
* reverted back to `getPlace` function call, but changed the implementation to return information for all types of named places
* create-task now accepts a `Record<string, string>` for pickup and dropoff points, as it maps the name of the waypoint to the name of the handler
* checks for valid pickup and dropoff waypoint names and handler names before triggering change, to prevent crashes in the backend
* fixed a minor typo where modifying dropoff location changes pickup locations too

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test