### PR TITLE
Fix oddly failing robot label and use same as other labels

### DIFF
--- a/packages/react-components/lib/map/three-fiber/robot-three-maker.tsx
+++ b/packages/react-components/lib/map/three-fiber/robot-three-maker.tsx
@@ -2,6 +2,7 @@ import { Circle, Line, Text } from '@react-three/drei';
 import { ThreeEvent } from '@react-three/fiber';
 import React from 'react';
 import { Euler, Vector3 } from 'three';
+import { TextThreeRendering } from './text-maker';
 
 export interface RobotData {
   fleet: string;
@@ -69,9 +70,7 @@ export const RobotThreeMaker = ({
 }: RobotThreeMakerProps): JSX.Element => {
   return (
     <>
-      <Text color="black" fontSize={0.5} position={[position.x, position.y, position.z + 1]}>
-        {robot.name}
-      </Text>
+      <TextThreeRendering position={[position.x, position.y, position.z + 1]} text={robot.name} />
       <CircleShape
         position={position}
         rotation={rotation}


### PR DESCRIPTION
## What's new

Fix issue where font needs to be downloaded during runtime.

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test