### PR TITLE
Turning off submit task tests for sanity check

### DIFF
--- a/packages/dashboard-e2e/tests/ui-interactions/index.test.ts
+++ b/packages/dashboard-e2e/tests/ui-interactions/index.test.ts
@@ -2,6 +2,6 @@
 // but doing it this way allows us to correctly populate the wdio test suite name.
 describe('ui interactions', async () => {
   await import('./door-controls.test');
-  await import('./submit-task.test');
+  // await import('./submit-task.test');
   await import('./create-task-from-any-tab.test');
 });

--- a/packages/dashboard-e2e/tests/ui-interactions/index.test.ts
+++ b/packages/dashboard-e2e/tests/ui-interactions/index.test.ts
@@ -2,6 +2,6 @@
 // but doing it this way allows us to correctly populate the wdio test suite name.
 describe('ui interactions', async () => {
   await import('./door-controls.test');
-  // await import('./submit-task.test');
+  await import('./submit-task.test');
   await import('./create-task-from-any-tab.test');
 });

--- a/packages/dashboard-e2e/tests/ui-interactions/submit-task.test.ts
+++ b/packages/dashboard-e2e/tests/ui-interactions/submit-task.test.ts
@@ -6,21 +6,22 @@ describe('submit task', () => {
     await (await appBar.$('button[aria-label="Tasks"]')).click();
     await (await appBar.$('button[aria-label="new task"]')).click();
     await (await $('#task-type')).click();
-    const getPatrolOption = async () => {
+    const getDeliveryOption = async () => {
       const options = await $$('[role=option]');
       for (const opt of options) {
         const text = await opt.getText();
-        if (text === 'Patrol') {
+        if (text === 'Delivery') {
           return opt;
         }
       }
       return null;
     };
-    await browser.waitUntil(async () => !!(await getPatrolOption()));
-    const patrolOption = (await getPatrolOption())!;
-    await patrolOption.click();
+    await browser.waitUntil(async () => !!(await getDeliveryOption()));
+    const deliveryOption = (await getDeliveryOption())!;
+    await deliveryOption.click();
 
-    await (await $('#place-input')).setValue('coe');
+    await (await $('#pickup-location')).setValue('pantry');
+    await (await $('#dropoff-location')).setValue('coe');
 
     await (await $('button[aria-label="Submit Now"]')).click();
     await expect($('div=Successfully created task')).toBeDisplayed();


### PR DESCRIPTION
## What's new

Changing task submission e2e test to `Delivery`

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test