### PR TITLE
Log the parsed token, which should contain the mapping

### DIFF
--- a/packages/rmf-auth/lib/keycloak.ts
+++ b/packages/rmf-auth/lib/keycloak.ts
@@ -7,7 +7,8 @@ const debug = Debug('authenticator');
 
 export class KeycloakAuthenticator
   extends EventEmitter<AuthenticatorEventType>
-  implements Authenticator {
+  implements Authenticator
+{
   get user(): string | undefined {
     return this._user;
   }
@@ -33,6 +34,16 @@ export class KeycloakAuthenticator
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (this._inst.idTokenParsed as any).preferred_username;
   }
+
+  // private _getRoles(): string {
+  //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  //   return (this._inst.idTokenParsed as any).realm_roles;
+  // }
+
+  // private _getGroups(): string {
+  //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  //   return (this._inst.idTokenParsed as any).groups;
+  // }
 
   async init(): Promise<void> {
     if (this._initialized) {
@@ -66,6 +77,9 @@ export class KeycloakAuthenticator
     }
 
     this._user = this._inst.tokenParsed && this._getUser();
+
+    console.log(this._inst.idTokenParsed as any);
+
     this._initialized = true;
   }
 


### PR DESCRIPTION
## What's new

Map roles and groups into keycloak token
* Retrieve `realm_roles` and `groups` from keycloak token

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test