### PR TITLE
Display an alert when low display res detected

### DIFF
--- a/packages/dashboard-e2e/wdio.conf.js
+++ b/packages/dashboard-e2e/wdio.conf.js
@@ -22,7 +22,8 @@ function browserstackOptions(opts) {
   return {
     projectName: 'rmf-web',
     buildName: `dashboard-e2e:${process.env.BROWSERSTACK_BUILD || 'local'}`,
-    resolution: '1920x1080',
+    // resolution: '1920x1080',
+    resolution: '2560x1600',
     localIdentifier,
     ...opts,
   };

--- a/packages/dashboard-e2e/wdio.conf.js
+++ b/packages/dashboard-e2e/wdio.conf.js
@@ -22,7 +22,7 @@ function browserstackOptions(opts) {
   return {
     projectName: 'rmf-web',
     buildName: `dashboard-e2e:${process.env.BROWSERSTACK_BUILD || 'local'}`,
-    // resolution: '1920x1080',
+    // Resolution higher than 1080p to prevent triggering low resolution alert.
     resolution: '2560x1600',
     localIdentifier,
     ...opts,

--- a/packages/dashboard/src/components/app-base.tsx
+++ b/packages/dashboard/src/components/app-base.tsx
@@ -9,7 +9,7 @@ import {
 } from '@mui/material';
 import { ThemeProvider } from '@mui/material/styles';
 import React from 'react';
-import { rmfDark, rmfDarkLeaflet, rmfLight } from 'react-components';
+import { rmfDark, rmfDarkLeaflet, rmfLight, AlertDialog } from 'react-components';
 import { loadSettings, saveSettings, Settings, ThemeMode } from '../settings';
 import { AppController, AppControllerContext, SettingsContext } from './app-contexts';
 import AppBar from './appbar';
@@ -30,6 +30,7 @@ const defaultTheme = createTheme();
 export function AppBase({ children }: React.PropsWithChildren<{}>): JSX.Element | null {
   const [settings, setSettings] = React.useState(() => loadSettings());
   const [showAlert, setShowAlert] = React.useState(false);
+  const [lowResolutionAlert, setLowResolutionAlert] = React.useState(false);
   const [alertSeverity, setAlertSeverity] = React.useState<AlertProps['severity']>('error');
   const [alertMessage, setAlertMessage] = React.useState('');
   const [alertDuration, setAlertDuration] = React.useState(DefaultAlertDuration);
@@ -65,6 +66,48 @@ export function AppBase({ children }: React.PropsWithChildren<{}>): JSX.Element 
     [updateSettings],
   );
 
+  React.useEffect(() => {
+    const checkSize = () => {
+      if (window.innerHeight < 1080 || window.innerWidth < 1080) {
+        setLowResolutionAlert(true);
+      }
+    };
+    checkSize();
+    window.addEventListener('resize', checkSize);
+  }, []);
+
+  const dismissDisplayAlert = () => {
+    setLowResolutionAlert(false);
+  };
+
+  const lowResolutionDisplayAlert = () => {
+    return (
+      <AlertDialog
+        key="display-alert"
+        onDismiss={dismissDisplayAlert}
+        title="Low display resolution detected"
+        alertContents={[
+          {
+            title: 'Current resolution',
+            value: `${window.innerWidth} x ${window.innerHeight}`,
+          },
+          {
+            title: 'Minimum recommended resolution',
+            value: '1920 x 1080',
+          },
+          {
+            title: 'Message',
+            value:
+              'To ensure maximum compatibility, please reduce the zoom ' +
+              'level in the browser (Ctrl+Minus) or display settings, ' +
+              'or change to a higher resolution display device.',
+          },
+        ]}
+        backgroundColor={theme.palette.background.default}
+      />
+    );
+  };
+
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
@@ -72,6 +115,7 @@ export function AppBase({ children }: React.PropsWithChildren<{}>): JSX.Element 
       <SettingsContext.Provider value={settings}>
         <AppControllerContext.Provider value={appController}>
           <AlertStore />
+          {lowResolutionAlert && lowResolutionDisplayAlert()}
           <Grid
             container
             direction="column"


### PR DESCRIPTION
## What's new

Displays an alert if the display resolution is low.

https://github.com/open-rmf/rmf-web/assets/5383623/d5b12cea-0a44-4a21-a634-237818fc29da

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test