### PR TITLE
Rearrange schedule view, with better word prompts

### DIFF
--- a/packages/dashboard/src/components/tasks/tasks-app.tsx
+++ b/packages/dashboard/src/components/tasks/tasks-app.tsx
@@ -53,6 +53,8 @@ function tabPanelId(index: number): string {
 
 function TabPanel(props: TabPanelProps) {
   const { children, selectedTabIndex, index, ...other } = props;
+  // Removing top padding for Schedule as there is too much whitespace after
+  // the day-week-month view has been shifted to the right.
   return (
     <div
       role="tabpanel"
@@ -62,7 +64,10 @@ function TabPanel(props: TabPanelProps) {
       {...other}
     >
       {selectedTabIndex === index && (
-        <Box component="div" sx={{ p: 3 }}>
+        <Box
+          component="div"
+          sx={{ p: 3, pt: selectedTabIndex === TaskTablePanel.Schedule ? 0 : 3 }}
+        >
           {children}
         </Box>
       )}


### PR DESCRIPTION
## What's new

* Separated `Day`, `Week`, `Month` view change buttons away from `Today` as it is confusing what those buttons do together
* Change text of `Today` button based on view

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test