### PR TITLE
Selecting a favorite task changes taskRequests, instead of append

### DIFF
--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -973,17 +973,14 @@ export function CreateTaskForm({
                       setOpenDialog={setOpenFavoriteDialog}
                       listItemClick={() => {
                         setFavoriteTaskBuffer(favoriteTask);
-                        setTaskRequests((prev) => {
-                          return [
-                            ...prev,
-                            {
-                              category: favoriteTask.category,
-                              description: favoriteTask.description,
-                              unix_millis_earliest_start_time: Date.now(),
-                              priority: favoriteTask.priority,
-                            },
-                          ];
-                        });
+                        setTaskRequests([
+                          {
+                            category: favoriteTask.category,
+                            description: favoriteTask.description,
+                            unix_millis_earliest_start_time: Date.now(),
+                            priority: favoriteTask.priority,
+                          }]
+                        );
                       }}
                     />
                   );


### PR DESCRIPTION
## What's new

Selecting a favorite task set it as the main task, instead of appending it to a list of task.

This fixes the issue of including the default task.

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test