### PR TITLE
Removing admin requirement for task cancellation

### DIFF
--- a/packages/api-server/api_server/authenticator.py
+++ b/packages/api-server/api_server/authenticator.py
@@ -67,7 +67,7 @@ class JwtAuthenticator:
 
 class StubAuthenticator(JwtAuthenticator):
     def __init__(self):  # pylint: disable=super-init-not-called
-        self._user = User(username="stub", is_admin=True)
+        self._user = User(username="stub", is_admin=False)
 
     async def verify_token(self, token: Optional[str]) -> User:
         return self._user

--- a/packages/dashboard/src/components/tasks/task-details-app.tsx
+++ b/packages/dashboard/src/components/tasks/task-details-app.tsx
@@ -2,12 +2,12 @@ import { Button, CardContent, Grid, Typography, useTheme } from '@mui/material';
 import { TaskState } from 'api-client';
 import React from 'react';
 import { TaskInfo } from 'react-components';
-import { UserProfileContext } from 'rmf-auth';
+// import { UserProfileContext } from 'rmf-auth';
 import { of, switchMap } from 'rxjs';
 import { AppControllerContext } from '../app-contexts';
 import { AppEvents } from '../app-events';
 import { createMicroApp } from '../micro-app';
-import { Enforcer } from '../permissions';
+// import { Enforcer } from '../permissions';
 import { RmfAppContext } from '../rmf-app';
 
 export const TaskDetailsApp = createMicroApp('Task Details', () => {
@@ -30,11 +30,11 @@ export const TaskDetailsApp = createMicroApp('Task Details', () => {
     return () => sub.unsubscribe();
   }, [rmf]);
 
-  const profile = React.useContext(UserProfileContext);
+  // const profile = React.useContext(UserProfileContext);
   const taskCancellable =
     taskState &&
-    profile &&
-    Enforcer.canCancelTask(profile) &&
+    // profile &&
+    // Enforcer.canCancelTask(profile) &&
     taskState.status &&
     !['canceled', 'killed', 'completed', 'failed'].includes(taskState.status);
   const handleCancelTaskClick = React.useCallback<React.MouseEventHandler>(async () => {

--- a/packages/dashboard/src/components/tasks/task-inspector.tsx
+++ b/packages/dashboard/src/components/tasks/task-inspector.tsx
@@ -15,8 +15,8 @@ import { AppControllerContext } from '../app-contexts';
 import { AppEvents } from '../app-events';
 import { RmfAppContext } from '../rmf-app';
 import { TaskInfo } from 'react-components';
-import { UserProfileContext } from 'rmf-auth';
-import { Enforcer } from '../permissions';
+// import { UserProfileContext } from 'rmf-auth';
+// import { Enforcer } from '../permissions';
 import { TaskLogs } from './task-logs';
 
 export interface TableDataGridState {
@@ -59,12 +59,12 @@ export function TaskInspector({ task, onClose }: TableDataGridState): JSX.Elemen
     return () => sub.unsubscribe();
   }, [rmf, task]);
 
-  const profile = React.useContext(UserProfileContext);
+  // const profile = React.useContext(UserProfileContext);
 
   const taskCancellable =
     taskState &&
-    profile &&
-    Enforcer.canCancelTask(profile) &&
+    // profile &&
+    // Enforcer.canCancelTask(profile) &&
     taskState.status &&
     !['canceled', 'killed', 'completed', 'failed'].includes(taskState.status);
 


### PR DESCRIPTION
## What's new

Temporarily remove admin requirement for cancellation.

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test