### PR TITLE
Hammer/catch disconnect

### DIFF
--- a/packages/api-server/api_server/routes/internal.py
+++ b/packages/api-server/api_server/routes/internal.py
@@ -62,9 +62,15 @@ class ConnectionManager:
     async def connect(self, websocket: WebSocket):
         await websocket.accept()
         self.active_connections.append(websocket)
+        logger.info(
+            f"ConnectionManager: {len(self.active_connections)} websocket connections still alive"
+        )
 
     def disconnect(self, websocket: WebSocket):
         self.active_connections.remove(websocket)
+        logger.info(
+            f"ConnectionManager: {len(self.active_connections)} websocket connections still alive"
+        )
 
 
 connection_manager = ConnectionManager()


### PR DESCRIPTION
## What's new

* Reverts use of `asyncio` when dealing with websocket messages
* Using multiple client example https://fastapi.tiangolo.com/advanced/websockets/#handling-disconnections-and-multiple-clients
* Log connections still alive

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test