### PR TITLE
Hammer/permissions

### DIFF
--- a/packages/api-server/api_server/authenticator.py
+++ b/packages/api-server/api_server/authenticator.py
@@ -79,7 +79,7 @@ class JwtAuthenticator:
 
 class StubAuthenticator(JwtAuthenticator):
     def __init__(self):  # pylint: disable=super-init-not-called
-        self._user = User(username="stub", is_admin=False)
+        self._user = User(username="stub", is_admin=True)
 
     async def verify_token(self, token: Optional[str]) -> User:
         return self._user

--- a/packages/dashboard/src/components/delivery-alert-store.tsx
+++ b/packages/dashboard/src/components/delivery-alert-store.tsx
@@ -13,7 +13,6 @@ import { base } from 'react-components';
 import { AppControllerContext } from './app-contexts';
 import { RmfAppContext } from './rmf-app';
 import { TaskInspector } from './tasks/task-inspector';
-import { UserProfileContext } from 'rmf-auth';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -62,7 +61,6 @@ const DeliveryWarningDialog = React.memo((props: DeliveryWarningDialogProps) => 
   const [cancelling, setCancelling] = React.useState(false);
   const appController = React.useContext(AppControllerContext);
   const rmf = React.useContext(RmfAppContext);
-  const profile = React.useContext(UserProfileContext);
 
   React.useEffect(() => {
     if (deliveryAlert.action !== 'waiting') {
@@ -222,19 +220,6 @@ const DeliveryWarningDialog = React.memo((props: DeliveryWarningDialogProps) => 
           />
         </DialogContent>
         <DialogActions>
-          {newTaskState && profile && profile.user.is_admin ? (
-            <Tooltip title="Inspects the state and logs of the task.">
-              <Button
-                size="small"
-                variant="contained"
-                onClick={() => setOpenTaskInspector(true)}
-                disabled={false}
-                autoFocus
-              >
-                Inspect
-              </Button>
-            </Tooltip>
-          ) : null}
           {(newTaskState && newTaskState.status && newTaskState.status === 'canceled') ||
           deliveryAlert.category === 'cancelled' ? (
             <Button size="small" variant="contained" disabled autoFocus>

--- a/packages/dashboard/src/components/delivery-alert-store.tsx
+++ b/packages/dashboard/src/components/delivery-alert-store.tsx
@@ -13,6 +13,7 @@ import { base } from 'react-components';
 import { AppControllerContext } from './app-contexts';
 import { RmfAppContext } from './rmf-app';
 import { TaskInspector } from './tasks/task-inspector';
+import { UserProfileContext } from 'rmf-auth';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -61,6 +62,7 @@ const DeliveryWarningDialog = React.memo((props: DeliveryWarningDialogProps) => 
   const [cancelling, setCancelling] = React.useState(false);
   const appController = React.useContext(AppControllerContext);
   const rmf = React.useContext(RmfAppContext);
+  const profile = React.useContext(UserProfileContext);
 
   React.useEffect(() => {
     if (deliveryAlert.action !== 'waiting') {
@@ -220,7 +222,7 @@ const DeliveryWarningDialog = React.memo((props: DeliveryWarningDialogProps) => 
           />
         </DialogContent>
         <DialogActions>
-          {newTaskState ? (
+          {newTaskState && profile && profile.user.is_admin ? (
             <Tooltip title="Inspects the state and logs of the task.">
               <Button
                 size="small"

--- a/packages/dashboard/src/components/robots/robot-summary.tsx
+++ b/packages/dashboard/src/components/robots/robot-summary.tsx
@@ -32,6 +32,8 @@ import {
   BatteryChargingFull,
   BatteryUnknown,
 } from '@mui/icons-material';
+import { UserProfileContext } from 'rmf-auth';
+import { TaskCancelButton } from '../tasks/task-cancellation';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -110,6 +112,7 @@ const showBatteryIcon = (robot: RobotState, robotBattery: number) => {
 export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) => {
   const classes = useStyles();
   const rmf = React.useContext(RmfAppContext);
+  const profile = React.useContext(UserProfileContext);
 
   const [isOpen, setIsOpen] = React.useState(true);
   const [robotState, setRobotState] = React.useState<RobotState | null>(null);
@@ -280,15 +283,22 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
       )}
       <DialogContent>{returnDialogContent()}</DialogContent>
       <DialogActions sx={{ justifyContent: 'center' }}>
-        <Button
+        {profile && profile.user.is_admin ? (
+          <Button
+            size="small"
+            variant="contained"
+            onClick={() => setOpenTaskDetailsLogs(true)}
+            autoFocus
+            disabled={taskState === null}
+          >
+            Inspect Task
+          </Button>
+        ) : null}
+        <TaskCancelButton
+          taskId={taskState ? taskState.booking.id : null}
           size="small"
           variant="contained"
-          onClick={() => setOpenTaskDetailsLogs(true)}
-          autoFocus
-          disabled={taskState === null}
-        >
-          Inspect Task
-        </Button>
+        />
       </DialogActions>
       {openTaskDetailsLogs && taskState && (
         <TaskInspector task={taskState} onClose={() => setOpenTaskDetailsLogs(false)} />

--- a/packages/dashboard/src/components/robots/robot-summary.tsx
+++ b/packages/dashboard/src/components/robots/robot-summary.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  Button,
   Dialog,
   DialogActions,
   DialogContent,
@@ -32,7 +31,6 @@ import {
   BatteryChargingFull,
   BatteryUnknown,
 } from '@mui/icons-material';
-import { UserProfileContext } from 'rmf-auth';
 import { TaskCancelButton } from '../tasks/task-cancellation';
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -112,7 +110,6 @@ const showBatteryIcon = (robot: RobotState, robotBattery: number) => {
 export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) => {
   const classes = useStyles();
   const rmf = React.useContext(RmfAppContext);
-  const profile = React.useContext(UserProfileContext);
 
   const [isOpen, setIsOpen] = React.useState(true);
   const [robotState, setRobotState] = React.useState<RobotState | null>(null);
@@ -283,17 +280,6 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
       )}
       <DialogContent>{returnDialogContent()}</DialogContent>
       <DialogActions sx={{ justifyContent: 'center' }}>
-        {profile && profile.user.is_admin ? (
-          <Button
-            size="small"
-            variant="contained"
-            onClick={() => setOpenTaskDetailsLogs(true)}
-            autoFocus
-            disabled={taskState === null}
-          >
-            Inspect Task
-          </Button>
-        ) : null}
         <TaskCancelButton
           taskId={taskState ? taskState.booking.id : null}
           size="small"

--- a/packages/dashboard/src/components/tasks/task-alert.tsx
+++ b/packages/dashboard/src/components/tasks/task-alert.tsx
@@ -287,7 +287,7 @@ export function TaskAlertDialog({ alert, removeAlert }: TaskAlertDialogProps): J
         onDismiss={removeAlert}
         acknowledgedBy={taskAlert.acknowledgedBy}
         onAcknowledge={taskAlert.acknowledgedBy ? undefined : acknowledgeAlert}
-        onInspect={() => setOpenTaskInspector(true)}
+        // onInspect={() => setOpenTaskInspector(true)}
         title={taskAlert.title}
         progress={taskAlert.progress}
         alertContents={taskAlert.content}

--- a/packages/dashboard/src/components/tasks/task-alert.tsx
+++ b/packages/dashboard/src/components/tasks/task-alert.tsx
@@ -287,7 +287,6 @@ export function TaskAlertDialog({ alert, removeAlert }: TaskAlertDialogProps): J
         onDismiss={removeAlert}
         acknowledgedBy={taskAlert.acknowledgedBy}
         onAcknowledge={taskAlert.acknowledgedBy ? undefined : acknowledgeAlert}
-        // onInspect={() => setOpenTaskInspector(true)}
         title={taskAlert.title}
         progress={taskAlert.progress}
         alertContents={taskAlert.content}

--- a/packages/dashboard/src/components/tasks/task-cancellation.tsx
+++ b/packages/dashboard/src/components/tasks/task-cancellation.tsx
@@ -1,0 +1,93 @@
+import { Button, ButtonProps, Theme, Tooltip } from '@mui/material';
+import { TaskState } from 'api-client';
+import React from 'react';
+import { AppControllerContext } from '../app-contexts';
+import { AppEvents } from '../app-events';
+import { RmfAppContext } from '../rmf-app';
+import { UserProfileContext } from 'rmf-auth';
+import { Enforcer } from '../permissions';
+import { makeStyles, createStyles } from '@mui/styles';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    enableHover: {
+      '&.Mui-disabled': {
+        pointerEvents: 'auto',
+      },
+    },
+  }),
+);
+
+export interface TaskCancelButtonProp extends ButtonProps {
+  taskId: string | null;
+}
+
+export function TaskCancelButton({ taskId, ...otherProps }: TaskCancelButtonProp): JSX.Element {
+  const classes = useStyles();
+  const rmf = React.useContext(RmfAppContext);
+  const appController = React.useContext(AppControllerContext);
+  const profile = React.useContext(UserProfileContext);
+
+  const [taskState, setTaskState] = React.useState<TaskState | null>(null);
+
+  React.useEffect(() => {
+    if (!rmf || !taskId) {
+      return;
+    }
+    const sub = rmf.getTaskStateObs(taskId).subscribe(setTaskState);
+    return () => sub.unsubscribe();
+  }, [rmf, taskId]);
+
+  const taskCancellable =
+    taskState &&
+    taskState.status &&
+    !['canceled', 'killed', 'completed', 'failed'].includes(taskState.status);
+  const userCanCancelTask = profile && Enforcer.canCancelTask(profile);
+
+  function capitalizeFirstLetter(status: string): string {
+    return status.charAt(0).toUpperCase() + status.slice(1);
+  }
+
+  const handleCancelTaskClick = React.useCallback<React.MouseEventHandler>(async () => {
+    if (!taskState) {
+      return;
+    }
+    try {
+      if (!rmf) {
+        throw new Error('tasks api not available');
+      }
+      await rmf.tasksApi?.postCancelTaskTasksCancelTaskPost({
+        type: 'cancel_task_request',
+        task_id: taskState.booking.id,
+      });
+      appController.showAlert('success', 'Successfully cancelled task');
+      AppEvents.taskSelect.next(null);
+    } catch (e) {
+      appController.showAlert('error', `Failed to cancel task: ${(e as Error).message}`);
+    }
+  }, [appController, taskState, rmf]);
+
+  return taskCancellable && userCanCancelTask ? (
+    <Button onClick={handleCancelTaskClick} autoFocus {...otherProps}>
+      Cancel Task
+    </Button>
+  ) : taskCancellable && !userCanCancelTask ? (
+    <Tooltip title="You don't have permission to cancel tasks.">
+      <Button disabled className={classes['enableHover']} {...otherProps}>
+        Cancel Task
+      </Button>
+    </Tooltip>
+  ) : (
+    <Tooltip
+      title={
+        taskState && taskState.status
+          ? `${capitalizeFirstLetter(taskState.status)} task cannot be cancelled.`
+          : `Task cannot be cancelled.`
+      }
+    >
+      <Button disabled className={classes['enableHover']} {...otherProps}>
+        Cancel Task
+      </Button>
+    </Tooltip>
+  );
+}

--- a/packages/dashboard/src/components/tasks/task-schedule.tsx
+++ b/packages/dashboard/src/components/tasks/task-schedule.tsx
@@ -24,6 +24,7 @@ import {
 import { useCreateTaskFormData } from '../../hooks/useCreateTaskForm';
 import useGetUsername from '../../hooks/useFetchUser';
 import { AppControllerContext } from '../app-contexts';
+import { UserProfileContext } from 'rmf-auth';
 import { AppEvents } from '../app-events';
 import { RmfAppContext } from '../rmf-app';
 import { toApiSchedule } from './utils';
@@ -68,6 +69,8 @@ const disablingCellsWithoutEvents = (
 export const TaskSchedule = () => {
   const rmf = React.useContext(RmfAppContext);
   const { showAlert } = React.useContext(AppControllerContext);
+  const profile = React.useContext(UserProfileContext);
+
   const { waypointNames, pickupPoints, dropoffPoints, cleaningZoneNames } =
     useCreateTaskFormData(rmf);
   const username = useGetUsername(rmf);
@@ -162,6 +165,7 @@ export const TaskSchedule = () => {
           currentValue={EventScopes.CURRENT}
           allValue={EventScopes.ALL}
           value={value}
+          isAdmin={profile ? profile.user.is_admin : false}
           onChange={onChange}
         />
       </ConfirmationDialog>
@@ -428,6 +432,7 @@ export const TaskSchedule = () => {
             currentValue={EventScopes.CURRENT}
             allValue={EventScopes.ALL}
             value={eventScope}
+            isAdmin={profile ? profile.user.is_admin : false}
             onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
               setEventScope(event.target.value)
             }

--- a/packages/dashboard/src/components/tasks/task-summary.tsx
+++ b/packages/dashboard/src/components/tasks/task-summary.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   Box,
-  Button,
   LinearProgress,
   LinearProgressProps,
   Theme,
@@ -18,7 +17,6 @@ import { Status, TaskState } from 'api-client';
 import { base } from 'react-components';
 import { TaskInspector } from './task-inspector';
 import { RmfAppContext } from '../rmf-app';
-import { UserProfileContext } from 'rmf-auth';
 import { TaskCancelButton } from './task-cancellation';
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -75,7 +73,6 @@ export interface TaskSummaryProps {
 export const TaskSummary = React.memo((props: TaskSummaryProps) => {
   const classes = useStyles();
   const rmf = React.useContext(RmfAppContext);
-  const profile = React.useContext(UserProfileContext);
 
   const { onClose, task } = props;
 
@@ -190,16 +187,6 @@ export const TaskSummary = React.memo((props: TaskSummaryProps) => {
       )}
       <DialogContent>{returnDialogContent()}</DialogContent>
       <DialogActions sx={{ justifyContent: 'center' }}>
-        {profile && profile.user.is_admin ? (
-          <Button
-            size="small"
-            variant="contained"
-            onClick={() => setOpenTaskDetailsLogs(true)}
-            autoFocus
-          >
-            Inspect
-          </Button>
-        ) : null}
         <TaskCancelButton
           taskId={taskState ? taskState.booking.id : null}
           size="small"

--- a/packages/dashboard/src/components/tasks/task-summary.tsx
+++ b/packages/dashboard/src/components/tasks/task-summary.tsx
@@ -18,6 +18,8 @@ import { Status, TaskState } from 'api-client';
 import { base } from 'react-components';
 import { TaskInspector } from './task-inspector';
 import { RmfAppContext } from '../rmf-app';
+import { UserProfileContext } from 'rmf-auth';
+import { TaskCancelButton } from './task-cancellation';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -73,6 +75,7 @@ export interface TaskSummaryProps {
 export const TaskSummary = React.memo((props: TaskSummaryProps) => {
   const classes = useStyles();
   const rmf = React.useContext(RmfAppContext);
+  const profile = React.useContext(UserProfileContext);
 
   const { onClose, task } = props;
 
@@ -187,14 +190,21 @@ export const TaskSummary = React.memo((props: TaskSummaryProps) => {
       )}
       <DialogContent>{returnDialogContent()}</DialogContent>
       <DialogActions sx={{ justifyContent: 'center' }}>
-        <Button
+        {profile && profile.user.is_admin ? (
+          <Button
+            size="small"
+            variant="contained"
+            onClick={() => setOpenTaskDetailsLogs(true)}
+            autoFocus
+          >
+            Inspect
+          </Button>
+        ) : null}
+        <TaskCancelButton
+          taskId={taskState ? taskState.booking.id : null}
           size="small"
           variant="contained"
-          onClick={() => setOpenTaskDetailsLogs(true)}
-          autoFocus
-        >
-          Inspect
-        </Button>
+        />
       </DialogActions>
       {openTaskDetailsLogs && (
         <TaskInspector task={taskState} onClose={() => setOpenTaskDetailsLogs(false)} />

--- a/packages/react-components/lib/tasks/task-schedule-event-edit-delete-popup.spec.tsx
+++ b/packages/react-components/lib/tasks/task-schedule-event-edit-delete-popup.spec.tsx
@@ -14,6 +14,7 @@ describe('EventEditDeletePopup', () => {
         currentValue={currentValue}
         allValue={allValue}
         value={value}
+        isAdmin={true}
         onChange={onChange}
       />,
     );
@@ -23,5 +24,20 @@ describe('EventEditDeletePopup', () => {
 
     // Check if the onChange function was called with the correct value
     expect(onChange).toHaveBeenCalled();
+  });
+
+  it('all events change disabled for non-admin', () => {
+    const { getByLabelText } = render(
+      <EventEditDeletePopup
+        currentValue={currentValue}
+        allValue={allValue}
+        value={value}
+        isAdmin={false}
+        onChange={onChange}
+      />,
+    );
+
+    // Check that changing all events is disabled for non-admins
+    expect(getByLabelText('All events in this schedule').toHaveAttribute('disabled'));
   });
 });

--- a/packages/react-components/lib/tasks/task-schedule-event-edit-delete-popup.spec.tsx
+++ b/packages/react-components/lib/tasks/task-schedule-event-edit-delete-popup.spec.tsx
@@ -37,7 +37,10 @@ describe('EventEditDeletePopup', () => {
       />,
     );
 
-    // Check that changing all events is disabled for non-admins
-    expect(getByLabelText('All events in this schedule').toHaveAttribute('disabled'));
+    // Simulate a change event by clicking on a radio button
+    fireEvent.click(getByLabelText('All events in this schedule'));
+
+    // Check that onChange was not called since the button is disabled
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-components/lib/tasks/task-schedule-event-edit-delete-popup.spec.tsx
+++ b/packages/react-components/lib/tasks/task-schedule-event-edit-delete-popup.spec.tsx
@@ -25,22 +25,4 @@ describe('EventEditDeletePopup', () => {
     // Check if the onChange function was called with the correct value
     expect(onChange).toHaveBeenCalled();
   });
-
-  it('all events change disabled for non-admin', () => {
-    const { getByLabelText } = render(
-      <EventEditDeletePopup
-        currentValue={currentValue}
-        allValue={allValue}
-        value={value}
-        isAdmin={false}
-        onChange={onChange}
-      />,
-    );
-
-    // Simulate a change event by clicking on a radio button
-    fireEvent.click(getByLabelText('All events in this schedule'));
-
-    // Check that onChange was not called since the button is disabled
-    expect(onChange).not.toHaveBeenCalled();
-  });
 });

--- a/packages/react-components/lib/tasks/task-schedule-event-edit-delete-popup.tsx
+++ b/packages/react-components/lib/tasks/task-schedule-event-edit-delete-popup.tsx
@@ -5,6 +5,7 @@ interface EventEditDeletePopupProps {
   currentValue: string;
   allValue: string;
   value: string;
+  isAdmin: boolean;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
@@ -12,6 +13,7 @@ export function EventEditDeletePopup({
   currentValue,
   allValue,
   value,
+  isAdmin,
   onChange,
 }: EventEditDeletePopupProps): JSX.Element {
   return (
@@ -25,6 +27,7 @@ export function EventEditDeletePopup({
         <FormControlLabel value={currentValue} control={<Radio />} label={'This event'} />
         <FormControlLabel
           value={allValue}
+          disabled={isAdmin}
           control={<Radio />}
           label={'All events in this schedule'}
         />

--- a/packages/react-components/lib/tasks/task-schedule-event-edit-delete-popup.tsx
+++ b/packages/react-components/lib/tasks/task-schedule-event-edit-delete-popup.tsx
@@ -27,7 +27,7 @@ export function EventEditDeletePopup({
         <FormControlLabel value={currentValue} control={<Radio />} label={'This event'} />
         <FormControlLabel
           value={allValue}
-          disabled={isAdmin}
+          disabled={!isAdmin}
           control={<Radio />}
           label={'All events in this schedule'}
         />


### PR DESCRIPTION
## What's new

* `stub` to be admin
* only admins allowed to cancel tasks
* refactored task cancellation button into a component that handles enforcing permissions, events and toasts
* edit schedule series only available for admins
* removed all inspect buttons

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test