### PR TITLE
Revert jasmine and ts-node versions

### DIFF
--- a/packages/ros-translator/package.json
+++ b/packages/ros-translator/package.json
@@ -10,10 +10,10 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/jasmine": "^5.1.4",
-    "jasmine": "^5.1.0",
+    "@types/jasmine": "^3.8.2",
+    "jasmine": "^3.6.6",
     "pipenv-install": "workspace:*",
-    "ts-node": "^10.9.1",
+    "ts-node": "^9.1.1",
     "typescript": "~5.3.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -751,17 +751,17 @@ importers:
   packages/ros-translator:
     devDependencies:
       '@types/jasmine':
-        specifier: ^5.1.4
-        version: 5.1.4
+        specifier: ^3.8.2
+        version: 3.10.18
       jasmine:
-        specifier: ^5.1.0
-        version: 5.1.0
+        specifier: ^3.6.6
+        version: 3.99.0
       pipenv-install:
         specifier: workspace:*
         version: link:../../pipenv-install
       ts-node:
-        specifier: ^10.9.1
-        version: 10.9.1(@types/node@20.10.3)(typescript@5.3.2)
+        specifier: ^9.1.1
+        version: 9.1.1(typescript@5.3.2)
       typescript:
         specifier: ~5.3.2
         version: 5.3.2
@@ -6345,6 +6345,10 @@ packages:
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
+    dev: true
+
+  /@types/jasmine@3.10.18:
+    resolution: {integrity: sha512-jOk52a1Kz+1oU5fNWwAcNe64/GsE7r/Q6ronwDox0D3ETo/cr4ICMQyeXrj7G6FPW1n8YjRoAZA2F0XBr6GicQ==}
     dev: true
 
   /@types/jasmine@5.1.4:
@@ -12949,12 +12953,24 @@ packages:
       minimatch: 3.1.2
     dev: true
 
+  /jasmine-core@3.99.1:
+    resolution: {integrity: sha512-Hu1dmuoGcZ7AfyynN3LsfruwMbxMALMka+YtZeGoLuDEySVmVAPaonkNoBRIw/ectu8b9tVQCJNgp4a4knp+tg==}
+    dev: true
+
   /jasmine-core@4.6.0:
     resolution: {integrity: sha512-O236+gd0ZXS8YAjFx8xKaJ94/erqUliEkJTDedyE7iHvv4ZVqi+q+8acJxu05/WJDKm512EUNn809In37nWlAQ==}
     dev: true
 
   /jasmine-core@5.1.1:
     resolution: {integrity: sha512-UrzO3fL7nnxlQXlvTynNAenL+21oUQRlzqQFsA2U11ryb4+NLOCOePZ70PTojEaUKhiFugh7dG0Q+I58xlPdWg==}
+    dev: true
+
+  /jasmine@3.99.0:
+    resolution: {integrity: sha512-YIThBuHzaIIcjxeuLmPD40SjxkEcc8i//sGMDKCgkRMVgIwRJf5qyExtlJpQeh7pkeoBSOe6lQEdg+/9uKg9mw==}
+    hasBin: true
+    dependencies:
+      glob: 7.2.3
+      jasmine-core: 3.99.1
     dev: true
 
   /jasmine@5.1.0:
@@ -19726,6 +19742,22 @@ packages:
       make-error: 1.3.6
       source-map-support: 0.5.21
       typescript: 4.4.4
+      yn: 3.1.1
+    dev: true
+
+  /ts-node@9.1.1(typescript@5.3.2):
+    resolution: {integrity: sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=2.7'
+    dependencies:
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      source-map-support: 0.5.21
+      typescript: 5.3.2
       yn: 3.1.1
     dev: true
 


### PR DESCRIPTION
## What's new

Revert versions for jasmine and ts-node to get tests working again.

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test