### PR TITLE
Adding console logs and getting building map manually alongside subscription

### DIFF
--- a/packages/dashboard/src/components/map-app.tsx
+++ b/packages/dashboard/src/components/map-app.tsx
@@ -1,4 +1,4 @@
-import { styled } from '@mui/material';
+import { styled, CircularProgress } from '@mui/material';
 import {
   BuildingMap,
   Dispenser,
@@ -378,8 +378,6 @@ export const MapApp = styled(
       return () => sub.unsubscribe();
     }, [robotLocations, resourceManager?.defaultRobotZoom]);
 
-    const ready = buildingMap && currentLevel;
-
     const [sceneBoundingBox, setSceneBoundingBox] = React.useState<Box3 | undefined>(undefined);
     const [distance, setDistance] = React.useState<number>(0);
 
@@ -396,13 +394,21 @@ export const MapApp = styled(
       setDistance(Math.max(size.x, size.y, size.z) * 0.7);
     }, [sceneBoundingBox]);
 
-    return ready ? (
-      <Suspense fallback={null}>
+    // if (!buildingMap) {
+    //   console.log('no buildingMap yet');
+    // }
+    // if (!currentLevel) {
+    //   console.log('no currentLevel yet');
+    // }
+
+    return buildingMap && currentLevel && robotLocations ? (
+      <Suspense fallback={<CircularProgress />}>
         <LayersController
           disabledLayers={disabledLayers}
           levels={buildingMap.levels}
           currentLevel={currentLevel}
           onChange={(event: ChangeEvent<HTMLInputElement>, value: string) => {
+            console.log('change level triggered');
             AppEvents.levelSelect.next(
               buildingMap.levels.find((l: Level) => l.name === value) || buildingMap.levels[0],
             );
@@ -560,7 +566,14 @@ export const MapApp = styled(
           <RobotSummary robot={selectedRobot} onClose={() => setOpenRobotSummary(false)} />
         )}
       </Suspense>
-    ) : null;
+    ) : // ) : !buildingMap ? (
+    //   <>
+
+    //     <CircularProgress />
+    //   </>
+    // ) : !currentLevel ? (
+    //   <></>
+    null;
   }),
 )({
   // This ensures that the resize handle is above the map.

--- a/packages/dashboard/src/components/map-app.tsx
+++ b/packages/dashboard/src/components/map-app.tsx
@@ -1,4 +1,4 @@
-import { styled, CircularProgress } from '@mui/material';
+import { styled } from '@mui/material';
 import {
   BuildingMap,
   Dispenser,
@@ -402,7 +402,7 @@ export const MapApp = styled(
     // }
 
     return buildingMap && currentLevel && robotLocations ? (
-      <Suspense fallback={<CircularProgress />}>
+      <Suspense fallback={null}>
         <LayersController
           disabledLayers={disabledLayers}
           levels={buildingMap.levels}
@@ -566,14 +566,7 @@ export const MapApp = styled(
           <RobotSummary robot={selectedRobot} onClose={() => setOpenRobotSummary(false)} />
         )}
       </Suspense>
-    ) : // ) : !buildingMap ? (
-    //   <>
-
-    //     <CircularProgress />
-    //   </>
-    // ) : !currentLevel ? (
-    //   <></>
-    null;
+    ) : null;
   }),
 )({
   // This ensures that the resize handle is above the map.

--- a/packages/dashboard/src/components/map-app.tsx
+++ b/packages/dashboard/src/components/map-app.tsx
@@ -194,19 +194,34 @@ export const MapApp = styled(
         return;
       }
 
+      const handleBuildingMap = (newMap: BuildingMap) => {
+        setBuildingMap(newMap);
+        const currentLevel = AppEvents.levelSelect.value
+          ? AppEvents.levelSelect.value
+          : newMap.levels[0];
+        AppEvents.levelSelect.next(currentLevel);
+        setWaypoints(
+          getPlaces(newMap).filter(
+            (p) => p.level === currentLevel.name && p.vertex.name.length > 0,
+          ),
+        );
+      };
+
+      (async () => {
+        try {
+          const newMap = (await rmf.buildingApi.getBuildingMapBuildingMapGet()).data;
+          handleBuildingMap(newMap);
+        } catch (e) {
+          console.log(`failed to get building map: ${(e as Error).message}`);
+        }
+        console.log('get building map called');
+      })();
+
       const subs: Subscription[] = [];
       subs.push(
         rmf.buildingMapObs.subscribe((newMap) => {
-          setBuildingMap(newMap);
-          const currentLevel = AppEvents.levelSelect.value
-            ? AppEvents.levelSelect.value
-            : newMap.levels[0];
-          AppEvents.levelSelect.next(currentLevel);
-          setWaypoints(
-            getPlaces(newMap).filter(
-              (p) => p.level === currentLevel.name && p.vertex.name.length > 0,
-            ),
-          );
+          console.log('new building map subscribed.');
+          handleBuildingMap(newMap);
         }),
       );
       subs.push(rmf.dispensersObs.subscribe(setDispensers));

--- a/packages/dashboard/src/components/map-app.tsx
+++ b/packages/dashboard/src/components/map-app.tsx
@@ -394,13 +394,6 @@ export const MapApp = styled(
       setDistance(Math.max(size.x, size.y, size.z) * 0.7);
     }, [sceneBoundingBox]);
 
-    // if (!buildingMap) {
-    //   console.log('no buildingMap yet');
-    // }
-    // if (!currentLevel) {
-    //   console.log('no currentLevel yet');
-    // }
-
     return buildingMap && currentLevel && robotLocations ? (
       <Suspense fallback={null}>
         <LayersController

--- a/packages/dashboard/src/components/three-fiber/robot-three.tsx
+++ b/packages/dashboard/src/components/three-fiber/robot-three.tsx
@@ -20,6 +20,9 @@ export const RobotThree = ({ robots, robotLocations, onRobotClick }: RobotThreeP
         const robotId = `${robot.fleet}/${robot.name}`;
         const robotLocation = robotLocations[robotId];
         if (!robotLocation) {
+          console.log(
+            `RobotThree: Failed to get ${robotId}'s location: robot location was not found`,
+          );
           return null;
         }
         const rotationZ = robotLocation[2] + Math.PI / 2;

--- a/packages/dashboard/src/components/three-fiber/robot-three.tsx
+++ b/packages/dashboard/src/components/three-fiber/robot-three.tsx
@@ -19,6 +19,9 @@ export const RobotThree = ({ robots, robotLocations, onRobotClick }: RobotThreeP
       {robots.map((robot) => {
         const robotId = `${robot.fleet}/${robot.name}`;
         const robotLocation = robotLocations[robotId];
+        if (!robotLocation) {
+          return null;
+        }
         const rotationZ = robotLocation[2] + Math.PI / 2;
 
         const position = new Vector3(robotLocation[0], robotLocation[1], STANDAR_Z_POSITION);


### PR DESCRIPTION
## What's new

Debugging issue where building map is not retrieved while waypoints are rendered.

* More logs and more checks (to be removed)
* Fixed a race condition where robot locations have not come in yet
* Get building map explicity before setting up subscriptions

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test