### PR TITLE
Close session to handle additional session IDs

### DIFF
--- a/packages/api-client/lib/openapi/api.ts
+++ b/packages/api-client/lib/openapi/api.ts
@@ -1446,11 +1446,11 @@ export interface LiftRequest {
    */
   destination: string;
   /**
-   *
+   * By default the node name of the API server is used, this field allows publishing the same request to additional session IDs
    * @type {Array<string>}
    * @memberof LiftRequest
    */
-  session_ids: Array<string>;
+  additional_session_ids: Array<string>;
 }
 /**
  *

--- a/packages/api-client/lib/openapi/api.ts
+++ b/packages/api-client/lib/openapi/api.ts
@@ -1445,6 +1445,12 @@ export interface LiftRequest {
    * @memberof LiftRequest
    */
   destination: string;
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof LiftRequest
+   */
+  session_ids: Array<string>;
 }
 /**
  *

--- a/packages/api-client/lib/openapi/api.ts
+++ b/packages/api-client/lib/openapi/api.ts
@@ -1450,7 +1450,7 @@ export interface LiftRequest {
    * @type {Array<string>}
    * @memberof LiftRequest
    */
-  additional_session_ids: Array<string>;
+  additional_session_ids?: Array<string>;
 }
 /**
  *

--- a/packages/api-client/lib/version.ts
+++ b/packages/api-client/lib/version.ts
@@ -3,6 +3,6 @@ import { version as rmfModelVer } from 'rmf-models';
 
 export const version = {
   rmfModels: rmfModelVer,
-  rmfServer: 'e376894166b5036d3eb55375f900f670ac4a107a',
+  rmfServer: '3f5c17324194bb52c9884661dcc3b9f546194e4e',
   openapiGenerator: '6.2.1',
 };

--- a/packages/api-client/lib/version.ts
+++ b/packages/api-client/lib/version.ts
@@ -3,6 +3,6 @@ import { version as rmfModelVer } from 'rmf-models';
 
 export const version = {
   rmfModels: rmfModelVer,
-  rmfServer: '44fc2b83b81867a7b04166fbd41893d0582c74b6',
+  rmfServer: 'e376894166b5036d3eb55375f900f670ac4a107a',
   openapiGenerator: '6.2.1',
 };

--- a/packages/api-client/lib/version.ts
+++ b/packages/api-client/lib/version.ts
@@ -3,6 +3,6 @@ import { version as rmfModelVer } from 'rmf-models';
 
 export const version = {
   rmfModels: rmfModelVer,
-  rmfServer: '6ca8484298a18d0b71041295c6c7880555971461',
+  rmfServer: '44fc2b83b81867a7b04166fbd41893d0582c74b6',
   openapiGenerator: '6.2.1',
 };

--- a/packages/api-client/schema/index.ts
+++ b/packages/api-client/schema/index.ts
@@ -2913,7 +2913,7 @@ export default {
       },
       LiftRequest: {
         title: 'LiftRequest',
-        required: ['request_type', 'door_mode', 'destination', 'additional_session_ids'],
+        required: ['request_type', 'door_mode', 'destination'],
         type: 'object',
         properties: {
           request_type: {
@@ -2935,6 +2935,7 @@ export default {
             items: { type: 'string' },
             description:
               'By default the node name of the API server is used, this field allows publishing the same request to additional session IDs',
+            default: [],
           },
         },
       },

--- a/packages/api-client/schema/index.ts
+++ b/packages/api-client/schema/index.ts
@@ -2913,7 +2913,7 @@ export default {
       },
       LiftRequest: {
         title: 'LiftRequest',
-        required: ['request_type', 'door_mode', 'destination', 'session_ids'],
+        required: ['request_type', 'door_mode', 'destination', 'additional_session_ids'],
         type: 'object',
         properties: {
           request_type: {
@@ -2929,7 +2929,13 @@ export default {
               'https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_lift_msgs/msg/LiftRequest.msg',
           },
           destination: { title: 'Destination', type: 'string' },
-          session_ids: { title: 'Session Ids', type: 'array', items: { type: 'string' } },
+          additional_session_ids: {
+            title: 'Additional Session Ids',
+            type: 'array',
+            items: { type: 'string' },
+            description:
+              'By default the node name of the API server is used, this field allows publishing the same request to additional session IDs',
+          },
         },
       },
       LiftState: {

--- a/packages/api-client/schema/index.ts
+++ b/packages/api-client/schema/index.ts
@@ -2913,7 +2913,7 @@ export default {
       },
       LiftRequest: {
         title: 'LiftRequest',
-        required: ['request_type', 'door_mode', 'destination'],
+        required: ['request_type', 'door_mode', 'destination', 'session_ids'],
         type: 'object',
         properties: {
           request_type: {
@@ -2929,6 +2929,7 @@ export default {
               'https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_lift_msgs/msg/LiftRequest.msg',
           },
           destination: { title: 'Destination', type: 'string' },
+          session_ids: { title: 'Session Ids', type: 'array', items: { type: 'string' } },
         },
       },
       LiftState: {

--- a/packages/api-server/api_server/gateway.py
+++ b/packages/api-server/api_server/gateway.py
@@ -173,7 +173,7 @@ class RmfGateway:
         destination: str,
         request_type: int,
         door_mode: int,
-        session_ids: List[str],
+        additional_session_ids: List[str],
     ):
         msg = RmfLiftRequest(
             lift_name=lift_name,
@@ -186,7 +186,7 @@ class RmfGateway:
         self._lift_req.publish(msg)
         self._adapter_lift_req.publish(msg)
 
-        for session_id in session_ids:
+        for session_id in additional_session_ids:
             msg.session_id = session_id
             self._lift_req.publish(msg)
             self._adapter_lift_req.publish(msg)

--- a/packages/api-server/api_server/gateway.py
+++ b/packages/api-server/api_server/gateway.py
@@ -168,7 +168,12 @@ class RmfGateway:
         self._door_req.publish(msg)
 
     def request_lift(
-        self, lift_name: str, destination: str, request_type: int, door_mode: int
+        self,
+        lift_name: str,
+        destination: str,
+        request_type: int,
+        door_mode: int,
+        session_ids: List[str],
     ):
         msg = RmfLiftRequest(
             lift_name=lift_name,
@@ -180,6 +185,11 @@ class RmfGateway:
         )
         self._lift_req.publish(msg)
         self._adapter_lift_req.publish(msg)
+
+        for session_id in session_ids:
+            msg.session_id = session_id
+            self._lift_req.publish(msg)
+            self._adapter_lift_req.publish(msg)
 
 
 _rmf_gateway: RmfGateway

--- a/packages/api-server/api_server/models/lifts.py
+++ b/packages/api-server/api_server/models/lifts.py
@@ -32,6 +32,6 @@ class LiftRequest(BaseModel):
     )
     destination: str
     additional_session_ids: List[str] = Field(
-        ...,
+        default=[],
         description="By default the node name of the API server is used, this field allows publishing the same request to additional session IDs",  # pylint: disable=line-too-long
     )

--- a/packages/api-server/api_server/models/lifts.py
+++ b/packages/api-server/api_server/models/lifts.py
@@ -31,3 +31,4 @@ class LiftRequest(BaseModel):
         description="https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_lift_msgs/msg/LiftRequest.msg",  # pylint: disable=line-too-long
     )
     destination: str
+    session_ids: List[str]

--- a/packages/api-server/api_server/models/lifts.py
+++ b/packages/api-server/api_server/models/lifts.py
@@ -31,4 +31,7 @@ class LiftRequest(BaseModel):
         description="https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_lift_msgs/msg/LiftRequest.msg",  # pylint: disable=line-too-long
     )
     destination: str
-    session_ids: List[str]
+    additional_session_ids: List[str] = Field(
+        ...,
+        description="By default the node name of the API server is used, this field allows publishing the same request to additional session IDs",  # pylint: disable=line-too-long
+    )

--- a/packages/api-server/api_server/routes/lifts.py
+++ b/packages/api-server/api_server/routes/lifts.py
@@ -78,4 +78,5 @@ def _post_lift_request(
         lift_request.destination,
         lift_request.request_type,
         lift_request.door_mode,
+        lift_request.session_ids,
     )

--- a/packages/api-server/api_server/routes/lifts.py
+++ b/packages/api-server/api_server/routes/lifts.py
@@ -78,5 +78,5 @@ def _post_lift_request(
         lift_request.destination,
         lift_request.request_type,
         lift_request.door_mode,
-        lift_request.session_ids,
+        lift_request.additional_session_ids,
     )

--- a/packages/api-server/api_server/routes/test_lifts.py
+++ b/packages/api-server/api_server/routes/test_lifts.py
@@ -44,3 +44,19 @@ class TestLiftsRoute(AppFixture):
             },
         )
         self.assertEqual(resp.status_code, 200)
+
+    def test_request_lift_with_more_session_ids(self):
+        resp = self.client.post(
+            "/lifts/test_lift/request",
+            json={
+                "request_type": RmfLiftRequest.REQUEST_AGV_MODE,
+                "door_mode": RmfLiftRequest.DOOR_OPEN,
+                "destination": "L1",
+                "additional_session_ids": [
+                    "fleet1/robot1",
+                    "fleet1/robot2",
+                    "fleet2/robot1",
+                ],
+            },
+        )
+        self.assertEqual(resp.status_code, 200)

--- a/packages/dashboard/src/components/lifts-app.tsx
+++ b/packages/dashboard/src/components/lifts-app.tsx
@@ -49,6 +49,7 @@ export const LiftsApp = createMicroApp('Lifts', () => {
                       destination,
                       door_mode: doorState,
                       request_type: requestType,
+                      session_ids: [],
                     });
                   },
                 },

--- a/packages/dashboard/src/components/lifts-app.tsx
+++ b/packages/dashboard/src/components/lifts-app.tsx
@@ -1,5 +1,6 @@
 import { BuildingMap } from 'api-client';
 import React from 'react';
+import { LiftRequest as RmfLiftRequest } from 'rmf-models';
 import { LiftTableData, LiftDataGridTable } from 'react-components';
 import { createMicroApp } from './micro-app';
 import { RmfAppContext } from './rmf-app';
@@ -44,12 +45,25 @@ export const LiftsApp = createMicroApp('Lifts', () => {
                   doorState: liftState.door_state,
                   motionState: liftState.motion_state,
                   lift: lift,
-                  onRequestSubmit: (_ev, doorState, requestType, destination) => {
+                  onRequestSubmit: async (_ev, doorState, requestType, destination) => {
+                    let fleet_session_ids: string[] = [];
+                    if (requestType === RmfLiftRequest.REQUEST_END_SESSION) {
+                      const fleets = (await rmf?.fleetsApi.getFleetsFleetsGet()).data;
+                      for (const fleet of fleets) {
+                        if (!fleet.robots) {
+                          continue;
+                        }
+                        for (const robotName of Object.keys(fleet.robots)) {
+                          fleet_session_ids.push(`${fleet.name}/${robotName}`);
+                        }
+                      }
+                    }
+
                     return rmf?.liftsApi.postLiftRequestLiftsLiftNameRequestPost(lift.name, {
                       destination,
                       door_mode: doorState,
                       request_type: requestType,
-                      session_ids: [],
+                      additional_session_ids: fleet_session_ids,
                     });
                   },
                 },


### PR DESCRIPTION
## What's new

Lift end session behavior changes
* modifies `LiftRequest` model to accept additional session IDs
* requests will be published per normal, with additional publishes to each additional session ID
* on the frontend, the additional session IDs are only added if the request type is End Session
* additional session IDs are formatted as `fleet_name/robot_name`, by querying the fleet get API


https://github.com/open-rmf/rmf-web/assets/5383623/5211b82f-9fe7-4fee-a516-70135bc7d731



## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test