### PR TITLE
Fix - schedule single event (#791)

### DIFF
--- a/packages/dashboard/src/components/tasks/task-schedule-utils.ts
+++ b/packages/dashboard/src/components/tasks/task-schedule-utils.ts
@@ -101,7 +101,9 @@ export const scheduleToEvents = (
       (scheStartFrom == null || scheStartFrom <= cur) &&
       (scheUntil == null || scheUntil >= cur)
     ) {
-      if (!task.except_dates.includes(cur.toLocaleDateString())) {
+      const curToIso = cur.toISOString();
+      const curFormatted = `${curToIso.slice(0, 10)}`;
+      if (!task.except_dates.includes(curFormatted)) {
         events.push({
           start: cur,
           end: addMinutes(cur, 45),


### PR DESCRIPTION
* Fix editing single event setting the correct date
* Add toIsoFormat
* format date to isoFormat
* Format to isoFormat
* Revert to exceptDateref insted of the schedule request time

---------

(cherry picked from commit c9c4570594d102a62c70863ec130b03aa6fdbe07)