### PR TITLE
Fix/delivery alerts sub

### DIFF
--- a/packages/dashboard/src/components/delivery-alert-store.tsx
+++ b/packages/dashboard/src/components/delivery-alert-store.tsx
@@ -43,6 +43,12 @@ const DeliveryWarningDialog = React.memo((props: DeliveryWarningDialogProps) => 
   const rmf = React.useContext(RmfAppContext);
 
   React.useEffect(() => {
+    if (deliveryAlert.action !== 'waiting') {
+      setActionTaken(true);
+    }
+  }, [deliveryAlert]);
+
+  React.useEffect(() => {
     if (!rmf) {
       console.error('Tasks api not available.');
       setNewTaskState(null);

--- a/packages/dashboard/src/components/delivery-alert-store.tsx
+++ b/packages/dashboard/src/components/delivery-alert-store.tsx
@@ -125,6 +125,24 @@ const DeliveryWarningDialog = React.memo((props: DeliveryWarningDialogProps) => 
     [rmf],
   );
 
+  const titleUpdateText = (action: string) => {
+    switch (action) {
+      case 'override': {
+        return ' - [Overridden]';
+      }
+      case 'resume': {
+        return ' - [Resumed]';
+      }
+      case 'cancel': {
+        return ' - [Cancelled]';
+      }
+      case 'waiting':
+      default: {
+        return '';
+      }
+    }
+  };
+
   return (
     <>
       <Dialog
@@ -139,7 +157,9 @@ const DeliveryWarningDialog = React.memo((props: DeliveryWarningDialogProps) => 
         open={isOpen}
         key={deliveryAlert.id}
       >
-        <DialogTitle align="center">Delivery - warning!</DialogTitle>
+        <DialogTitle align="center">
+          Delivery - warning!{titleUpdateText(deliveryAlert.action)}
+        </DialogTitle>
         <Divider />
         <DialogContent>
           <TextField


### PR DESCRIPTION
## What's new

* Fix database saving by using inherited model of `DeliveryAlertPydantic`
* push update to subscriptions when a delivery alert action happens
* consider action taken when updated delivery alert action is not `waiting`
* display action update to title as well, otherwise it is rather confusing to users, which action was taken by someone else

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test