### PR TITLE
Using default zoom from resources if available

### DIFF
--- a/packages/dashboard/src/components/map-app.tsx
+++ b/packages/dashboard/src/components/map-app.tsx
@@ -44,7 +44,7 @@ const TrajectoryUpdateInterval = 2000;
 const SettingsKey = 'mapAppSettings';
 const colorManager = new ColorManager();
 
-const DEFAULT_ZOOM_LEVEL = 0.5;
+const DEFAULT_ZOOM_LEVEL = 5;
 
 function getRobotId(fleetName: string, robotName: string): string {
   return `${fleetName}/${robotName}`;
@@ -216,11 +216,13 @@ export const MapApp = styled(
     const [imageUrl, setImageUrl] = React.useState<string | null>(null);
     const [bounds, setBounds] = React.useState<L.LatLngBoundsLiteral | null>(null);
     const [center, setCenter] = React.useState<L.LatLngTuple>([0, 0]);
-    const [zoom, setZoom] = React.useState<number>(DEFAULT_ZOOM_LEVEL);
+    const [zoom, setZoom] = React.useState<number>(
+      resourceManager?.defaultZoom ?? DEFAULT_ZOOM_LEVEL,
+    );
 
     React.useEffect(() => {
       const sub = AppEvents.zoom.subscribe((currentValue) => {
-        setZoom(currentValue ?? DEFAULT_ZOOM_LEVEL);
+        setZoom(currentValue || resourceManager?.defaultZoom || DEFAULT_ZOOM_LEVEL);
       });
       return () => sub.unsubscribe();
     }, []);

--- a/packages/dashboard/src/managers/resource-manager.ts
+++ b/packages/dashboard/src/managers/resource-manager.ts
@@ -13,6 +13,7 @@ export interface ResourceConfigurationsType {
   helpLink?: string;
   reportIssue?: string;
   pickupZones?: string[];
+  defaultZoom?: number;
 }
 
 export default class ResourceManager {
@@ -22,6 +23,7 @@ export default class ResourceManager {
   helpLink: string;
   reportIssue: string;
   pickupZones?: string[];
+  defaultZoom: number;
 
   /**
    * Gets the default resource manager using the embedded resource file (aka "assets/resources/main.json").
@@ -56,6 +58,7 @@ export default class ResourceManager {
     this.helpLink = resources.helpLink || 'https://osrf.github.io/ros2multirobotbook/rmf-core.html';
     this.reportIssue = resources.reportIssue || 'https://github.com/open-rmf/rmf-web/issues';
     this.pickupZones = resources.pickupZones || [];
+    this.defaultZoom = resources.defaultZoom ?? 5;
   }
 }
 


### PR DESCRIPTION
## What's new

Default zoom to be configurable from dashboard resources under the key `defaultZoom`, with number as value.

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test