### PR TITLE
Schedule deletion: fix date differences due to different timezones, more tests

### DIFF
--- a/packages/api-server/api_server/app_config.py
+++ b/packages/api-server/api_server/app_config.py
@@ -21,7 +21,7 @@ class AppConfig:
     aud: str
     iss: Optional[str]
     ros_args: List[str]
-    timezone: Optional[str]
+    timezone: str
 
     def __post_init__(self):
         self.public_url = urllib.parse.urlparse(cast(str, self.public_url))

--- a/packages/api-server/api_server/default_config.py
+++ b/packages/api-server/api_server/default_config.py
@@ -35,5 +35,5 @@ config = {
     # Timezone at which the scheduler will operate in. This must be the same
     # as the system timezone, as well as the client UI timezone. Cross-timezone
     # scheduling is currently not supported.
-    "timezone": None,
+    "timezone": "UTC",
 }

--- a/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
+++ b/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
@@ -163,14 +163,17 @@ async def del_scheduled_tasks_event(
     if task is None:
         raise HTTPException(404)
 
-    utctz = ZoneInfo("UTC")
-    localtz = ZoneInfo(app_config.timezone) if app_config.timezone else None
+    tz = ZoneInfo(app_config.timezone) if app_config.timezone else None
+    event_date_str = event_date.replace(tzinfo=tz).isoformat()
 
-    event_date_str = event_date.replace(tzinfo=utctz).isoformat()
-    if localtz is not None:
-        event_date_utc = event_date.replace(tzinfo=utctz)
-        event_date_local = event_date_utc.astimezone(localtz)
-        event_date_str = event_date_local.isoformat()
+    # utctz = ZoneInfo("UTC")
+    # localtz = ZoneInfo(app_config.timezone) if app_config.timezone else None
+
+    # event_date_str = event_date.replace(tzinfo=utctz).isoformat()
+    # if localtz is not None:
+    #     event_date_utc = event_date.replace(tzinfo=utctz)
+    #     event_date_local = event_date_utc.astimezone(localtz)
+    #     event_date_str = event_date_local.isoformat()
 
     task.except_dates.append(event_date_str[:10])
     await task.save()

--- a/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
+++ b/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
@@ -163,17 +163,14 @@ async def del_scheduled_tasks_event(
     if task is None:
         raise HTTPException(404)
 
-    tz = ZoneInfo(app_config.timezone) if app_config.timezone else None
-    event_date_str = event_date.replace(tzinfo=tz).isoformat()
+    utctz = ZoneInfo("UTC")
+    localtz = ZoneInfo(app_config.timezone) if app_config.timezone else None
 
-    # utctz = ZoneInfo("UTC")
-    # localtz = ZoneInfo(app_config.timezone) if app_config.timezone else None
-
-    # event_date_str = event_date.replace(tzinfo=utctz).isoformat()
-    # if localtz is not None:
-    #     event_date_utc = event_date.replace(tzinfo=utctz)
-    #     event_date_local = event_date_utc.astimezone(localtz)
-    #     event_date_str = event_date_local.isoformat()
+    event_date_str = event_date.replace(tzinfo=utctz).isoformat()
+    if localtz is not None:
+        event_date_utc = event_date.replace(tzinfo=utctz)
+        event_date_local = event_date_utc.astimezone(localtz)
+        event_date_str = event_date_local.isoformat()
 
     task.except_dates.append(event_date_str[:10])
     await task.save()

--- a/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
+++ b/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
@@ -166,10 +166,8 @@ async def del_scheduled_tasks_event(
         logger.error(f"Task with scehdule id {task_id} not found")
         raise HTTPException(404)
 
-    # Server time zone, if not defined to use UTC
-    server_tz_info = (
-        ZoneInfo(app_config.timezone) if app_config.timezone else ZoneInfo("UTC")
-    )
+    # Server time zone
+    server_tz_info = ZoneInfo(app_config.timezone)
     logger.info(f"Server tz: {server_tz_info}")
 
     # If the event date has time zone information, we check if it is in the same

--- a/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
+++ b/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
@@ -174,6 +174,8 @@ async def del_scheduled_tasks_event(
 
     # If the event date has time zone information, we check if it is in the same
     # time zone as the server
+    # FIXME This solution breaks if users change the time zone of the server
+    # after creating schedules.
     event_date_utc_offset = event_date.utcoffset()
     server_time_utc_offset = datetime.now(tz=server_tz_info).utcoffset()
     if event_date_utc_offset is not None and server_time_utc_offset is not None:

--- a/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
+++ b/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
@@ -170,11 +170,11 @@ async def del_scheduled_tasks_event(
 
     # If the event date has time zone information, we check if it is in the same
     # time zone as the server
-    if event_date.tzinfo is not None:
-        event_tz_utc_offset_seconds = round(event_date.utcoffset().total_seconds())
-        server_tz_utc_offset_seconds = round(
-            datetime.now(tz=server_tz_info).utcoffset().total_seconds()
-        )
+    event_date_utc_offset = event_date.utcoffset()
+    server_time_utc_offset = datetime.now(tz=server_tz_info).utcoffset()
+    if event_date_utc_offset is not None and server_time_utc_offset is not None:
+        event_tz_utc_offset_seconds = round(event_date_utc_offset.total_seconds())
+        server_tz_utc_offset_seconds = round(server_time_utc_offset.total_seconds())
         # if the time zones are the same, we can extract the date directly
         if event_tz_utc_offset_seconds == server_tz_utc_offset_seconds:
             event_date_str = event_date.isoformat()

--- a/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
+++ b/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
@@ -177,6 +177,37 @@ async def del_scheduled_tasks_event(
         raise HTTPException(422, str(e)) from e
 
 
+# @router.put("/{task_id}/clear")
+# async def del_scheduled_tasks_event(
+#     task_id: int,
+#     event_date: datetime,
+#     task_repo: TaskRepository = Depends(task_repo_dep),
+# ):
+#     task = await get_scheduled_task(task_id)
+#     if task is None:
+#         raise HTTPException(404)
+
+#     utctz = ZoneInfo('UTC')
+#     localtz = ZoneInfo(app_config.timezone) if app_config.timezone else None
+
+#     event_date_str = event_date.replace(tzinfo=utctz).isoformat()
+#     if localtz is not None:
+#         event_date_utc = event_date.replace(tzinfo=utctz)
+#         event_date_local = event_date_utc.astimezone(localtz)
+#         event_date_str = event_date_local.isoformat()
+
+#     task.except_dates.append(event_date_str[:10])
+#     await task.save()
+
+#     for sche in task.schedules:
+#         schedule.clear(sche.get_id())
+
+#     try:
+#         await schedule_task(task, task_repo)
+#     except schedule.ScheduleError as e:
+#         raise HTTPException(422, str(e)) from e
+
+
 @router.post(
     "/{task_id}/update", status_code=201, response_model=ttm.ScheduledTaskPydantic
 )

--- a/packages/api-server/api_server/routes/tasks/test_scheduled_tasks.py
+++ b/packages/api-server/api_server/routes/tasks/test_scheduled_tasks.py
@@ -201,7 +201,7 @@ class TestScheduledTasksRoute(AppFixture):
         self.assertEqual(len(tasks), 0, tasks)
 
     def test_delete_scheduled_task_event_at_eight_am(self):
-        # assuming the server operates in GMT+8, while all the dates are
+        # testing server operates in GMT+8, while all the dates are
         # transmitted to the server using UTC.
 
         # 0800 GMT+8 10th February 2024, is 0000 UTC 10th February 2024
@@ -231,14 +231,10 @@ class TestScheduledTasksRoute(AppFixture):
             f"/scheduled_tasks/{schedule_task_id}/clear?event_date=2024-02-11T00:00:00.000Z"
         )
 
-        # we can find this scheduled task by querying
-        resp = self.client.get(
-            f"/scheduled_tasks?start_before={scheduled_date_str}&until_after={scheduled_date_str}"
-        )
+        # check the same scheduled task
+        resp = self.client.get(f"/scheduled_tasks/{schedule_task_id}")
         self.assertEqual(200, resp.status_code, resp.json())
-        tasks = resp.json()
-        self.assertEqual(len(tasks), 1, tasks)
-        scheduled_task = tasks[0]
+        scheduled_task = resp.json()
         self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
 
         # the except_date should be 11th February 2024
@@ -251,7 +247,7 @@ class TestScheduledTasksRoute(AppFixture):
         self.client.delete(f"/scheduled_tasks/{schedule_task_id}")
 
     def test_delete_scheduled_task_event_after_eight_am(self):
-        # assuming the server operates in GMT+8, while all the dates are
+        # testing server operates in GMT+8, while all the dates are
         # transmitted to the server using UTC.
 
         # 0801 GMT+8 10th February 2024, is 0001 UTC 10th February 2024
@@ -281,14 +277,10 @@ class TestScheduledTasksRoute(AppFixture):
             f"/scheduled_tasks/{schedule_task_id}/clear?event_date=2024-02-11T00:01:00.000Z"
         )
 
-        # we can find this scheduled task by querying
-        resp = self.client.get(
-            f"/scheduled_tasks?start_before={scheduled_date_str}&until_after={scheduled_date_str}"
-        )
+        # check the same scheduled task
+        resp = self.client.get(f"/scheduled_tasks/{schedule_task_id}")
         self.assertEqual(200, resp.status_code, resp.json())
-        tasks = resp.json()
-        self.assertEqual(len(tasks), 1, tasks)
-        scheduled_task = tasks[0]
+        scheduled_task = resp.json()
         self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
 
         # the except_date should be 11th February 2024
@@ -301,7 +293,7 @@ class TestScheduledTasksRoute(AppFixture):
         self.client.delete(f"/scheduled_tasks/{schedule_task_id}")
 
     def test_delete_scheduled_task_event_before_eight_am(self):
-        # assuming the server operates in GMT+8, all the dates are transmitted
+        # testing server operates in GMT+8, all the dates are transmitted
         # to the server using UTC.
 
         # every day at 0759 GMT+8 starting from 10th February 2024,
@@ -332,15 +324,10 @@ class TestScheduledTasksRoute(AppFixture):
             f"/scheduled_tasks/{schedule_task_id}/clear?event_date=2024-02-10T23:59:00.000Z"
         )
 
-        # we can find this scheduled task by querying starting before 23:59 UTC
-        # 9th February 2024
-        resp = self.client.get(
-            f"/scheduled_tasks?start_before={scheduled_date_str}&until_after={scheduled_date_str}"
-        )
+        # check the same scheduled task
+        resp = self.client.get(f"/scheduled_tasks/{schedule_task_id}")
         self.assertEqual(200, resp.status_code, resp.json())
-        tasks = resp.json()
-        self.assertEqual(len(tasks), 1, tasks)
-        scheduled_task = tasks[0]
+        scheduled_task = resp.json()
         self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
 
         # since the server is operating in GMT+8, the except_date should be
@@ -354,7 +341,7 @@ class TestScheduledTasksRoute(AppFixture):
         self.client.delete(f"/scheduled_tasks/{schedule_task_id}")
 
     def test_delete_scheduled_task_event_at_local_midnight(self):
-        # assuming the server operates in GMT+8, all the dates are transmitted
+        # testing server operates in GMT+8, all the dates are transmitted
         # to the server using UTC.
 
         # every day at 0000 GMT+8 starting from 12th February 2024,
@@ -385,15 +372,10 @@ class TestScheduledTasksRoute(AppFixture):
             f"/scheduled_tasks/{schedule_task_id}/clear?event_date=2024-02-12T16:00:00.000Z"
         )
 
-        # we can find this scheduled task by querying starting before 16:00 UTC
-        # 11th February 2024
-        resp = self.client.get(
-            f"/scheduled_tasks?start_before={scheduled_date_str}&until_after={scheduled_date_str}"
-        )
+        # check the same scheduled task
+        resp = self.client.get(f"/scheduled_tasks/{schedule_task_id}")
         self.assertEqual(200, resp.status_code, resp.json())
-        tasks = resp.json()
-        self.assertEqual(len(tasks), 1, tasks)
-        scheduled_task = tasks[0]
+        scheduled_task = resp.json()
         self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
 
         # since the server is operating in GMT+8, the except_date should be
@@ -405,18 +387,3 @@ class TestScheduledTasksRoute(AppFixture):
 
         # cleanup
         self.client.delete(f"/scheduled_tasks/{schedule_task_id}")
-
-    # def test_edit_scheduled_task(self):
-    #     raise NotImplementedError
-
-    # def test_edit_scheduled_task_event_at_eight_am(self):
-    #     raise NotImplementedError
-
-    # def test_edit_scheduled_task_event_after_eight_am(self):
-    #     raise NotImplementedError
-
-    # def test_edit_scheduled_task_event_before_eight_am(self):
-    #     raise NotImplementedError
-
-    # def test_edit_scheduled_task_event_at_local_midnight(self):
-    #     raise NotImplementedError

--- a/packages/api-server/api_server/routes/tasks/test_scheduled_tasks.py
+++ b/packages/api-server/api_server/routes/tasks/test_scheduled_tasks.py
@@ -405,3 +405,18 @@ class TestScheduledTasksRoute(AppFixture):
 
         # cleanup
         self.client.delete(f"/scheduled_tasks/{schedule_task_id}")
+
+    # def test_edit_scheduled_task(self):
+    #     raise NotImplementedError
+
+    # def test_edit_scheduled_task_event_at_eight_am(self):
+    #     raise NotImplementedError
+
+    # def test_edit_scheduled_task_event_after_eight_am(self):
+    #     raise NotImplementedError
+
+    # def test_edit_scheduled_task_event_before_eight_am(self):
+    #     raise NotImplementedError
+
+    # def test_edit_scheduled_task_event_at_local_midnight(self):
+    #     raise NotImplementedError

--- a/packages/api-server/api_server/routes/tasks/test_scheduled_tasks.py
+++ b/packages/api-server/api_server/routes/tasks/test_scheduled_tasks.py
@@ -1,5 +1,5 @@
-import urllib
 from datetime import datetime, timedelta
+from urllib.parse import urlencode
 
 from api_server.test import AppFixture
 
@@ -216,7 +216,7 @@ class TestScheduledTasksRoute(AppFixture):
         schedule_task_id = scheduled_task["id"]
         params = {"event_date": "2024-02-11T00:00:00+00:00"}
         self.client.put(
-            f"/scheduled_tasks/{schedule_task_id}/clear?{urllib.parse.urlencode(params)}"
+            f"/scheduled_tasks/{schedule_task_id}/clear?{urlencode(params)}"
         )
 
         # check the same scheduled task
@@ -235,7 +235,7 @@ class TestScheduledTasksRoute(AppFixture):
         schedule_task_id = scheduled_task["id"]
         params = {"event_date": "2024-02-12T08:00:00+08:00"}
         self.client.put(
-            f"/scheduled_tasks/{schedule_task_id}/clear?{urllib.parse.urlencode(params)}"
+            f"/scheduled_tasks/{schedule_task_id}/clear?{urlencode(params)}"
         )
 
         # check the same scheduled task
@@ -281,7 +281,7 @@ class TestScheduledTasksRoute(AppFixture):
         schedule_task_id = scheduled_task["id"]
         params = {"event_date": "2024-02-11T00:01:00+00:00"}
         self.client.put(
-            f"/scheduled_tasks/{schedule_task_id}/clear?{urllib.parse.urlencode(params)}"
+            f"/scheduled_tasks/{schedule_task_id}/clear?{urlencode(params)}"
         )
 
         # check the same scheduled task
@@ -300,7 +300,7 @@ class TestScheduledTasksRoute(AppFixture):
         schedule_task_id = scheduled_task["id"]
         params = {"event_date": "2024-02-12T08:01:00+08:00"}
         self.client.put(
-            f"/scheduled_tasks/{schedule_task_id}/clear?{urllib.parse.urlencode(params)}"
+            f"/scheduled_tasks/{schedule_task_id}/clear?{urlencode(params)}"
         )
 
         # check the same scheduled task
@@ -347,7 +347,7 @@ class TestScheduledTasksRoute(AppFixture):
         schedule_task_id = scheduled_task["id"]
         params = {"event_date": "2024-02-10T23:59:00+00:00"}
         self.client.put(
-            f"/scheduled_tasks/{schedule_task_id}/clear?{urllib.parse.urlencode(params)}"
+            f"/scheduled_tasks/{schedule_task_id}/clear?{urlencode(params)}"
         )
 
         # check the same scheduled task
@@ -367,7 +367,7 @@ class TestScheduledTasksRoute(AppFixture):
         schedule_task_id = scheduled_task["id"]
         params = {"event_date": "2024-02-12T07:59:00+08:00"}
         self.client.put(
-            f"/scheduled_tasks/{schedule_task_id}/clear?{urllib.parse.urlencode(params)}"
+            f"/scheduled_tasks/{schedule_task_id}/clear?{urlencode(params)}"
         )
 
         # check the same scheduled task
@@ -415,7 +415,7 @@ class TestScheduledTasksRoute(AppFixture):
         schedule_task_id = scheduled_task["id"]
         params = {"event_date": "2024-02-12T16:00:00+00:00"}
         self.client.put(
-            f"/scheduled_tasks/{schedule_task_id}/clear?{urllib.parse.urlencode(params)}"
+            f"/scheduled_tasks/{schedule_task_id}/clear?{urlencode(params)}"
         )
 
         # check the same scheduled task
@@ -435,7 +435,7 @@ class TestScheduledTasksRoute(AppFixture):
         schedule_task_id = scheduled_task["id"]
         params = {"event_date": "2024-02-14T00:00:00+08:00"}
         self.client.put(
-            f"/scheduled_tasks/{schedule_task_id}/clear?{urllib.parse.urlencode(params)}"
+            f"/scheduled_tasks/{schedule_task_id}/clear?{urlencode(params)}"
         )
 
         # check the same scheduled task

--- a/packages/api-server/scripts/sqlite_test_config.py
+++ b/packages/api-server/scripts/sqlite_test_config.py
@@ -1,3 +1,8 @@
 from base_test_config import config
 
-config.update({"db_url": "sqlite://:memory:"})
+config.update(
+    {
+        "db_url": "sqlite://:memory:",
+        "timezone": "Asia/Singapore",
+    }
+)

--- a/packages/dashboard/src/components/tasks/task-schedule-utils.ts
+++ b/packages/dashboard/src/components/tasks/task-schedule-utils.ts
@@ -173,3 +173,33 @@ export const getScheduledTaskTitle = (task: ScheduledTask): string => {
 
   return `${getShortDescription(task.task_request)}`;
 };
+
+// Pad a number to 2 digits
+function pad(n: number): string {
+  return `${Math.floor(Math.abs(n))}`.padStart(2, '0');
+}
+
+// Get timezone offset in ISO format (+hh:mm or -hh:mm)
+function getTimezoneOffset(date: Date): string {
+  const tzOffset = -date.getTimezoneOffset();
+  const diff = tzOffset >= 0 ? '+' : '-';
+  return diff + pad(tzOffset / 60) + ':' + pad(tzOffset % 60);
+}
+
+// Convert Date to ISO string that contains timezone information
+export function toISOStringWithTimezone(date: Date): string {
+  return (
+    date.getFullYear() +
+    '-' +
+    pad(date.getMonth() + 1) +
+    '-' +
+    pad(date.getDate()) +
+    'T' +
+    pad(date.getHours()) +
+    ':' +
+    pad(date.getMinutes()) +
+    ':' +
+    pad(date.getSeconds()) +
+    getTimezoneOffset(date)
+  );
+}

--- a/packages/dashboard/src/components/tasks/task-schedule-utils.ts
+++ b/packages/dashboard/src/components/tasks/task-schedule-utils.ts
@@ -186,7 +186,7 @@ function getTimezoneOffset(date: Date): string {
   return diff + pad(tzOffset / 60) + ':' + pad(tzOffset % 60);
 }
 
-// Convert Date to ISO string that contains timezone information
+// Convert Date to local time zone ISO string that contains timezone information
 export function toISOStringWithTimezone(date: Date): string {
   return (
     date.getFullYear() +

--- a/packages/dashboard/src/components/tasks/task-schedule-utils.ts
+++ b/packages/dashboard/src/components/tasks/task-schedule-utils.ts
@@ -101,8 +101,15 @@ export const scheduleToEvents = (
       (scheStartFrom == null || scheStartFrom <= cur) &&
       (scheUntil == null || scheUntil >= cur)
     ) {
-      const curToIso = cur.toISOString();
-      const curFormatted = `${curToIso.slice(0, 10)}`;
+      // cur is provided in the dashboard's and server's timezone, therefore
+      // cur should be formatted accordingly and checked against except_dates
+      // without converting to ISO (this will be UTC).
+      const numberToPaddedStr = (num: number): string => {
+        return num >= 10 ? num.toString() : `0${num}`;
+      };
+      const curFormatted = `${cur.getFullYear()}-${numberToPaddedStr(
+        cur.getMonth() + 1,
+      )}-${numberToPaddedStr(cur.getDate())}`;
       if (!task.except_dates.includes(curFormatted)) {
         events.push({
           start: cur,

--- a/packages/dashboard/src/components/tasks/task-schedule.tsx
+++ b/packages/dashboard/src/components/tasks/task-schedule.tsx
@@ -33,6 +33,7 @@ import {
   getScheduledTaskTitle,
   scheduleToEvents,
   scheduleWithSelectedDay,
+  toISOStringWithTimezone,
 } from './task-schedule-utils';
 
 enum EventScopes {
@@ -235,7 +236,7 @@ export const TaskSchedule = () => {
       if (eventScope === EventScopes.CURRENT) {
         await rmf.tasksApi.delScheduledTasksEventScheduledTasksTaskIdClearPut(
           task.id,
-          exceptDateRef.current.toISOString(),
+          toISOStringWithTimezone(exceptDateRef.current),
         );
       } else {
         await rmf.tasksApi.delScheduledTasksScheduledTasksTaskIdDelete(task.id);

--- a/packages/dashboard/src/components/tasks/task-schedule.tsx
+++ b/packages/dashboard/src/components/tasks/task-schedule.tsx
@@ -234,11 +234,11 @@ export const TaskSchedule = () => {
       }
 
       if (eventScope === EventScopes.CURRENT) {
-        await rmf.tasksApi.delScheduledTasksEventScheduledTasksTaskIdClearPut(
-          task.id,
-          toISOStringWithTimezone(exceptDateRef.current),
-        );
+        const eventDate = toISOStringWithTimezone(exceptDateRef.current);
+        console.debug(`Deleting schedule id ${task.id}, event date ${eventDate}`);
+        await rmf.tasksApi.delScheduledTasksEventScheduledTasksTaskIdClearPut(task.id, eventDate);
       } else {
+        console.debug(`Deleting schedule with id ${task.id}`);
         await rmf.tasksApi.delScheduledTasksScheduledTasksTaskIdDelete(task.id);
       }
       AppEvents.refreshTaskSchedule.next();

--- a/packages/dashboard/src/components/tasks/tests/task-schedule-utils.test.tsx
+++ b/packages/dashboard/src/components/tasks/tests/task-schedule-utils.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { toISOStringWithTimezone } from '../task-schedule-utils';
+
+it('converts date to ISO string while retaining timezone', async () => {
+  const date_str = '2024-02-14T19:20:34+08:00';
+  expect(toISOStringWithTimezone(new Date(date_str))).toBe(date_str);
+});
+
+export {};

--- a/packages/dashboard/src/components/tasks/tests/task-schedule-utils.test.tsx
+++ b/packages/dashboard/src/components/tasks/tests/task-schedule-utils.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { toISOStringWithTimezone } from '../task-schedule-utils';
-
-it('converts date to ISO string while retaining timezone', async () => {
-  const date_str = '2024-02-14T19:20:34+08:00';
-  expect(toISOStringWithTimezone(new Date(date_str))).toBe(date_str);
-});
-
-export {};


### PR DESCRIPTION
## What's new

* Added more tests on the route level
* Convert incoming except dates (in UTC) to any local timezones defined for the server, to determine the dates for `except_dates` 
* Fix the dashboard renders schedules.
  * deleting a task on day 1 before 8am results in day 2's task not being rendered, because day 1 is added into `except_date`, but `toISOFormat` checks in UTC, which makes day 1 -> day 0, and day 2 -> day 1, therefore failing to render day 2's

Before:
* we extract the date (YYYY-MM-DD) from the provided UTC dates, however this doesn't take into account of the case where UTC and server TZ has different dates (before Singapore 8am, for example). Currently this affects deleting or editing schedules before 8am only
* Example scenario, deleting a schedule at `05:00 GMT+8 2024-02-09`, will result in `21:00 GMT+0 2024-02-08`, where we will only check if the date `2024-02-08` if it should run. When  `05:00 GMT+8 2024-02-09` comes, the scheduler will see that only `2024-02-08` is exempted, while `2024-02-09` is not, and still proceeds to perform the schedule
* rendering issue

https://github.com/open-rmf/rmf-web/assets/5383623/74ae271a-2ef5-4632-9734-8c18aeea9441

Now:
* Convert received UTC dates into server TZ, before formatting the same way and extracting the date
* In the example scenario, after changing  `21:00 GMT+0 2024-02-08` back to server TZ `05:00 GMT+8 2024-02-09`, it will save `2024-02-09` as exempted, and when the scheduled time arrives, it will skip the schedule as intended.
* rendering fixed

https://github.com/open-rmf/rmf-web/assets/5383623/0fb3e9ea-b94c-466f-8acd-fd8861859702

Next:
* schedule editing, this bug also exists in editing, however those routes will also benefit from some refactoring, hence will be excluded from this PR for now

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test