### PR TITLE
Making default zoom levels a single source of truth

### DIFF
--- a/packages/dashboard/src/components/app-events.ts
+++ b/packages/dashboard/src/components/app-events.ts
@@ -19,6 +19,6 @@ export const AppEvents = {
   refreshAlertCount: new Subject<number>(),
   alertListOpenedAlert: new Subject<Alert | null>(),
   disabledLayers: new ReplaySubject<Record<string, boolean>>(),
-  zoom: new BehaviorSubject<number>(5),
+  zoom: new BehaviorSubject<number | null>(null),
   mapCenter: new BehaviorSubject<[number, number]>([0, 0]),
 };

--- a/packages/dashboard/src/components/map-app.tsx
+++ b/packages/dashboard/src/components/map-app.tsx
@@ -44,6 +44,8 @@ const TrajectoryUpdateInterval = 2000;
 const SettingsKey = 'mapAppSettings';
 const colorManager = new ColorManager();
 
+const DEFAULT_ZOOM_LEVEL = 5;
+
 function getRobotId(fleetName: string, robotName: string): string {
   return `${fleetName}/${robotName}`;
 }
@@ -214,11 +216,11 @@ export const MapApp = styled(
     const [imageUrl, setImageUrl] = React.useState<string | null>(null);
     const [bounds, setBounds] = React.useState<L.LatLngBoundsLiteral | null>(null);
     const [center, setCenter] = React.useState<L.LatLngTuple>([0, 0]);
-    const [zoom, setZoom] = React.useState<number>(5);
+    const [zoom, setZoom] = React.useState<number>(DEFAULT_ZOOM_LEVEL);
 
     React.useEffect(() => {
       const sub = AppEvents.zoom.subscribe((currentValue) => {
-        setZoom(currentValue);
+        setZoom(currentValue ?? DEFAULT_ZOOM_LEVEL);
       });
       return () => sub.unsubscribe();
     }, []);


### PR DESCRIPTION
## What's new

In order to make changing default zoom levels easier (before we migrate to `react-three-fiber`), I propose using a single source of truth for the default zoom level. This can make changing zoom levels for different deployments easier.

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test