### PR TITLE
Fix dashboard CI for react-three-fiber migration

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -37,7 +37,7 @@ jobs:
           skip-build: true
       - name: unit test
         env:
-          GENERATE_SOURCEMAP: false
+          NODE_OPTIONS: '--max_old_space_size=4096'
         run: . /rmf_demos_ws/install/setup.bash && pnpm run test:coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -37,7 +37,7 @@ jobs:
           skip-build: true
       - name: unit test
         env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          GENERATE_SOURCEMAP: false
         run: . /rmf_demos_ws/install/setup.bash && pnpm run test:coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -36,6 +36,8 @@ jobs:
           package: rmf-dashboard
           skip-build: true
       - name: unit test
+        env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
         run: . /rmf_demos_ws/install/setup.bash && pnpm run test:coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -32,7 +32,7 @@ jobs:
         run: apt update && apt install -y python3-venv python-is-python3
       - name: bootstrap
         env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
+          NODE_OPTIONS: '--max_old_space_size=4096 --experimental-vm-modules'
         uses: ./.github/actions/bootstrap
         with:
           package: rmf-dashboard

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -32,7 +32,7 @@ jobs:
         run: apt update && apt install -y python3-venv python-is-python3
       - name: bootstrap
         env:
-          NODE_OPTIONS: '--max_old_space_size=4096 --experimental-vm-modules'
+          NODE_OPTIONS: '--max_old_space_size=4096'
         uses: ./.github/actions/bootstrap
         with:
           package: rmf-dashboard

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -37,7 +37,8 @@ jobs:
           skip-build: true
       - name: unit test
         env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
+          NODE_OPTIONS: '--max_old_space_size=8192'
+          GENERATE_SOURCEMAP: false
         run: . /rmf_demos_ws/install/setup.bash && pnpm run test:coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -31,14 +31,13 @@ jobs:
       - name: setup python
         run: apt update && apt install -y python3-venv python-is-python3
       - name: bootstrap
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
         uses: ./.github/actions/bootstrap
         with:
           package: rmf-dashboard
           skip-build: true
       - name: unit test
-        env:
-          NODE_OPTIONS: '--max_old_space_size=8192'
-          GENERATE_SOURCEMAP: false
         run: . /rmf_demos_ws/install/setup.bash && pnpm run test:coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/packages/dashboard/src/components/three-fiber/robot-three.tsx
+++ b/packages/dashboard/src/components/three-fiber/robot-three.tsx
@@ -8,15 +8,9 @@ interface RobotThreeProps {
   robots: RobotData[];
   robotLocations: Record<string, [number, number, number]>;
   onRobotClick?: (ev: ThreeEvent<MouseEvent>, robot: RobotData) => void;
-  objectModel?: string;
 }
 
-export const RobotThree = ({
-  robots,
-  robotLocations,
-  onRobotClick,
-  objectModel, //Object model should be some path of the object to be rendered.
-}: RobotThreeProps) => {
+export const RobotThree = ({ robots, robotLocations, onRobotClick }: RobotThreeProps) => {
   const STANDAR_Z_POSITION = 4;
   const CIRCLE_SEGMENT = 64;
 
@@ -34,7 +28,6 @@ export const RobotThree = ({
               robot={robot}
               position={position}
               onRobotClick={onRobotClick}
-              objectModel={objectModel}
               rotation={new Euler(0, 0, rotationZ)}
               circleSegment={CIRCLE_SEGMENT}
             />

--- a/packages/react-components/lib/map/three-fiber/robot-three-maker.tsx
+++ b/packages/react-components/lib/map/three-fiber/robot-three-maker.tsx
@@ -1,9 +1,7 @@
 import { Circle, Line, Text } from '@react-three/drei';
-import { ThreeEvent, useLoader } from '@react-three/fiber';
+import { ThreeEvent } from '@react-three/fiber';
 import React from 'react';
 import { Euler, Vector3 } from 'three';
-import { MTLLoader } from 'three/examples/jsm/loaders/MTLLoader';
-import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader';
 
 export interface RobotData {
   fleet: string;
@@ -23,18 +21,10 @@ interface CircleShapeProps {
   segment: number;
 }
 
-interface ObjectLoaderProps {
-  position: Vector3;
-  rotation: THREE.Euler;
-  onRobotClick?: (ev: ThreeEvent<MouseEvent>) => void;
-  robot: RobotData;
-}
-
 interface RobotThreeMakerProps {
   robot: RobotData;
   position: Vector3;
   onRobotClick?: (ev: ThreeEvent<MouseEvent>, robot: RobotData) => void;
-  objectModel?: string;
   rotation: Euler;
   circleSegment: number;
 }
@@ -70,35 +60,10 @@ const CircleShape = ({
   );
 };
 
-const ObjectLoader = ({
-  position,
-  rotation,
-  onRobotClick,
-  robot,
-}: ObjectLoaderProps): JSX.Element => {
-  const objPath = '/Hatchback/meshes/hatchback.obj';
-  const mtlPath = '/Hatchback/meshes/hatchback.mtl';
-  const objectRef = React.useRef<THREE.Object3D>(null);
-  const scale = new Vector3(0.007, 0.007, 0.007);
-
-  const materials = useLoader(MTLLoader, mtlPath);
-  const object = useLoader(OBJLoader, objPath, (loader) => {
-    materials.preload();
-    loader.setMaterials(materials);
-  });
-  return (
-    <group position={position} rotation={rotation} scale={scale} onClick={onRobotClick}>
-      <primitive object={object} ref={objectRef} color={robot.color} opacity={1} />
-      <primitive object={object.clone()} ref={objectRef} />
-    </group>
-  );
-};
-
 export const RobotThreeMaker = ({
   robot,
   position,
   onRobotClick,
-  objectModel, //Object model should be some path of the object to be rendered.
   rotation,
   circleSegment,
 }: RobotThreeMakerProps): JSX.Element => {
@@ -107,23 +72,13 @@ export const RobotThreeMaker = ({
       <Text color="black" fontSize={0.5} position={[position.x, position.y, position.z + 1]}>
         {robot.name}
       </Text>
-
-      {objectModel ? (
-        <ObjectLoader
-          position={position}
-          rotation={rotation}
-          onRobotClick={(ev: ThreeEvent<MouseEvent>) => onRobotClick && onRobotClick(ev, robot)}
-          robot={robot}
-        />
-      ) : (
-        <CircleShape
-          position={position}
-          rotation={rotation}
-          onRobotClick={(ev: ThreeEvent<MouseEvent>) => onRobotClick && onRobotClick(ev, robot)}
-          robot={robot}
-          segment={circleSegment}
-        />
-      )}
+      <CircleShape
+        position={position}
+        rotation={rotation}
+        onRobotClick={(ev: ThreeEvent<MouseEvent>) => onRobotClick && onRobotClick(ev, robot)}
+        robot={robot}
+        segment={circleSegment}
+      />
     </>
   );
 };

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -114,5 +114,6 @@
     "react-grid-layout": "^1.3.4",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0"
-  }
+  },
+  "type": "module"
 }

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -114,6 +114,5 @@
     "react-grid-layout": "^1.3.4",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0"
-  },
-  "type": "module"
+  }
 }


### PR DESCRIPTION
## What's new

* Fixing max heap size for allocation on dashboard unit test.
* Remove stale use of `Hatchback` mesh
* Remove use of mesh for model

TODO:
* use dashboard resources to target an image to be used for robots
* use dashboard resources to set scale of such images (meters per pixel)

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test