### PR TITLE
Seconds and milliseconds of start time to be zero

### DIFF
--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -1044,12 +1044,15 @@ export function CreateTaskForm({
   const [formFullyFilled, setFormFullyFilled] = React.useState(requestTask !== undefined || false);
   const taskRequest = taskRequests[selectedTaskIdx];
   const [openSchedulingDialog, setOpenSchedulingDialog] = React.useState(false);
+  const defaultScheduleDate = new Date();
+  defaultScheduleDate.setSeconds(0);
+  defaultScheduleDate.setMilliseconds(0);
   const [schedule, setSchedule] = React.useState<Schedule>(
     scheduleToEdit ?? {
-      startOn: new Date(),
+      startOn: defaultScheduleDate,
       days: [true, true, true, true, true, true, true],
       until: undefined,
-      at: new Date(),
+      at: defaultScheduleDate,
     },
   );
   const [scheduleUntilValue, setScheduleUntilValue] = React.useState<string>(
@@ -1665,6 +1668,8 @@ export function CreateTaskForm({
                   setSchedule((prev) => {
                     date.setHours(schedule.at.getHours());
                     date.setMinutes(schedule.at.getMinutes());
+                    date.setSeconds(0);
+                    date.setMilliseconds(0);
                     console.debug(`DatePicker setSchedule: ${date}`);
                     return { ...prev, startOn: date };
                   });
@@ -1699,6 +1704,8 @@ export function CreateTaskForm({
                       const startOn = prev.startOn;
                       startOn.setHours(date.getHours());
                       startOn.setMinutes(date.getMinutes());
+                      startOn.setSeconds(0);
+                      startOn.setMilliseconds(0);
                       console.debug(`TimePicker setSchedule: ${date}`);
                       return { ...prev, at: date, startOn };
                     });


### PR DESCRIPTION
## What's new

Zero out seconds and milliseconds of schedule start times, to avoid skipping scheduled tasks

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test
