### PR TITLE
Catch connects as well

### DIFF
--- a/packages/api-server/api_server/app_config.py
+++ b/packages/api-server/api_server/app_config.py
@@ -22,7 +22,7 @@ class AppConfig:
     iss: Optional[str]
     ros_args: List[str]
     timezone: Optional[str]
-    websocket_unhealthy_connections_limit: int
+    websocket_unhealthy_connections_limit: Optional[int]
 
     def __post_init__(self):
         self.public_url = urllib.parse.urlparse(cast(str, self.public_url))

--- a/packages/api-server/api_server/app_config.py
+++ b/packages/api-server/api_server/app_config.py
@@ -22,6 +22,7 @@ class AppConfig:
     iss: Optional[str]
     ros_args: List[str]
     timezone: Optional[str]
+    websocket_unhealthy_connections_limit: int
 
     def __post_init__(self):
         self.public_url = urllib.parse.urlparse(cast(str, self.public_url))

--- a/packages/api-server/api_server/default_config.py
+++ b/packages/api-server/api_server/default_config.py
@@ -36,4 +36,5 @@ config = {
     # as the system timezone, as well as the client UI timezone. Cross-timezone
     # scheduling is currently not supported.
     "timezone": None,
+    "websocket_unhealthy_connections_limit": 5,
 }

--- a/packages/api-server/api_server/default_config.py
+++ b/packages/api-server/api_server/default_config.py
@@ -36,5 +36,8 @@ config = {
     # as the system timezone, as well as the client UI timezone. Cross-timezone
     # scheduling is currently not supported.
     "timezone": None,
-    "websocket_unhealthy_connections_limit": 5,
+    # Number of connections/disconnections to websockets within 2 minutes, to
+    # consider the connectivity unhealthy, and shut down the server. If not
+    # defined, the server will not be shut down.
+    "websocket_unhealthy_connections_limit": None,
 }

--- a/packages/api-server/api_server/routes/internal.py
+++ b/packages/api-server/api_server/routes/internal.py
@@ -39,7 +39,10 @@ class WebSocketHealthManager:
                 self.events = [datetime.now()]
 
         # If there are more than app_config.websocket_unhealthy_connections_limit events that occurred within 2 minutes, shut down the server
-        if len(self.events) > app_config.websocket_unhealthy_connections_limit:
+        if (
+            app_config.websocket_unhealthy_connections_limit is not None
+            and len(self.events) > app_config.websocket_unhealthy_connections_limit
+        ):
             unhealthy_period_seconds = (self.events[-1] - self.events[-3]).seconds
             if unhealthy_period_seconds < 120:
                 logger.error(

--- a/packages/api-server/api_server/routes/internal.py
+++ b/packages/api-server/api_server/routes/internal.py
@@ -29,7 +29,7 @@ class WebSocketHealthManager:
         # Clean up if the past event was more than 2 minutes ago
         if len(self.events) > 2:
             seconds_since_last_event = (self.events[-1] - self.events[-2]).seconds
-            logger.warn(
+            logger.warning(
                 f"Previous Web Socket connection/re-connection/disconnection event was {seconds_since_last_event} seconds ago"
             )
             if seconds_since_last_event > 120:
@@ -101,12 +101,12 @@ def task_log_has_error(task_log: mdl.TaskEventLog) -> bool:
 
 async def process_msg(msg: Dict[str, Any], fleet_repo: FleetRepository) -> None:
     if "type" not in msg:
-        logger.warn(msg)
-        logger.warn("Ignoring message, 'type' must include in msg field")
+        logger.warning(msg)
+        logger.warning("Ignoring message, 'type' must include in msg field")
         return
     payload_type: str = msg["type"]
     if not isinstance(payload_type, str):
-        logger.warn("error processing message, 'type' must be a string")
+        logger.warning("error processing message, 'type' must be a string")
         return
     logger.debug(msg)
 
@@ -167,4 +167,4 @@ async def rmf_gateway(websocket: WebSocket):
     except (WebSocketDisconnect, ConnectionClosed):
         connection_manager.disconnect(websocket)
         health_manager.add_event()
-        logger.warn("Client websocket disconnected")
+        logger.warning("Client websocket disconnected")


### PR DESCRIPTION
## What's new

Since the issue is about spurious invalid re-connections without disconnecting, `WebsocketHealthManager` does not do a good job to kill the server.

This keeps track of connections too, where no more than 5 connections within 2 minutes should occur.

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test
