### PR TITLE
More logs in node 18 to test locally, use fromtimestamp

### DIFF
--- a/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
+++ b/packages/api-server/api_server/models/tortoise_models/scheduled_task.py
@@ -71,7 +71,15 @@ class ScheduledTaskSchedule(Model):
             # schedule uses `datetime.now()`, which is tz naive
             # Assuming self.until is a datetime object with timezone information
             # Convert the timestamp to datetime without changing the timezone
-            job = job.until(datetime.utcfromtimestamp(self.until.timestamp()))
+            print(f"to_job until: {self.until}")
+            print(f"to_job until timestamp: {self.until.timestamp()}")
+            print(
+                f"to_job until utcfromtimestamp: {datetime.utcfromtimestamp(self.until.timestamp())}"
+            )
+            print(
+                f"to_job until fromtimestamp: {datetime.fromtimestamp(self.until.timestamp())}"
+            )
+            job = job.until(datetime.fromtimestamp(self.until.timestamp()))
 
         if self.period in (
             ScheduledTaskSchedule.Period.Monday,
@@ -95,6 +103,7 @@ class ScheduledTaskSchedule(Model):
         # Hashable value in order to tag the job with a unique identifier
         job.tag(self._id)
         if self.at is not None:
+            print(f"setting at {self.at}")
             job = job.at(self.at)
 
         return job

--- a/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
+++ b/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
@@ -49,7 +49,7 @@ async def schedule_task(task: ttm.ScheduledTask, task_repo: TaskRepository):
         await task.save()
 
     def do():
-        logger.info(f"starting task {task.pk}")
+        logger.info(f"schedule starting task {task.pk}")
         datetime_to_iso = datetime.now().isoformat()
         if datetime_to_iso[:10] in task.except_dates:
             return

--- a/packages/dashboard/src/components/appbar.tsx
+++ b/packages/dashboard/src/components/appbar.tsx
@@ -229,15 +229,21 @@ export const AppBar = React.memo(({ extraToolbarItems }: AppBarProps): React.Rea
       }
       if (!schedule) {
         await Promise.all(
-          taskRequests.map((request) =>
-            rmf.tasksApi.postDispatchTaskTasksDispatchTaskPost({
+          taskRequests.map((request) => {
+            console.log(`submitTask: ${request}`);
+            return rmf.tasksApi.postDispatchTaskTasksDispatchTaskPost({
               type: 'dispatch_task_request',
               request,
-            }),
-          ),
+            });
+          }),
         );
       } else {
-        const scheduleRequests = taskRequests.map((req) => toApiSchedule(req, schedule));
+        const scheduleRequests = taskRequests.map((req) => {
+          console.log('schedule task:');
+          console.log(req);
+          console.log(schedule);
+          return toApiSchedule(req, schedule);
+        });
         await Promise.all(
           scheduleRequests.map((req) => rmf.tasksApi.postScheduledTaskScheduledTasksPost(req)),
         );

--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -1558,14 +1558,19 @@ export function CreateTaskForm({
             <Grid item xs={6}>
               <DatePicker
                 value={schedule.startOn}
-                onChange={(date) =>
-                  date &&
+                onChange={(date) => {
+                  if (!date) {
+                    console.log('DatePicker: invalid date');
+                    return;
+                  }
+                  console.log(`DatePicker: ${date}`);
                   setSchedule((prev) => {
                     date.setHours(schedule.at.getHours());
                     date.setMinutes(schedule.at.getMinutes());
+                    console.log(`DatePicker setSchedule: ${date}`);
                     return { ...prev, startOn: date };
-                  })
-                }
+                  });
+                }}
                 label="Start On"
                 disabled={!scheduleEnabled}
               />
@@ -1575,15 +1580,17 @@ export function CreateTaskForm({
                 value={schedule.at}
                 onChange={(date) => {
                   if (!date) {
+                    console.error('TimePicker: invalid date');
                     return;
                   }
-                  setSchedule((prev) => ({ ...prev, at: date }));
+                  console.error(`TimePicker: ${date}`);
                   if (!isNaN(date.valueOf())) {
                     setSchedule((prev) => {
                       const startOn = prev.startOn;
                       startOn.setHours(date.getHours());
                       startOn.setMinutes(date.getMinutes());
-                      return { ...prev, startOn };
+                      console.log(`TimePicker setSchedule: ${date}`);
+                      return { ...prev, at: date, startOn };
                     });
                   }
                 }}
@@ -1637,14 +1644,19 @@ export function CreateTaskForm({
                     value={
                       scheduleUntilValue === ScheduleUntilValue.NEVER ? new Date() : schedule.until
                     }
-                    onChange={(date) =>
-                      date &&
+                    onChange={(date) => {
+                      if (!date) {
+                        console.error('Until DatePicker: invalid date');
+                        return;
+                      }
+                      console.log(`Until DatePicker: ${date}`);
                       setSchedule((prev) => {
                         date.setHours(23);
                         date.setMinutes(59);
+                        console.log(`Until DatePicker setSchedule: ${date}`);
                         return { ...prev, until: date };
-                      })
-                    }
+                      });
+                    }}
                     disabled={scheduleUntilValue !== ScheduleUntilValue.ON}
                   />
                 </Grid>


### PR DESCRIPTION
## What's new

Related to https://github.com/open-rmf/rmf-web/pull/869, for testing locally

* logs
* use `fromtimestamp`

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test