### PR TITLE
If the obstruction is related to a latching issue, allow resume

### DIFF
--- a/packages/dashboard/src/components/delivery-alert-store.tsx
+++ b/packages/dashboard/src/components/delivery-alert-store.tsx
@@ -693,12 +693,19 @@ export const DeliveryAlertStore = React.memo(() => {
           );
         }
 
+        // Allow resume if the obstruction is related to a latching problem.
         return (
           <DeliveryWarningDialog
             deliveryAlert={alert.deliveryAlert}
             taskState={alert.taskState}
             onOverride={alert.deliveryAlert.category === 'wrong' ? onOverride : undefined}
-            onResume={alert.deliveryAlert.category === 'obstructed' ? undefined : onResume}
+            onResume={
+              alert.deliveryAlert.category !== 'obstructed'
+                ? onResume
+                : alert.deliveryAlert.message && alert.deliveryAlert.message.includes(' latch ')
+                ? onResume
+                : undefined
+            }
             onClose={() =>
               setAlerts((prev) =>
                 Object.fromEntries(

--- a/packages/dashboard/src/components/tasks/task-schedule.tsx
+++ b/packages/dashboard/src/components/tasks/task-schedule.tsx
@@ -8,7 +8,7 @@ import {
   SchedulerHelpers,
   SchedulerProps,
 } from '@aldabil/react-scheduler/types';
-import { Button, Grid } from '@mui/material';
+import { Button } from '@mui/material';
 import {
   ApiServerModelsTortoiseModelsScheduledTaskScheduledTask as ScheduledTask,
   ApiServerModelsTortoiseModelsScheduledTaskScheduledTaskScheduleLeaf as ApiSchedule,
@@ -95,6 +95,7 @@ export const TaskSchedule = () => {
     const sub = AppEvents.refreshTaskApp.subscribe({
       next: () => {
         setRefreshTaskAppCount((oldValue) => ++oldValue);
+        console.log('refresh called');
       },
     });
     return () => sub.unsubscribe();
@@ -261,95 +262,15 @@ export const TaskSchedule = () => {
       disablingCellsWithoutEvents(calendarEvents, { start, ...props }),
   };
 
-  interface ViewSettings {
-    daySettings: DayProps | null;
-    weekSettings: WeekProps | null;
-    monthSettings: MonthProps | null;
-  }
-
-  const [viewSettings, setViewSettings] = React.useState<ViewSettings>({
-    daySettings: null,
-    weekSettings: defaultWeekSettings,
-    monthSettings: null,
-  });
-
-  const translations = {
-    navigation: {
-      month: 'Month',
-      week: 'Week',
-      day: 'Day',
-      today: 'Go to today',
-    },
-    form: {
-      addTitle: 'Add Event',
-      editTitle: 'Edit Event',
-      confirm: 'Confirm',
-      delete: 'Delete',
-      cancel: 'Cancel',
-    },
-    event: {
-      title: 'Title',
-      start: 'Start',
-      end: 'End',
-      allDay: 'All Day',
-    },
-    moreEvents: 'More...',
-    loading: 'Loading...',
-  };
-
   return (
     <div style={{ height: '100%', width: '100%' }}>
-      <Grid container justifyContent="flex-end">
-        <Button
-          size={'small'}
-          sx={viewSettings.daySettings ? { borderBottom: 2, borderRadius: 0 } : {}}
-          onClick={() => {
-            setViewSettings({
-              daySettings: defaultDaySettings,
-              weekSettings: null,
-              monthSettings: null,
-            });
-            AppEvents.refreshTaskApp.next();
-          }}
-        >
-          Day
-        </Button>
-        <Button
-          size={'small'}
-          sx={viewSettings.weekSettings ? { borderBottom: 2, borderRadius: 0 } : {}}
-          onClick={() => {
-            setViewSettings({
-              daySettings: null,
-              weekSettings: defaultWeekSettings,
-              monthSettings: null,
-            });
-            AppEvents.refreshTaskApp.next();
-          }}
-        >
-          Week
-        </Button>
-        <Button
-          size={'small'}
-          sx={viewSettings.monthSettings ? { borderBottom: 2, borderRadius: 0 } : {}}
-          onClick={() => {
-            setViewSettings({
-              daySettings: null,
-              weekSettings: null,
-              monthSettings: defaultMonthSettings,
-            });
-            AppEvents.refreshTaskApp.next();
-          }}
-        >
-          Month
-        </Button>
-      </Grid>
       <Scheduler
         // react-scheduler does not support refreshing, workaround by mounting a new instance.
         key={`scheduler-${refreshTaskAppCount}`}
         view="week"
-        day={viewSettings.daySettings}
-        week={viewSettings.weekSettings}
-        month={viewSettings.monthSettings}
+        day={defaultDaySettings}
+        week={defaultWeekSettings}
+        month={defaultMonthSettings}
         draggable={false}
         editable={true}
         getRemoteEvents={getRemoteEvents}
@@ -371,17 +292,6 @@ export const TaskSchedule = () => {
             }}
           />
         )}
-        translations={{
-          ...translations,
-          navigation: {
-            ...translations.navigation,
-            today: viewSettings.daySettings
-              ? 'Today'
-              : viewSettings.weekSettings
-              ? 'This week'
-              : 'This month',
-          },
-        }}
       />
       {openCreateTaskForm && (
         <CreateTaskForm

--- a/packages/dashboard/src/components/tasks/task-schedule.tsx
+++ b/packages/dashboard/src/components/tasks/task-schedule.tsx
@@ -95,7 +95,6 @@ export const TaskSchedule = () => {
     const sub = AppEvents.refreshTaskApp.subscribe({
       next: () => {
         setRefreshTaskAppCount((oldValue) => ++oldValue);
-        console.log('refresh called');
       },
     });
     return () => sub.unsubscribe();

--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -271,7 +271,7 @@ function DeliveryTaskForm({
           id="pickup-location"
           freeSolo
           fullWidth
-          options={Object.keys(pickupPoints)}
+          options={Object.keys(pickupPoints).sort()}
           value={taskDesc.phases[0].activity.description.activities[0].description}
           onInputChange={(_ev, newValue) => {
             const pickupLot = pickupPoints[newValue] ?? '';
@@ -358,7 +358,7 @@ function DeliveryTaskForm({
           id="dropoff-location"
           freeSolo
           fullWidth
-          options={Object.keys(dropoffPoints)}
+          options={Object.keys(dropoffPoints).sort()}
           value={taskDesc.phases[0].activity.description.activities[2].description}
           onInputChange={(_ev, newValue) => {
             const newTaskDesc = { ...taskDesc };
@@ -428,7 +428,7 @@ function DeliveryCustomTaskForm({
           id="pickup-zone"
           freeSolo
           fullWidth
-          options={pickupZones}
+          options={pickupZones.sort()}
           value={taskDesc.phases[0].activity.description.activities[0].description}
           onInputChange={(_ev, newValue) => {
             const newTaskDesc = { ...taskDesc };
@@ -513,7 +513,7 @@ function DeliveryCustomTaskForm({
           id="dropoff-location"
           freeSolo
           fullWidth
-          options={dropoffPoints}
+          options={dropoffPoints.sort()}
           value={taskDesc.phases[0].activity.description.activities[2].description}
           onInputChange={(_ev, newValue) => {
             const newTaskDesc = { ...taskDesc };
@@ -609,7 +609,7 @@ function PatrolTaskForm({ taskDesc, patrolWaypoints, onChange, allowSubmit }: Pa
           id="place-input"
           freeSolo
           fullWidth
-          options={patrolWaypoints}
+          options={patrolWaypoints.sort()}
           onChange={(_ev, newValue) =>
             newValue !== null &&
             onInputChange({


### PR DESCRIPTION
## What's new

* Fix schedule change day, week, month view (revert to original design provided by library)
* Allow resume if obstruction delivery alert is due to a latching problem 
* Sort option fields in task creation form, except for Cart IDs

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test
