### PR TITLE
Obstructed and Cancelled delivery alert category with desired behaviors

### DIFF
--- a/packages/api-server/api_server/models/delivery_alerts.py
+++ b/packages/api-server/api_server/models/delivery_alerts.py
@@ -14,6 +14,10 @@ def category_from_msg(category: int) -> str:
             value = ttm.DeliveryAlert.Category.Missing
         case 1:
             value = ttm.DeliveryAlert.Category.Wrong
+        case 2:
+            value = ttm.DeliveryAlert.Category.Obstructed
+        case 3:
+            value = ttm.DeliveryAlert.Category.Cancelled
         case _:
             pass
     return value
@@ -52,6 +56,10 @@ def category_to_msg(category: str) -> int:
             value = 0
         case ttm.DeliveryAlert.Category.Wrong:
             value = 1
+        case ttm.DeliveryAlert.Category.Obstructed:
+            value = 2
+        case ttm.DeliveryAlert.Category.Cancelled:
+            value = 3
         case _:
             pass
     return value

--- a/packages/api-server/api_server/models/tortoise_models/delivery_alerts.py
+++ b/packages/api-server/api_server/models/tortoise_models/delivery_alerts.py
@@ -13,6 +13,8 @@ class DeliveryAlert(Model):
     class Category(str, Enum):
         Missing = "missing"
         Wrong = "wrong"
+        Obstructed = "obstructed"
+        Cancelled = "cancelled"
 
     class Tier(str, Enum):
         Warning = "warning"


### PR DESCRIPTION
## What's new

* Works with https://github.com/open-rmf/rmf_internal_msgs/commit/0997d89ae93efd1a06359d5f4270bf3738e5160c
* Added `obstructed` and `cancelled` delivery alert category
* For `obstructed`
  * no UI action needed, message will instruct users to move things out of the way of the robot
  * user can close the alert, but if the dashboard is refreshed, it will pop out again if the obstruction is still ongoing
  * once fleet adapter is able to continue, it will send another delivery alert request with the same IDs to update action to `resume`, the delivery alert will then stop showing up
* For `cancelled`
  * we expect it to only have tier `error`
  * if however a tier `warning` comes through, it will be promoted to tier `error` with a console warning
  * no user interaction expected, they can only close it


https://github.com/open-rmf/rmf-web/assets/5383623/3817ab58-9e7c-4fab-bfb3-e9aaec92a6c1


## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test