### PR TITLE
Task json that accommodates on-cancel emergency lots

### DIFF
--- a/packages/dashboard/src/components/appbar.tsx
+++ b/packages/dashboard/src/components/appbar.tsx
@@ -552,6 +552,7 @@ export const AppBar = React.memo(({ extraToolbarItems }: AppBarProps): React.Rea
           cleaningZones={cleaningZoneNames}
           pickupZones={resourceManager?.pickupZones}
           cartIds={resourceManager?.cartIds}
+          emergencyLots={resourceManager?.emergencyLots}
           pickupPoints={pickupPoints}
           dropoffPoints={dropoffPoints}
           favoritesTasks={favoritesTasks}

--- a/packages/dashboard/src/components/appbar.tsx
+++ b/packages/dashboard/src/components/appbar.tsx
@@ -227,9 +227,6 @@ export const AppBar = React.memo(({ extraToolbarItems }: AppBarProps): React.Rea
       if (!rmf) {
         throw new Error('tasks api not available');
       }
-
-      console.log(taskRequests);
-
       if (!schedule) {
         await Promise.all(
           taskRequests.map((request) => {

--- a/packages/dashboard/src/components/appbar.tsx
+++ b/packages/dashboard/src/components/appbar.tsx
@@ -235,6 +235,9 @@ export const AppBar = React.memo(({ extraToolbarItems }: AppBarProps): React.Rea
       if (!rmf) {
         throw new Error('tasks api not available');
       }
+
+      console.log(taskRequests);
+
       if (!schedule) {
         await Promise.all(
           taskRequests.map((request) =>

--- a/packages/dashboard/src/managers/resource-manager.ts
+++ b/packages/dashboard/src/managers/resource-manager.ts
@@ -18,6 +18,7 @@ export interface ResourceConfigurationsType {
   attributionPrefix?: string;
   cartIds?: string[];
   loggedInDisplayLevel?: string;
+  emergencyLots?: string[];
 }
 
 export default class ResourceManager {
@@ -32,6 +33,7 @@ export default class ResourceManager {
   attributionPrefix?: string;
   cartIds?: string[];
   loggedInDisplayLevel?: string;
+  emergencyLots?: string[];
 
   /**
    * Gets the default resource manager using the embedded resource file (aka "assets/resources/main.json").
@@ -71,6 +73,7 @@ export default class ResourceManager {
     this.attributionPrefix = resources.attributionPrefix || 'OSRC-SG';
     this.cartIds = resources.cartIds || [];
     this.loggedInDisplayLevel = resources.loggedInDisplayLevel;
+    this.emergencyLots = resources.emergencyLots || [];
   }
 }
 

--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -88,6 +88,32 @@ interface DropoffActivity {
   };
 }
 
+interface OneOfWaypoint {
+  waypoint: string;
+}
+
+interface GoToOneOfThePlacesActivity {
+  category: string;
+  description: {
+    one_of: OneOfWaypoint[];
+    constraints: [
+      {
+        category: string;
+        description: string;
+      },
+    ];
+  };
+}
+
+interface OnCancelDropoff {
+  category: string;
+  description: [
+    dropoff_if_carrying_payload: DropoffActivity,
+    go_to_one_of_the_places: GoToOneOfThePlacesActivity,
+    delivery_dropoff: DropoffActivity,
+  ];
+}
+
 interface DeliveryCustomPhase {
   activity: {
     category: string;
@@ -100,6 +126,7 @@ interface DeliveryCustomPhase {
       ];
     };
   };
+  on_cancel: OnCancelDropoff[];
 }
 
 interface DeliveryCustomTaskDescription {
@@ -119,6 +146,7 @@ interface DeliveryPhase {
       ];
     };
   };
+  on_cancel: OnCancelDropoff[];
 }
 
 interface DeliveryTaskDescription {
@@ -775,6 +803,7 @@ function defaultDeliveryTaskDescription(): DeliveryTaskDescription {
             ],
           },
         },
+        on_cancel: [],
       },
     ],
   };
@@ -819,6 +848,7 @@ function defaultDeliveryCustomTaskDescription(taskCategory: string): DeliveryCus
             ],
           },
         },
+        on_cancel: [],
       },
     ],
   };
@@ -1155,6 +1185,44 @@ export function CreateTaskForm({
       // Workaround where all the task category need to be compose.
       if (t.category !== 'patrol') {
         t.category = 'compose';
+
+        const dropoffIfCarryingPayload: DropoffActivity = {
+          category: 'perform_action',
+          description: {
+            unix_millis_action_duration_estimate: 60000,
+            category: 'dropoff_if_carrying_payload',
+            description: {},
+          },
+        };
+        const goToOneOfThePlaces: GoToOneOfThePlacesActivity = {
+          category: 'go_to_place',
+          description: {
+            one_of: emergencyLots.map((placeName) => {
+              return {
+                waypoint: placeName,
+              };
+            }),
+            constraints: [
+              {
+                category: 'prefer_same_map',
+                description: '',
+              },
+            ],
+          },
+        };
+        const deliveryDropoff: DropoffActivity = {
+          category: 'perform_action',
+          description: {
+            unix_millis_action_duration_estimate: 60000,
+            category: 'delivery_dropoff',
+            description: {},
+          },
+        };
+        const onCancelDropoff: OnCancelDropoff = {
+          category: 'sequence',
+          description: [dropoffIfCarryingPayload, goToOneOfThePlaces, deliveryDropoff],
+        };
+        taskRequest.description.phases[0].on_cancel = [onCancelDropoff];
       }
     }
 

--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -942,6 +942,7 @@ export interface CreateTaskFormProps
   patrolWaypoints?: string[];
   pickupZones?: string[];
   cartIds?: string[];
+  emergencyLots?: string[];
   pickupPoints?: Record<string, string>;
   dropoffPoints?: Record<string, string>;
   favoritesTasks?: TaskFavorite[];
@@ -967,6 +968,7 @@ export function CreateTaskForm({
   patrolWaypoints = [],
   pickupZones = [],
   cartIds = [],
+  emergencyLots = [],
   pickupPoints = {},
   dropoffPoints = {},
   favoritesTasks = [],


### PR DESCRIPTION
## What's new

* `emergencyLots` added to `resourceManager`
* updated task json for deliveries and custom deliveries

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test