### PR TITLE
Hammer/fix uat

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -958,11 +958,11 @@
         },
         "schedule": {
             "hashes": [
-                "sha256:617adce8b4bf38c360b781297d59918fbebfb2878f1671d189f4f4af5d0567a4",
-                "sha256:e6ca13585e62c810e13a08682e0a6a8ad245372e376ba2b8679294f377dfc8e4"
+                "sha256:14cdeb083a596aa1de6dc77639a1b2ac8bf6eaafa82b1c9279d3612823063d01",
+                "sha256:843bc0538b99c93f02b8b50e3e39886c06f2d003b24f48e1aa4cadfa3f341279"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.1.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==1.2.1"
         },
         "semver": {
             "hashes": [

--- a/packages/api-server/api_server/app_config.py
+++ b/packages/api-server/api_server/app_config.py
@@ -21,6 +21,7 @@ class AppConfig:
     aud: str
     iss: Optional[str]
     ros_args: List[str]
+    timezone: Optional[str]
 
     def __post_init__(self):
         self.public_url = urllib.parse.urlparse(cast(str, self.public_url))

--- a/packages/api-server/api_server/default_config.py
+++ b/packages/api-server/api_server/default_config.py
@@ -32,4 +32,8 @@ config = {
     # e.g.
     #   Run with sim time: ["-p", "use_sim_time:=true"]
     "ros_args": [],
+    # Timezone at which the scheduler will operate in. This must be the same
+    # as the system timezone, as well as the client UI timezone. Cross-timezone
+    # scheduling is currently not supported.
+    "timezone": None,
 }

--- a/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
+++ b/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
@@ -104,9 +104,8 @@ class ScheduledTaskSchedule(Model):
             print(f"setting at {self.at}")
             # job = job.at(self.at)
             # TODO(ac): not hardcode this timezone
-            job = job.at(
-                self.at, timezone("Asia/Singapore")
-            )  # pyright: ignore[reportGeneralTypeIssues]
+            tz = timezone("Asia/Singapore")  # pyright: ignore[reportGeneralTypeIssues]
+            job = job.at(self.at, tz)
 
         return job
 

--- a/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
+++ b/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
@@ -2,8 +2,8 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
+import pytz
 import schedule
-from pytz import timezone
 from schedule import Job
 from tortoise import Tortoise
 from tortoise.contrib.pydantic.creator import (
@@ -63,7 +63,7 @@ class ScheduledTaskSchedule(Model):
     def get_id(self) -> IntField:
         return self._id
 
-    def to_job(self) -> Job:
+    def to_job(self, timezone: Optional[str] = None) -> Job:
         if self.every is not None:
             job = schedule.every(self.every)
         else:
@@ -102,9 +102,11 @@ class ScheduledTaskSchedule(Model):
         job.tag(self._id)
         if self.at is not None:
             print(f"setting at {self.at}")
-            # job = job.at(self.at)
-            # TODO(ac): not hardcode this timezone
-            job = job.at(self.at, str(timezone("Asia/Singapore")))
+            if timezone is not None:
+                print(f"setting at timezone {timezone}")
+                job = job.at(self.at, str(pytz.timezone(timezone)))
+            else:
+                job = job.at(self.at)
 
         return job
 

--- a/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
+++ b/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
@@ -107,7 +107,7 @@ class ScheduledTaskSchedule(Model):
             print(f"setting at {self.at}")
             # job = job.at(self.at)
             # TODO(ac): not hardcode this timezone
-            job = job.at(self.at, timezone("Singapore"))
+            job = job.at(self.at, timezone("Asia/Singapore"))
 
         return job
 

--- a/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
+++ b/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import Optional
 
 import schedule
+from pytz import timezone
 from schedule import Job
 from tortoise import Tortoise
 from tortoise.contrib.pydantic.creator import (
@@ -104,7 +105,9 @@ class ScheduledTaskSchedule(Model):
         job.tag(self._id)
         if self.at is not None:
             print(f"setting at {self.at}")
-            job = job.at(self.at)
+            # job = job.at(self.at)
+            # TODO(ac): not hardcode this timezone
+            job = job.at(self.at, timezone("Singapore"))
 
         return job
 

--- a/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
+++ b/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
@@ -74,9 +74,12 @@ class ScheduledTaskSchedule(Model):
             print(f"to_job until: {self.until}")
             print(f"to_job until timestamp: {self.until.timestamp()}")
             print(
-                f"to_job until timestamp utc: {datetime.utcfromtimestamp(self.until.timestamp())}"
+                f"to_job until utcfromtimestamp: {datetime.utcfromtimestamp(self.until.timestamp())}"
             )
-            job = job.until(datetime.utcfromtimestamp(self.until.timestamp()))
+            print(
+                f"to_job until fromtimestamp: {datetime.fromtimestamp(self.until.timestamp())}"
+            )
+            job = job.until(datetime.fromtimestamp(self.until.timestamp()))
 
         if self.period in (
             ScheduledTaskSchedule.Period.Monday,
@@ -100,7 +103,7 @@ class ScheduledTaskSchedule(Model):
         # Hashable value in order to tag the job with a unique identifier
         job.tag(self._id)
         if self.at is not None:
-            print(self.at)
+            print(f"setting at {self.at}")
             job = job.at(self.at)
 
         return job

--- a/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
+++ b/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
@@ -71,6 +71,11 @@ class ScheduledTaskSchedule(Model):
             # schedule uses `datetime.now()`, which is tz naive
             # Assuming self.until is a datetime object with timezone information
             # Convert the timestamp to datetime without changing the timezone
+            print(f"to_job until: {self.until}")
+            print(f"to_job until timestamp: {self.until.timestamp()}")
+            print(
+                f"to_job until timestamp utc: {datetime.utcfromtimestamp(self.until.timestamp())}"
+            )
             job = job.until(datetime.utcfromtimestamp(self.until.timestamp()))
 
         if self.period in (
@@ -95,6 +100,7 @@ class ScheduledTaskSchedule(Model):
         # Hashable value in order to tag the job with a unique identifier
         job.tag(self._id)
         if self.at is not None:
+            print(self.at)
             job = job.at(self.at)
 
         return job

--- a/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
+++ b/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
@@ -104,8 +104,7 @@ class ScheduledTaskSchedule(Model):
             print(f"setting at {self.at}")
             # job = job.at(self.at)
             # TODO(ac): not hardcode this timezone
-            tz = timezone("Asia/Singapore")  # pyright: ignore[reportGeneralTypeIssues]
-            job = job.at(self.at, tz)
+            job = job.at(self.at, str(timezone("Asia/Singapore")))
 
         return job
 

--- a/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
+++ b/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
@@ -75,9 +75,6 @@ class ScheduledTaskSchedule(Model):
             print(f"to_job until: {self.until}")
             print(f"to_job until timestamp: {self.until.timestamp()}")
             print(
-                f"to_job until utcfromtimestamp: {datetime.utcfromtimestamp(self.until.timestamp())}"
-            )
-            print(
                 f"to_job until fromtimestamp: {datetime.fromtimestamp(self.until.timestamp())}"
             )
             job = job.until(datetime.fromtimestamp(self.until.timestamp()))
@@ -107,7 +104,9 @@ class ScheduledTaskSchedule(Model):
             print(f"setting at {self.at}")
             # job = job.at(self.at)
             # TODO(ac): not hardcode this timezone
-            job = job.at(self.at, timezone("Asia/Singapore"))
+            job = job.at(
+                self.at, timezone("Asia/Singapore")
+            )  # pyright: ignore[reportGeneralTypeIssues]
 
         return job
 

--- a/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
+++ b/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
@@ -8,6 +8,7 @@ from fastapi import Depends, HTTPException, Query
 from pydantic import BaseModel
 from tortoise.expressions import Q
 
+from api_server.app_config import app_config
 from api_server.authenticator import user_dep
 from api_server.dependencies import pagination_query
 from api_server.fast_io import FastIORouter
@@ -31,7 +32,7 @@ async def schedule_task(task: ttm.ScheduledTask, task_repo: TaskRepository):
     jobs: list[tuple[ttm.ScheduledTaskSchedule, schedule.Job]] = []
     for sche in task.schedules:
         try:
-            jobs.append((sche, sche.to_job()))
+            jobs.append((sche, sche.to_job(app_config.timezone)))
         except schedule.ScheduleValueError:
             pass
     if len(jobs) == 0:

--- a/packages/api-server/setup.py
+++ b/packages/api-server/setup.py
@@ -26,7 +26,7 @@ setup(
         "tortoise-orm~=0.18.1",
         "pyjwt[crypto]~=2.4",
         "pydantic~=1.9",
-        "schedule~=1.1.0",
+        "schedule~=1.2.1",
     ],
     extras_require={
         "postgres": ["asyncpg~=0.25.0"],

--- a/packages/api-server/sqlite_local_config.py
+++ b/packages/api-server/sqlite_local_config.py
@@ -11,5 +11,6 @@ config.update(
         "cache_directory": f"{run_dir}/cache",  # The directory where cached files should be stored.
         "ros_args": ["-p", "use_sim_time:=true"],
         "log_level": "INFO",
+        "timezone": "Asia/Singapore",
     }
 )

--- a/packages/dashboard/src/components/appbar.tsx
+++ b/packages/dashboard/src/components/appbar.tsx
@@ -230,7 +230,7 @@ export const AppBar = React.memo(({ extraToolbarItems }: AppBarProps): React.Rea
       if (!schedule) {
         await Promise.all(
           taskRequests.map((request) => {
-            console.log(`submitTask: ${request}`);
+            console.debug(`submitTask: ${request}`);
             return rmf.tasksApi.postDispatchTaskTasksDispatchTaskPost({
               type: 'dispatch_task_request',
               request,
@@ -239,9 +239,9 @@ export const AppBar = React.memo(({ extraToolbarItems }: AppBarProps): React.Rea
         );
       } else {
         const scheduleRequests = taskRequests.map((req) => {
-          console.log('schedule task:');
-          console.log(req);
-          console.log(schedule);
+          console.debug('schedule task:');
+          console.debug(req);
+          console.debug(schedule);
           return toApiSchedule(req, schedule);
         });
         await Promise.all(

--- a/packages/dashboard/src/components/appbar.tsx
+++ b/packages/dashboard/src/components/appbar.tsx
@@ -229,15 +229,21 @@ export const AppBar = React.memo(({ extraToolbarItems }: AppBarProps): React.Rea
       }
       if (!schedule) {
         await Promise.all(
-          taskRequests.map((request) =>
-            rmf.tasksApi.postDispatchTaskTasksDispatchTaskPost({
+          taskRequests.map((request) => {
+            console.log(`submitTask: ${request}`);
+            return rmf.tasksApi.postDispatchTaskTasksDispatchTaskPost({
               type: 'dispatch_task_request',
               request,
-            }),
-          ),
+            });
+          }),
         );
       } else {
-        const scheduleRequests = taskRequests.map((req) => toApiSchedule(req, schedule));
+        const scheduleRequests = taskRequests.map((req) => {
+          console.log('schedule task:');
+          console.log(req);
+          console.log(schedule);
+          return toApiSchedule(req, schedule);
+        });
         await Promise.all(
           scheduleRequests.map((req) => rmf.tasksApi.postScheduledTaskScheduledTasksPost(req)),
         );

--- a/packages/dashboard/src/components/lift-summary.tsx
+++ b/packages/dashboard/src/components/lift-summary.tsx
@@ -3,8 +3,9 @@ import { Dialog, DialogContent, DialogTitle, Divider, TextField } from '@mui/mat
 import { Theme } from '@mui/material/styles';
 import { RmfAppContext } from './rmf-app';
 import { getApiErrorMessage } from './utils';
-import { doorStateToString, healthStatusToOpMode, LiftTableData, base } from 'react-components';
+import { doorStateToString, liftModeToString, LiftTableData, base } from 'react-components';
 import { Lift } from 'api-client';
+import { LiftState as RmfLiftState } from 'rmf-models';
 import { makeStyles, createStyles } from '@mui/styles';
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -29,7 +30,7 @@ export const LiftSummary = ({ onClose, lift }: LiftSummaryProps): JSX.Element =>
   const [liftData, setLiftData] = React.useState<LiftTableData>({
     index: 0,
     name: '',
-    opMode: '',
+    mode: RmfLiftState.MODE_UNKNOWN,
     currentFloor: '',
     destinationFloor: '',
     doorState: 0,
@@ -44,13 +45,11 @@ export const LiftSummary = ({ onClose, lift }: LiftSummaryProps): JSX.Element =>
 
     const fetchDataForLift = async () => {
       try {
-        const { data } = await rmf.liftsApi.getLiftHealthLiftsLiftNameHealthGet(lift.name);
-        const { health_status } = data;
         const sub = rmf.getLiftStateObs(lift.name).subscribe((liftState) => {
           setLiftData({
             index: -1,
             name: lift.name,
-            opMode: health_status ? health_status : 'N/A',
+            mode: liftState.current_mode,
             currentFloor: liftState.current_floor,
             destinationFloor: liftState.destination_floor,
             doorState: liftState.door_state,
@@ -97,9 +96,9 @@ export const LiftSummary = ({ onClose, lift }: LiftSummaryProps): JSX.Element =>
             case 'name':
               displayLabel = 'Name';
               break;
-            case 'opMode':
-              displayValue = healthStatusToOpMode(value);
-              displayLabel = 'Op. Mode';
+            case 'mode':
+              displayValue = liftModeToString(value);
+              displayLabel = 'Mode';
               break;
             case 'currentFloor':
               displayLabel = 'Current Floor';

--- a/packages/dashboard/src/components/lifts-app.tsx
+++ b/packages/dashboard/src/components/lifts-app.tsx
@@ -30,8 +30,6 @@ export const LiftsApp = createMicroApp('Lifts', () => {
 
     buildingMap?.lifts.map(async (lift, i) => {
       try {
-        const { data } = await rmf.liftsApi.getLiftHealthLiftsLiftNameHealthGet(lift.name);
-        const { health_status } = data;
         const sub = rmf.getLiftStateObs(lift.name).subscribe((liftState) => {
           setLiftTableData((prev) => {
             return {
@@ -40,7 +38,7 @@ export const LiftsApp = createMicroApp('Lifts', () => {
                 {
                   index: i,
                   name: lift.name,
-                  opMode: health_status ? health_status : 'N/A',
+                  mode: liftState.current_mode,
                   currentFloor: liftState.current_floor,
                   destinationFloor: liftState.destination_floor,
                   doorState: liftState.door_state,
@@ -74,7 +72,7 @@ export const LiftsApp = createMicroApp('Lifts', () => {
         });
         return () => sub.unsubscribe();
       } catch (error) {
-        console.error(`Failed to get lift health: ${getApiErrorMessage(error)}`);
+        console.error(`Failed to get lift state: ${getApiErrorMessage(error)}`);
       }
     });
   }, [rmf, buildingMap]);

--- a/packages/dashboard/src/components/tasks/task-schedule-utils.ts
+++ b/packages/dashboard/src/components/tasks/task-schedule-utils.ts
@@ -50,18 +50,10 @@ export const scheduleToEvents = (
     console.warn('Unable to convert schedule without [at] to an event');
     return [];
   }
-  console.log('Schedule to Event');
-  console.log(`start: ${start}`);
-  console.log(`end: ${end}`);
-
   const [hours, minutes] = schedule.at.split(':').map((s: string) => Number(s));
-  console.log(`hours: ${hours}`);
-  console.log(`minutes: ${minutes}`);
   let cur = new Date(start);
-  console.log(`cur before set: ${cur}`);
   cur.setHours(hours);
   cur.setMinutes(minutes);
-  console.log(`cur after set: ${cur}`);
 
   const scheStartFrom = schedule.start_from ? startOfMinute(new Date(schedule.start_from)) : null;
   const scheUntil = schedule.until ? endOfMinute(new Date(schedule.until)) : null;

--- a/packages/dashboard/src/components/tasks/task-schedule-utils.ts
+++ b/packages/dashboard/src/components/tasks/task-schedule-utils.ts
@@ -50,10 +50,18 @@ export const scheduleToEvents = (
     console.warn('Unable to convert schedule without [at] to an event');
     return [];
   }
+  console.log('Schedule to Event');
+  console.log(`start: ${start}`);
+  console.log(`end: ${end}`);
+
   const [hours, minutes] = schedule.at.split(':').map((s: string) => Number(s));
+  console.log(`hours: ${hours}`);
+  console.log(`minutes: ${minutes}`);
   let cur = new Date(start);
+  console.log(`cur before set: ${cur}`);
   cur.setHours(hours);
   cur.setMinutes(minutes);
+  console.log(`cur after set: ${cur}`);
 
   const scheStartFrom = schedule.start_from ? startOfMinute(new Date(schedule.start_from)) : null;
   const scheUntil = schedule.until ? endOfMinute(new Date(schedule.until)) : null;

--- a/packages/dashboard/src/components/tasks/task-schedule.tsx
+++ b/packages/dashboard/src/components/tasks/task-schedule.tsx
@@ -8,7 +8,7 @@ import {
   SchedulerHelpers,
   SchedulerProps,
 } from '@aldabil/react-scheduler/types';
-import { Button } from '@mui/material';
+import { Button, Typography } from '@mui/material';
 import {
   ApiServerModelsTortoiseModelsScheduledTaskScheduledTask as ScheduledTask,
   ApiServerModelsTortoiseModelsScheduledTaskScheduledTaskScheduleLeaf as ApiSchedule,
@@ -291,6 +291,9 @@ export const TaskSchedule = () => {
             }}
           />
         )}
+        viewerExtraComponent={(fields, event) => {
+          return <Typography variant="caption">{event.title}</Typography>;
+        }}
       />
       {openCreateTaskForm && (
         <CreateTaskForm

--- a/packages/dashboard/src/components/tasks/task-schedule.tsx
+++ b/packages/dashboard/src/components/tasks/task-schedule.tsx
@@ -106,6 +106,8 @@ export const TaskSchedule = () => {
       if (!rmf) {
         return;
       }
+      console.log(`end: ${params.end.toISOString()}`);
+      console.log(`start: ${params.start.toISOString()}`);
       const tasks = (
         await rmf.tasksApi.getScheduledTasksScheduledTasksGet(
           params.end.toISOString(),

--- a/packages/dashboard/src/components/tasks/task-schedule.tsx
+++ b/packages/dashboard/src/components/tasks/task-schedule.tsx
@@ -106,8 +106,6 @@ export const TaskSchedule = () => {
       if (!rmf) {
         return;
       }
-      console.log(`end: ${params.end.toISOString()}`);
-      console.log(`start: ${params.start.toISOString()}`);
       const tasks = (
         await rmf.tasksApi.getScheduledTasksScheduledTasksGet(
           params.end.toISOString(),

--- a/packages/dashboard/src/components/tasks/tasks-app.tsx
+++ b/packages/dashboard/src/components/tasks/tasks-app.tsx
@@ -85,6 +85,7 @@ export const TasksApp = React.memo(
       const rmf = React.useContext(RmfAppContext);
       const [autoRefresh, setAutoRefresh] = React.useState(true);
       const [refreshTaskAppCount, setRefreshTaskAppCount] = React.useState(0);
+      const [selectedPanelIndex, setSelectedPanelIndex] = React.useState(TaskTablePanel.QueueTable);
 
       const uploadFileInputRef = React.useRef<HTMLInputElement>(null);
       const [openTaskSummary, setOpenTaskSummary] = React.useState(false);
@@ -144,6 +145,11 @@ export const TasksApp = React.memo(
       const GET_LIMIT = 10;
       React.useEffect(() => {
         if (!rmf) {
+          return;
+        }
+
+        if (selectedPanelIndex !== TaskTablePanel.QueueTable) {
+          console.debug('Stop subscribing to task queue updates when viewing schedule tab');
           return;
         }
 
@@ -238,7 +244,14 @@ export const TasksApp = React.memo(
           );
         })();
         return () => subs.forEach((s) => s.unsubscribe());
-      }, [rmf, refreshTaskAppCount, tasksState.page, filterFields.model, sortFields.model]);
+      }, [
+        rmf,
+        refreshTaskAppCount,
+        tasksState.page,
+        filterFields.model,
+        sortFields.model,
+        selectedPanelIndex,
+      ]);
 
       const getAllTasks = async (timestamp: Date) => {
         if (!rmf) {
@@ -310,8 +323,6 @@ export const TasksApp = React.memo(
       const handleCloseExportMenu = () => {
         setAnchorExportElement(null);
       };
-
-      const [selectedPanelIndex, setSelectedPanelIndex] = React.useState(TaskTablePanel.QueueTable);
 
       const handlePanelChange = (_: React.SyntheticEvent, newSelectedTabIndex: number) => {
         setSelectedPanelIndex(newSelectedTabIndex);

--- a/packages/dashboard/src/components/tasks/utils.ts
+++ b/packages/dashboard/src/components/tasks/utils.ts
@@ -20,8 +20,9 @@ export function parseTasksFile(contents: string): TaskRequest[] {
 export function downloadCsvFull(timestamp: Date, allTasks: TaskState[]) {
   const columnSeparator = ';';
   const rowSeparator = '\n';
+  let csvContent = `sep=${columnSeparator}` + rowSeparator;
   const keys = Object.keys(allTasks[0]);
-  let csvContent = keys.join(columnSeparator) + rowSeparator;
+  csvContent += keys.join(columnSeparator) + rowSeparator;
   allTasks.forEach((task) => {
     keys.forEach((k) => {
       type TaskStateKey = keyof typeof task;
@@ -53,6 +54,7 @@ export function downloadCsvMinimal(
 ) {
   const columnSeparator = ';';
   const rowSeparator = '\n';
+  let csvContent = `sep=${columnSeparator}` + rowSeparator;
   const keys = [
     'Date',
     'Requester',
@@ -63,7 +65,7 @@ export function downloadCsvMinimal(
     'End Time',
     'State',
   ];
-  let csvContent = keys.join(columnSeparator) + rowSeparator;
+  csvContent += keys.join(columnSeparator) + rowSeparator;
   allTasks.forEach((task) => {
     const request: TaskRequest | undefined = taskRequestMap[task.booking.id];
     const values = [

--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -1585,14 +1585,19 @@ export function CreateTaskForm({
             <Grid item xs={6}>
               <DatePicker
                 value={schedule.startOn}
-                onChange={(date) =>
-                  date &&
+                onChange={(date) => {
+                  if (!date) {
+                    console.log('DatePicker: invalid date');
+                    return;
+                  }
+                  console.log(`DatePicker: ${date}`);
                   setSchedule((prev) => {
                     date.setHours(schedule.at.getHours());
                     date.setMinutes(schedule.at.getMinutes());
+                    console.log(`DatePicker setSchedule: ${date}`);
                     return { ...prev, startOn: date };
-                  })
-                }
+                  });
+                }}
                 label="Start On"
                 disabled={!scheduleEnabled}
                 renderInput={(props) => (
@@ -1614,15 +1619,17 @@ export function CreateTaskForm({
                 value={schedule.at}
                 onChange={(date) => {
                   if (!date) {
+                    console.error('TimePicker: invalid date');
                     return;
                   }
-                  setSchedule((prev) => ({ ...prev, at: date }));
+                  console.error(`TimePicker: ${date}`);
                   if (!isNaN(date.valueOf())) {
                     setSchedule((prev) => {
                       const startOn = prev.startOn;
                       startOn.setHours(date.getHours());
                       startOn.setMinutes(date.getMinutes());
-                      return { ...prev, startOn };
+                      console.log(`TimePicker setSchedule: ${date}`);
+                      return { ...prev, at: date, startOn };
                     });
                   }
                 }}
@@ -1688,14 +1695,19 @@ export function CreateTaskForm({
                     value={
                       scheduleUntilValue === ScheduleUntilValue.NEVER ? new Date() : schedule.until
                     }
-                    onChange={(date) =>
-                      date &&
+                    onChange={(date) => {
+                      if (!date) {
+                        console.error('Until DatePicker: invalid date');
+                        return;
+                      }
+                      console.log(`Until DatePicker: ${date}`);
                       setSchedule((prev) => {
                         date.setHours(23);
                         date.setMinutes(59);
+                        console.log(`Until DatePicker setSchedule: ${date}`);
                         return { ...prev, until: date };
-                      })
-                    }
+                      });
+                    }}
                     disabled={scheduleUntilValue !== ScheduleUntilValue.ON}
                     renderInput={(props) => (
                       <TextField

--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -1587,14 +1587,14 @@ export function CreateTaskForm({
                 value={schedule.startOn}
                 onChange={(date) => {
                   if (!date) {
-                    console.log('DatePicker: invalid date');
+                    console.error('DatePicker: invalid date');
                     return;
                   }
-                  console.log(`DatePicker: ${date}`);
+                  console.debug(`DatePicker: ${date}`);
                   setSchedule((prev) => {
                     date.setHours(schedule.at.getHours());
                     date.setMinutes(schedule.at.getMinutes());
-                    console.log(`DatePicker setSchedule: ${date}`);
+                    console.debug(`DatePicker setSchedule: ${date}`);
                     return { ...prev, startOn: date };
                   });
                 }}
@@ -1622,13 +1622,13 @@ export function CreateTaskForm({
                     console.error('TimePicker: invalid date');
                     return;
                   }
-                  console.error(`TimePicker: ${date}`);
+                  console.debug(`TimePicker: ${date}`);
                   if (!isNaN(date.valueOf())) {
                     setSchedule((prev) => {
                       const startOn = prev.startOn;
                       startOn.setHours(date.getHours());
                       startOn.setMinutes(date.getMinutes());
-                      console.log(`TimePicker setSchedule: ${date}`);
+                      console.debug(`TimePicker setSchedule: ${date}`);
                       return { ...prev, at: date, startOn };
                     });
                   }
@@ -1700,11 +1700,11 @@ export function CreateTaskForm({
                         console.error('Until DatePicker: invalid date');
                         return;
                       }
-                      console.log(`Until DatePicker: ${date}`);
+                      console.debug(`Until DatePicker: ${date}`);
                       setSchedule((prev) => {
                         date.setHours(23);
                         date.setMinutes(59);
-                        console.log(`Until DatePicker setSchedule: ${date}`);
+                        console.debug(`Until DatePicker setSchedule: ${date}`);
                         return { ...prev, until: date };
                       });
                     }}

--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -1405,6 +1405,7 @@ export function CreateTaskForm({
                           }}
                         />
                       )}
+                      disabled
                     />
                   </Grid>
                   <Grid item xs={1}>


### PR DESCRIPTION
## What's new

- [x] More logs for schedule times and conversions
- [x] using `datetime.fromtimestamp(self.until.timestamp()))`
- [x] test with changed pod timezone
- [x] export csv to designate semicolons as delimiters for Excel
- [x] fix schedule glitching due to logging
- [x] change logs to debug logs instead
- [x] disables unused and confusing start time field
- [x] lift op mode to mode, from lift state
- [x] additional schedule event viewer component for entire task description

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test