### PR TITLE
Reverting to latest pnpm version when #6994 is fixed

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -13,7 +13,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@v2.2.2
       with:
-        version: '8.6.12'
+        version: 'latest'
     - uses: actions/setup-node@v2
       with:
         node-version: '16'


### PR DESCRIPTION
## What's new

Revert `pnpm` to latest.

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
