### PR TITLE
Small fixes to react-three-fiber migration

### DIFF
--- a/packages/dashboard/src/components/map-app.tsx
+++ b/packages/dashboard/src/components/map-app.tsx
@@ -19,7 +19,6 @@ import {
   RobotTableData,
   ShapeThreeRendering,
   TextThreeRendering,
-  WallMaker,
 } from 'react-components';
 import { EMPTY, merge, scan, Subscription, switchMap } from 'rxjs';
 import appConfig from '../app-config';
@@ -404,9 +403,6 @@ export const MapApp = styled(
               RIGHT: undefined,
             }}
           />
-          {currentLevel.wall_graph.edges.length && (
-            <WallMaker wallGraph={currentLevel.wall_graph} />
-          )}
           {!disabledLayers['Doors'] && currentLevel.doors.length > 0
             ? currentLevel.doors.map((door, i) => (
                 <Door

--- a/packages/dashboard/src/components/map-app.tsx
+++ b/packages/dashboard/src/components/map-app.tsx
@@ -13,7 +13,6 @@ import {
   findSceneBoundingBoxFromThreeFiber,
   fromRmfCoords,
   getPlaces,
-  loadAffineImage,
   Place,
   ReactThreeFiberImageMaker,
   RobotTableData,
@@ -30,8 +29,8 @@ import { RobotData } from './robots-overlay';
 import { TrajectoryData } from './trajectories-overlay';
 import { WorkcellData } from './workcells-overlay';
 import { RobotSummary } from './robots/robot-summary';
-import { Box3, MOUSE, Vector3 } from 'three';
-import { Canvas } from '@react-three/fiber';
+import { Box3, MOUSE, TextureLoader, Vector3 } from 'three';
+import { Canvas, useLoader } from '@react-three/fiber';
 import { OrbitControls, Line } from '@react-three/drei';
 import { LayersController } from './three-fiber';
 import { Lifts, Door, RobotThree } from './three-fiber';
@@ -232,8 +231,8 @@ export const MapApp = styled(
       }
 
       (async () => {
-        const affineImage = await loadAffineImage(currentLevel.images[0]);
-        setImageUrl(affineImage.src);
+        useLoader.preload(TextureLoader, currentLevel.images[0].data);
+        setImageUrl(currentLevel.images[0].data);
       })();
 
       buildingMap &&
@@ -376,9 +375,7 @@ export const MapApp = styled(
           levels={buildingMap.levels}
           currentLevel={currentLevel}
           onChange={(event: ChangeEvent<HTMLInputElement>, value: string) => {
-            setCurrentLevel(
-              buildingMap.levels.find((l) => l.name === event.target.value) || currentLevel,
-            );
+            setCurrentLevel(buildingMap.levels.find((l) => l.name === value) || currentLevel);
           }}
         />
         <Canvas

--- a/packages/react-components/lib/map/three-fiber/image-maker.tsx
+++ b/packages/react-components/lib/map/three-fiber/image-maker.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Level } from 'api-client';
 import { useLoader } from '@react-three/fiber';
-import { TextureLoader } from 'three';
+import { Texture, TextureLoader } from 'three';
 
 export interface ImageThreeProps {
   level: Level;
@@ -9,7 +9,18 @@ export interface ImageThreeProps {
 }
 
 export const ReactThreeFiberImageMaker = ({ level, imageUrl }: ImageThreeProps): JSX.Element => {
-  const texture = useLoader(TextureLoader, imageUrl);
+  let texture: Texture | undefined = undefined;
+  try {
+    texture = useLoader(TextureLoader, imageUrl);
+  } catch (e) {
+    console.error(`Texture loading failed for url ${imageUrl}: ${(e as Error).message}`);
+  }
+
+  if (!texture) {
+    console.error(`Failed to create image texture with ${imageUrl}.`);
+    return <></>;
+  }
+
   const image = level.images[0];
   const scale = image.scale;
   const x_offset = (texture.image.width * scale) / 2 + image.x_offset;


### PR DESCRIPTION
## What's new

- [x] Disable walls
- [x] Fix race conditions for maps, potentially due to `CORS` timeouts when handling images

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test