### PR TITLE
Catch failure to load old schedules in database

### DIFF
--- a/packages/api-server/api_server/app.py
+++ b/packages/api-server/api_server/app.py
@@ -199,10 +199,14 @@ async def on_startup():
             logger.warning(f"user [{t.created_by}] does not exist")
             continue
         task_repo = TaskRepository(user)
-        await routes.scheduled_tasks.schedule_task(t, task_repo)
-        scheduled += 1
-    logger.info(f"loaded {scheduled} tasks")
-    logger.info("successfully started scheduler")
+        try:
+            await routes.scheduled_tasks.schedule_task(t, task_repo)
+            scheduled += 1
+        except Exception as e:
+            logger.warning(
+                f"Unable to schedule task request with id [{t.id}] by {t.created_by}: {e}"
+            )
+            logger.warning(f"Skipping request: [{t.task_request}]")
 
     ros.spin_background()
     logger.info("started app")

--- a/packages/api-server/api_server/app.py
+++ b/packages/api-server/api_server/app.py
@@ -204,9 +204,7 @@ async def on_startup():
             await routes.scheduled_tasks.schedule_task(t, task_repo)
             scheduled += 1
         except Exception as e:
-            logger.warning(
-                f"Unable to schedule task request with id [{t.id}] by {t.created_by}: {e}"
-            )
+            logger.warning(f"Unable to schedule task requested by {t.created_by}: {e}")
             logger.warning(f"Skipping request: [{t.task_request}]")
     logger.info(
         f"Retrieved {len(scheduled_tasks)} scheduled tasks, scheduled {scheduled} tasks"

--- a/packages/api-server/api_server/app.py
+++ b/packages/api-server/api_server/app.py
@@ -203,7 +203,7 @@ async def on_startup():
         try:
             await routes.scheduled_tasks.schedule_task(t, task_repo)
             scheduled += 1
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-except
             logger.warning(f"Unable to schedule task requested by {t.created_by}: {e}")
             logger.warning(f"Skipping request: [{t.task_request}]")
     logger.info(

--- a/packages/api-server/api_server/app.py
+++ b/packages/api-server/api_server/app.py
@@ -196,7 +196,8 @@ async def on_startup():
     for t in scheduled_tasks:
         user = await User.load_from_db(t.created_by)
         if user is None:
-            logger.warning(f"user [{t.created_by}] does not exist")
+            logger.warning(f"User who scheduled task, [{t.created_by}] does not exist")
+            logger.warning(f"Skipping request: [{t.task_request}]")
             continue
         task_repo = TaskRepository(user)
         try:
@@ -207,6 +208,9 @@ async def on_startup():
                 f"Unable to schedule task request with id [{t.id}] by {t.created_by}: {e}"
             )
             logger.warning(f"Skipping request: [{t.task_request}]")
+    logger.info(
+        f"Retrieved {len(scheduled_tasks)} scheduled tasks, scheduled {scheduled} tasks"
+    )
 
     ros.spin_background()
     logger.info("started app")

--- a/packages/api-server/api_server/authenticator.py
+++ b/packages/api-server/api_server/authenticator.py
@@ -81,18 +81,18 @@ class StubAuthenticator(JwtAuthenticator):
     def __init__(self):  # pylint: disable=super-init-not-called
         self._user = None
 
-    async def _get_user(self) -> User:
+    async def _get_user(self, claims: dict) -> User:
         if self._user is None:
             self._user = await User.load_or_create_from_db("stub")
             await self._user.update_admin(True)
         return self._user
 
     async def verify_token(self, token: Optional[str]) -> User:
-        return await self._get_user()
+        return await self._get_user({})
 
     def fastapi_dep(self) -> Callable[..., Union[Coroutine[Any, Any, User], User]]:
         async def dep():
-            return await self._get_user()
+            return await self._get_user({})
 
         return dep
 

--- a/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
+++ b/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
@@ -54,6 +54,7 @@ async def schedule_task(task: ttm.ScheduledTask, task_repo: TaskRepository):
         if datetime_to_iso[:10] in task.except_dates:
             return
         asyncio.get_event_loop().create_task(run())
+        logger.warning(f"schedule has {len(schedule.get_jobs())} jobs left")
 
     for _, j in jobs:
         j.do(do)

--- a/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
+++ b/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
@@ -150,7 +150,10 @@ async def del_scheduled_tasks_event(
     for sche in task.schedules:
         schedule.clear(sche.get_id())
 
-    await schedule_task(task, task_repo)
+    try:
+        await schedule_task(task, task_repo)
+    except schedule.ScheduleError as e:
+        raise HTTPException(422, str(e)) from e
 
 
 @router.post(

--- a/packages/api-server/psql_local_config.py
+++ b/packages/api-server/psql_local_config.py
@@ -7,7 +7,7 @@ run_dir = f"{here}/run"
 
 config.update(
     {
-        "db_url": "postgres://postgres:postgres@127.0.0.1:5432/rmf-web-rmf-server",
+        "db_url": "postgres://postgres:postgres@127.0.0.1:5432",
         "cache_directory": f"{run_dir}/cache",  # The directory where cached files should be stored.
     }
 )

--- a/packages/api-server/psql_local_config.py
+++ b/packages/api-server/psql_local_config.py
@@ -1,11 +1,13 @@
+import os
+
 from sqlite_local_config import config
 
-here = dirname(__file__)
+here = os.path.dirname(__file__)
 run_dir = f"{here}/run"
 
 config.update(
     {
-        "db_url": "postgres://postgres:postgres@127.0.0.1:5432",
+        "db_url": "postgres://postgres:postgres@127.0.0.1:5432/rmf-web-rmf-server",
         "cache_directory": f"{run_dir}/cache",  # The directory where cached files should be stored.
     }
 )

--- a/packages/dashboard/src/components/app-events.ts
+++ b/packages/dashboard/src/components/app-events.ts
@@ -18,6 +18,7 @@ export const AppEvents = {
   robotSelect: new Subject<[fleetName: string, robotName: string] | null>(),
   taskSelect: new Subject<TaskState | null>(),
   refreshTaskApp: new Subject<void>(),
+  refreshTaskSchedule: new Subject<void>(),
   refreshAlert: new Subject<void>(),
   alertListOpenedAlert: new Subject<Alert | null>(),
   disabledLayers: new ReplaySubject<Record<string, boolean>>(),

--- a/packages/dashboard/src/components/tasks/task-schedule.tsx
+++ b/packages/dashboard/src/components/tasks/task-schedule.tsx
@@ -75,7 +75,7 @@ export const TaskSchedule = () => {
     useCreateTaskFormData(rmf);
   const username = useGetUsername(rmf);
   const [eventScope, setEventScope] = React.useState<string>(EventScopes.CURRENT);
-  const [refreshTaskAppCount, setRefreshTaskAppCount] = React.useState(0);
+  const [refreshTaskScheduleCount, setRefreshTaskScheduleCount] = React.useState(0);
   const exceptDateRef = React.useRef<Date>(new Date());
   const currentEventIdRef = React.useRef<number>(-1);
   const [currentScheduleTask, setCurrentScheduledTask] = React.useState<ScheduledTask | undefined>(
@@ -92,9 +92,9 @@ export const TaskSchedule = () => {
   });
 
   React.useEffect(() => {
-    const sub = AppEvents.refreshTaskApp.subscribe({
+    const sub = AppEvents.refreshTaskSchedule.subscribe({
       next: () => {
-        setRefreshTaskAppCount((oldValue) => ++oldValue);
+        setRefreshTaskScheduleCount((oldValue) => ++oldValue);
       },
     });
     return () => sub.unsubscribe();
@@ -144,7 +144,7 @@ export const TaskSchedule = () => {
         onClose={() => {
           scheduler.close();
           setEventScope(EventScopes.CURRENT);
-          AppEvents.refreshTaskApp.next();
+          AppEvents.refreshTaskSchedule.next();
         }}
         onSubmit={() => {
           setOpenCreateTaskForm(true);
@@ -157,7 +157,7 @@ export const TaskSchedule = () => {
           if (eventScope === EventScopes.CURRENT) {
             setScheduleToEdit(scheduleWithSelectedDay(task.schedules, exceptDateRef.current));
           }
-          AppEvents.refreshTaskApp.next();
+          AppEvents.refreshTaskSchedule.next();
           scheduler.close();
         }}
       >
@@ -200,7 +200,7 @@ export const TaskSchedule = () => {
       );
 
       setEventScope(EventScopes.CURRENT);
-      AppEvents.refreshTaskApp.next();
+      AppEvents.refreshTaskSchedule.next();
     },
     [rmf, currentScheduleTask, eventScope],
   );
@@ -225,7 +225,7 @@ export const TaskSchedule = () => {
       } else {
         await rmf.tasksApi.delScheduledTasksScheduledTasksTaskIdDelete(task.id);
       }
-      AppEvents.refreshTaskApp.next();
+      AppEvents.refreshTaskSchedule.next();
 
       // Set the default values
       setOpenDeleteScheduleDialog(false);
@@ -265,7 +265,7 @@ export const TaskSchedule = () => {
     <div style={{ height: '100%', width: '100%' }}>
       <Scheduler
         // react-scheduler does not support refreshing, workaround by mounting a new instance.
-        key={`scheduler-${refreshTaskAppCount}`}
+        key={`scheduler-${refreshTaskScheduleCount}`}
         view="week"
         day={defaultDaySettings}
         week={defaultWeekSettings}
@@ -287,7 +287,7 @@ export const TaskSchedule = () => {
             value={eventScope}
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
               setEventScope(event.target.value);
-              AppEvents.refreshTaskApp.next();
+              AppEvents.refreshTaskSchedule.next();
             }}
           />
         )}
@@ -305,7 +305,7 @@ export const TaskSchedule = () => {
           onClose={() => {
             setOpenCreateTaskForm(false);
             setEventScope(EventScopes.CURRENT);
-            AppEvents.refreshTaskApp.next();
+            AppEvents.refreshTaskSchedule.next();
           }}
           submitTasks={submitTasks}
           onSuccess={() => {


### PR DESCRIPTION
## What's new

* Catch exception when server loads an old schedule from DB and it is invalid (because it is in the past)
* try catch for deletion of scheduled tasks events and scheduling a new one
* Fix psql script
* Fix constantly updating schedule app with new refresh task app event only for scheduler

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test