### PR TITLE
Frontend changes, more auth logs, relax token refresh interval

### DIFF
--- a/packages/dashboard/src/components/app-events.ts
+++ b/packages/dashboard/src/components/app-events.ts
@@ -18,6 +18,7 @@ export const AppEvents = {
   robotSelect: new Subject<[fleetName: string, robotName: string] | null>(),
   taskSelect: new Subject<TaskState | null>(),
   refreshTaskApp: new Subject<void>(),
+  refreshFavoriteTasks: new Subject<void>(),
   refreshTaskSchedule: new Subject<void>(),
   refreshAlert: new Subject<void>(),
   alertListOpenedAlert: new Subject<Alert | null>(),

--- a/packages/dashboard/src/components/rmf-app/rmf-ingress.ts
+++ b/packages/dashboard/src/components/rmf-app/rmf-ingress.ts
@@ -88,18 +88,24 @@ export class RmfIngress {
     // the axios swagger generator is bugged, it does not properly attach the token so we have
     // to manually add them.
     const axiosInst = axios.create();
-    axiosInst.interceptors.request.use(async (req) => {
-      await authenticator.refreshToken();
-      const token = authenticator.token;
-      if (!token) {
+    axiosInst.interceptors.request.use(
+      async (req) => {
+        await authenticator.refreshToken();
+        const token = authenticator.token;
+        if (!token) {
+          return req;
+        }
+        req.headers['Authorization'] = `Bearer ${token}`;
         return req;
-      }
-      req.headers['Authorization'] = `Bearer ${token}`;
-      return req;
-    });
+      },
+      (error) => {
+        console.error(`Axios request error: ${error}`);
+      },
+    );
     axiosInst.interceptors.response.use(
       (response) => response,
       (error) => {
+        console.error(`Axios response error: ${error}`);
         if (error.response.status === 401) {
           window.location.href = '/';
         }

--- a/packages/dashboard/src/components/rmf-app/rmf-ingress.ts
+++ b/packages/dashboard/src/components/rmf-app/rmf-ingress.ts
@@ -97,6 +97,14 @@ export class RmfIngress {
       req.headers['Authorization'] = `Bearer ${token}`;
       return req;
     });
+    axiosInst.interceptors.response.use(
+      (response) => response,
+      (error) => {
+        if (error.response.status === 401) {
+          window.location.href = '/';
+        }
+      },
+    );
     const apiConfig = new Configuration({
       accessToken: authenticator.token,
       basePath: appConfig.rmfServerUrl,

--- a/packages/react-components/lib/lifts/lift-request-dialog.tsx
+++ b/packages/react-components/lib/lifts/lift-request-dialog.tsx
@@ -3,6 +3,7 @@ import TextField from '@mui/material/TextField';
 import React from 'react';
 import { ConfirmationDialog, ConfirmationDialogProps } from '../confirmation-dialog';
 import { requestDoorModeToString, requestModeToString } from './lift-utils';
+import { LiftRequest as RmfLiftRequest } from 'rmf-models';
 
 const classes = {
   closeButton: 'lift-request-close-button',
@@ -136,6 +137,7 @@ export const LiftRequestDialog = ({
           getOptionLabel={(option) => option}
           onChange={(_, value) => setDestination(value || '')}
           options={availableLevels}
+          disabled={requestType === RmfLiftRequest.REQUEST_END_SESSION}
           renderInput={(params) => (
             <TextField
               {...params}
@@ -155,6 +157,7 @@ export const LiftRequestDialog = ({
           getOptionLabel={(option) => requestDoorModeToString(option)}
           onChange={(_, value) => setDoorState(value as number)}
           options={availableDoorModes}
+          disabled={requestType === RmfLiftRequest.REQUEST_END_SESSION}
           renderInput={(params) => (
             <TextField
               {...params}

--- a/packages/rmf-auth/lib/keycloak.ts
+++ b/packages/rmf-auth/lib/keycloak.ts
@@ -83,10 +83,10 @@ export class KeycloakAuthenticator
     try {
       const refreshed = await this._inst.updateToken(30);
       refreshed && debug('token refreshed');
-      console.log(`${new Date().toLocaleTimeString()}: token refreshed 30`);
+      console.log(`${new Date().toLocaleTimeString()}: initToken token refreshed 30`);
     } catch {
       debug('token not refreshed');
-      console.log(`${new Date().toLocaleTimeString()}: token not refreshed 30`);
+      console.log(`${new Date().toLocaleTimeString()}: initToken token not refreshed 30`);
     }
 
     this._user = this._inst.tokenParsed && this._getUser();
@@ -96,17 +96,17 @@ export class KeycloakAuthenticator
   }
 
   async refreshToken(): Promise<void> {
-    // check and update the token 5 seconds prior to expiry
+    // check and update the token 30 seconds prior to expiry
     if (this._initialized) {
-      const refreshed = await this._inst.updateToken(5);
+      const refreshed = await this._inst.updateToken(30);
       if (refreshed) {
         this._user = this._getUser();
         this._isAdmin = this._isUserAdmin();
         this.emit('tokenRefresh', null);
-        console.log(`${new Date().toLocaleTimeString()}: token refreshed 5`);
+        console.log(`${new Date().toLocaleTimeString()}: refreshToken token refreshed 30`);
       } else {
         debug('token not refreshed');
-        console.error(`${new Date().toLocaleTimeString()}: token not refreshed 5`);
+        console.error(`${new Date().toLocaleTimeString()}: refreshToken token not refreshed 30`);
       }
     }
     return;


### PR DESCRIPTION
## What's new

Various frontend changes and potential fix to auth issue
* selecting lift end session will disable all other options
* favorite tasks have its own event trigger, reducing the amount of task queue table recurring polling
* increasing the token refresh allowance to 30 seconds
* logs axios error during request or response, attempts to move client to route `/`
* alert when the client disconnects (WIP)

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test