### PR TITLE
Shuts down server if internal websocket connections exceed max allowed defined in config

### DIFF
--- a/packages/api-server/api_server/app_config.py
+++ b/packages/api-server/api_server/app_config.py
@@ -22,6 +22,7 @@ class AppConfig:
     iss: Optional[str]
     ros_args: List[str]
     timezone: Optional[str]
+    max_internal_websocket_connections: Optional[int]
 
     def __post_init__(self):
         self.public_url = urllib.parse.urlparse(cast(str, self.public_url))

--- a/packages/api-server/api_server/default_config.py
+++ b/packages/api-server/api_server/default_config.py
@@ -36,7 +36,7 @@ config = {
     # as the system timezone, as well as the client UI timezone. Cross-timezone
     # scheduling is currently not supported.
     "timezone": None,
-    # Maximum number of allowed internal websocket connections. This is a
+    # FIXME Maximum number of allowed internal websocket connections. This is a
     # temporary solution to https://github.com/open-rmf/rmf-web/issues/897. If
     # it goes beyond this number, the server will shut down. If not defined,
     # this number will not be enforced in any way.

--- a/packages/api-server/api_server/default_config.py
+++ b/packages/api-server/api_server/default_config.py
@@ -36,4 +36,9 @@ config = {
     # as the system timezone, as well as the client UI timezone. Cross-timezone
     # scheduling is currently not supported.
     "timezone": None,
+    # Maximum number of allowed internal websocket connections. This is a
+    # temporary solution to https://github.com/open-rmf/rmf-web/issues/897. If
+    # it goes beyond this number, the server will shut down. If not defined,
+    # this number will not be enforced in any way.
+    "max_internal_websocket_connections": None,
 }

--- a/packages/api-server/api_server/routes/internal.py
+++ b/packages/api-server/api_server/routes/internal.py
@@ -1,12 +1,12 @@
 # NOTE: This will eventually replace `gateway.py``
 import os
-from datetime import datetime
 from typing import Any, Dict
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from websockets.exceptions import ConnectionClosed
 
 from api_server import models as mdl
+from api_server.app_config import app_config
 from api_server.logger import logger as base_logger
 from api_server.repositories import AlertRepository, FleetRepository, TaskRepository
 from api_server.rmf_io import alert_events, fleet_events, task_events
@@ -16,43 +16,6 @@ logger = base_logger.getChild("RmfGatewayApp")
 user: mdl.User = mdl.User(username="__rmf_internal__", is_admin=True)
 task_repo = TaskRepository(user)
 alert_repo = AlertRepository(user, task_repo)
-
-
-class WebSocketHealthManager:
-    def __init__(self):
-        self.disconnects = []
-
-    def disconnected(self):
-        self.disconnects.append(datetime.now())
-
-        # Clean up if the past disconnection is more than 2 minutes ago
-        if len(self.disconnects) > 2:
-            seconds_since_last_disconnect = (
-                self.disconnects[-1] - self.disconnects[-2]
-            ).seconds
-            logger.warn(
-                f"Previous Web Socket disconnection was {seconds_since_last_disconnect} seconds ago"
-            )
-            if seconds_since_last_disconnect > 120:
-                logger.info(
-                    "Previous Web Socket disconnection was more than 2 minutes ago, cleaning up"
-                )
-                self.disconnects = [datetime.now()]
-
-        # If there are more than 5 disconnects that occurred within 2 minutes, shut down the server
-        if len(self.disconnects) > 5:
-            unhealthy_period_seconds = (
-                self.disconnects[-1] - self.disconnects[-5]
-            ).seconds
-            if unhealthy_period_seconds < 120:
-                logger.error(
-                    f"Web Sockets had 5 disconnections within {unhealthy_period_seconds} seconds"
-                )
-                logger.error("Shutting down server")
-                os._exit(1)  # pylint: disable=protected-access
-
-
-health_manager = WebSocketHealthManager()
 
 
 class ConnectionManager:
@@ -65,6 +28,18 @@ class ConnectionManager:
         logger.info(
             f"ConnectionManager: {len(self.active_connections)} websocket connections still alive"
         )
+
+        # Temporary fix for https://github.com/open-rmf/rmf-web/issues/897
+        if (
+            app_config.max_internal_websocket_connections is not None
+            and len(self.active_connections)
+            > app_config.max_internal_websocket_connections
+        ):
+            logger.error(
+                f"ConnectionManager: exceeded maximum allowed internal websocket connections [{app_config.max_internal_websocket_connections}]"
+            )
+            logger.error("ConnectionManager: Shutting down server")
+            os._exit(1)  # pylint: disable=protected-access
 
     def disconnect(self, websocket: WebSocket):
         self.active_connections.remove(websocket)
@@ -168,5 +143,4 @@ async def rmf_gateway(websocket: WebSocket):
             await process_msg(msg, fleet_repo)
     except (WebSocketDisconnect, ConnectionClosed):
         connection_manager.disconnect(websocket)
-        health_manager.disconnected()
         logger.warn("Client websocket disconnected")


### PR DESCRIPTION
## What's new

Implements an optional static limit to the number of internal websocket connections allowed. Supercedes https://github.com/open-rmf/rmf-web/pull/895

Temporary fix for https://github.com/open-rmf/rmf-web/issues/897

* Removes `WebsocketHealthManager`, just uses `ConnectionManager`
* New configurable parameter `max_internal_websocket_connections`. This value should be number of fleet adapters using `BroadcastClient` + number of task dispatchers

To test
* add `"max_internal_websocket_connections": 1,` to `packages/api-server/sqlite_local_config.py`, we only allow one fleet adapter connection
* launch office demo, `ros2 launch rmf_demos_gz office.launch.xml server_uri:="ws://localhost:8000/_internal" headless:=1`, this launches `rmf_task_dispatcher` without server connection at the moment
* in a separate terminal start a new task dispatcher and provide it with the server URI, `ros2 run rmf_task_ros2 rmf_task_dispatcher --ros-args -p use_sim_time:=true -p server_uri:="ws://localhost:8000/_internal"`
* The server will announce that the number of internal websocket connections was exceeded and shut down

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test