### PR TITLE
Publish to both lift_requests and adapter_lift_requests

### DIFF
--- a/packages/api-server/api_server/gateway.py
+++ b/packages/api-server/api_server/gateway.py
@@ -69,6 +69,9 @@ class RmfGateway:
             RmfDoorRequest, "adapter_door_requests", 10
         )
         self._lift_req = ros_node().create_publisher(
+            RmfLiftRequest, "lift_requests", 10
+        )
+        self._adapter_lift_req = ros_node().create_publisher(
             RmfLiftRequest, "adapter_lift_requests", 10
         )
         self._submit_task_srv = ros_node().create_client(RmfSubmitTask, "submit_task")
@@ -176,6 +179,7 @@ class RmfGateway:
             door_state=door_mode,
         )
         self._lift_req.publish(msg)
+        self._adapter_lift_req.publish(msg)
 
 
 _rmf_gateway: RmfGateway


### PR DESCRIPTION
## What's new

Lift requests publish to both `lift_requests` and `adapter_lift_requests`.

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test