### PR TITLE
Update schedule with timezone information

### DIFF
--- a/packages/api-server/.pylintrc
+++ b/packages/api-server/.pylintrc
@@ -151,6 +151,8 @@ disable=print-statement,
         fixme,
         logging-fstring-interpolation,
         line-too-long,
+        too-many-lines,
+
 # fastapi heavily uses singletons, disallowing global statements just ends up with things
 # using nonlocal as singletons which are functionally the same as globals.
         global-statement,

--- a/packages/api-server/api_server/routes/tasks/test_scheduled_tasks.py
+++ b/packages/api-server/api_server/routes/tasks/test_scheduled_tasks.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from datetime import datetime, timedelta
 from urllib.parse import urlencode
 

--- a/packages/api-server/api_server/routes/tasks/test_scheduled_tasks.py
+++ b/packages/api-server/api_server/routes/tasks/test_scheduled_tasks.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 from datetime import datetime, timedelta
 from urllib.parse import urlencode
 
@@ -160,7 +161,7 @@ class TestScheduledTasksRoute(AppFixture):
         self.assertIn(task["id"], tasks)
 
     def test_delete_scheduled_task(self):
-        schedule_date_str = "2024-02-10T10:00:00+08:00"
+        schedule_date_str = "2124-02-10T10:00:00+08:00"
         scheduled_task_description = {
             "task_request": {
                 "category": "test",
@@ -188,11 +189,7 @@ class TestScheduledTasksRoute(AppFixture):
         self.assertEqual(404, resp.status_code, resp.json())
 
     def test_delete_scheduled_task_event_at_eight_am(self):
-        # testing server operates in GMT+8, while all the dates are
-        # transmitted to the server using UTC.
-
-        # 0800 GMT+8 10th February 2024, is 0000 UTC 10th February 2024
-        scheduled_date_str = "2024-02-10T00:00:00+00:00"
+        scheduled_date_str = "2124-02-10T08:00:00+08:00"
         scheduled_task_description = {
             "task_request": {
                 "category": "test",
@@ -211,10 +208,10 @@ class TestScheduledTasksRoute(AppFixture):
         scheduled_task = resp.json()
         self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
 
-        # delete a single event from this schedule, for 0800 GMT+8 11th February 2024,
-        # which is 0000 UTC 11th February 2024.
+        # delete a single event from this schedule, for 0800 GMT+8 11th February 2124,
+        # which is 0000 UTC 11th February 2124.
         schedule_task_id = scheduled_task["id"]
-        params = {"event_date": "2024-02-11T00:00:00+00:00"}
+        params = {"event_date": "2124-02-11T00:00:00+00:00"}
         self.client.put(
             f"/scheduled_tasks/{schedule_task_id}/clear?{urlencode(params)}"
         )
@@ -225,15 +222,15 @@ class TestScheduledTasksRoute(AppFixture):
         scheduled_task = resp.json()
         self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
 
-        # the except_date should be 11th February 2024
+        # the except_date should be 11th February 2124
         self.assertEqual(len(scheduled_task["except_dates"]), 1, scheduled_task)
         self.assertEqual(
-            scheduled_task["except_dates"][0], "2024-02-11", scheduled_task
+            scheduled_task["except_dates"][0], "2124-02-11", scheduled_task
         )
 
-        # delete a single event from this schedule, for 0800 GMT+8 12th February 2024
+        # delete a single event from this schedule, for 0800 GMT+8 12th February 2124
         schedule_task_id = scheduled_task["id"]
-        params = {"event_date": "2024-02-12T08:00:00+08:00"}
+        params = {"event_date": "2124-02-12T08:00:00+08:00"}
         self.client.put(
             f"/scheduled_tasks/{schedule_task_id}/clear?{urlencode(params)}"
         )
@@ -244,10 +241,10 @@ class TestScheduledTasksRoute(AppFixture):
         scheduled_task = resp.json()
         self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
 
-        # the except_date should now have both 11th and 12th February 2024
+        # the except_date should now have both 11th and 12th February 2124
         self.assertEqual(len(scheduled_task["except_dates"]), 2, scheduled_task)
-        self.assertTrue("2024-02-11" in scheduled_task["except_dates"], scheduled_task)
-        self.assertTrue("2024-02-12" in scheduled_task["except_dates"], scheduled_task)
+        self.assertTrue("2124-02-11" in scheduled_task["except_dates"], scheduled_task)
+        self.assertTrue("2124-02-12" in scheduled_task["except_dates"], scheduled_task)
 
         # cleanup
         self.client.delete(f"/scheduled_tasks/{schedule_task_id}")
@@ -256,8 +253,8 @@ class TestScheduledTasksRoute(AppFixture):
         # testing server operates in GMT+8, while all the dates are
         # transmitted to the server using UTC.
 
-        # 0801 GMT+8 10th February 2024, is 0001 UTC 10th February 2024
-        scheduled_date_str = "2024-02-10T00:01:00+00:00"
+        # 0801 GMT+8 10th February 2124, is 0001 UTC 10th February 2124
+        scheduled_date_str = "2124-02-10T00:01:00+00:00"
         scheduled_task_description = {
             "task_request": {
                 "category": "test",
@@ -276,10 +273,10 @@ class TestScheduledTasksRoute(AppFixture):
         scheduled_task = resp.json()
         self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
 
-        # delete a single event from this schedule, for 0801 GMT+8 11th February 2024,
-        # which is 0001 UTC 11th February 2024.
+        # delete a single event from this schedule, for 0801 GMT+8 11th February 2124,
+        # which is 0001 UTC 11th February 2124.
         schedule_task_id = scheduled_task["id"]
-        params = {"event_date": "2024-02-11T00:01:00+00:00"}
+        params = {"event_date": "2124-02-11T00:01:00+00:00"}
         self.client.put(
             f"/scheduled_tasks/{schedule_task_id}/clear?{urlencode(params)}"
         )
@@ -290,15 +287,15 @@ class TestScheduledTasksRoute(AppFixture):
         scheduled_task = resp.json()
         self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
 
-        # the except_date should be 11th February 2024
+        # the except_date should be 11th February 2124
         self.assertEqual(len(scheduled_task["except_dates"]), 1, scheduled_task)
         self.assertEqual(
-            scheduled_task["except_dates"][0], "2024-02-11", scheduled_task
+            scheduled_task["except_dates"][0], "2124-02-11", scheduled_task
         )
 
-        # delete a single event from this schedule, for 0801 GMT+8 12th February 2024
+        # delete a single event from this schedule, for 0801 GMT+8 12th February 2124
         schedule_task_id = scheduled_task["id"]
-        params = {"event_date": "2024-02-12T08:01:00+08:00"}
+        params = {"event_date": "2124-02-12T08:01:00+08:00"}
         self.client.put(
             f"/scheduled_tasks/{schedule_task_id}/clear?{urlencode(params)}"
         )
@@ -309,21 +306,16 @@ class TestScheduledTasksRoute(AppFixture):
         scheduled_task = resp.json()
         self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
 
-        # the except_date should now have both 11th and 12th February 2024
+        # the except_date should now have both 11th and 12th February 2124
         self.assertEqual(len(scheduled_task["except_dates"]), 2, scheduled_task)
-        self.assertTrue("2024-02-11" in scheduled_task["except_dates"], scheduled_task)
-        self.assertTrue("2024-02-12" in scheduled_task["except_dates"], scheduled_task)
+        self.assertTrue("2124-02-11" in scheduled_task["except_dates"], scheduled_task)
+        self.assertTrue("2124-02-12" in scheduled_task["except_dates"], scheduled_task)
 
         # cleanup
         self.client.delete(f"/scheduled_tasks/{schedule_task_id}")
 
     def test_delete_scheduled_task_event_before_eight_am(self):
-        # testing server operates in GMT+8, all the dates are transmitted
-        # to the server using UTC.
-
-        # every day at 0759 GMT+8 starting from 10th February 2024,
-        # which is 2359 UTC 9th February 2024.
-        scheduled_date_str = "2024-02-09T23:59:00+00:00"
+        scheduled_date_str = "2124-02-09T07:59:00+08:00"
         scheduled_task_description = {
             "task_request": {
                 "category": "test",
@@ -342,10 +334,10 @@ class TestScheduledTasksRoute(AppFixture):
         scheduled_task = resp.json()
         self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
 
-        # delete a single event from this schedule, for 0759 GMT+8 11th February 2024,
-        # which is 2359 UTC 10th February 2024.
+        # delete a single event from this schedule, for 0759 GMT+8 11th February 2124,
+        # which is 2359 UTC 10th February 2124.
         schedule_task_id = scheduled_task["id"]
-        params = {"event_date": "2024-02-10T23:59:00+00:00"}
+        params = {"event_date": "2124-02-10T23:59:00+00:00"}
         self.client.put(
             f"/scheduled_tasks/{schedule_task_id}/clear?{urlencode(params)}"
         )
@@ -357,15 +349,15 @@ class TestScheduledTasksRoute(AppFixture):
         self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
 
         # since the server is operating in GMT+8, the except_date should be
-        # 11th February 2024, and not 10th February 2024
+        # 11th February 2124, and not 10th February 2124
         self.assertEqual(len(scheduled_task["except_dates"]), 1, scheduled_task)
         self.assertEqual(
-            scheduled_task["except_dates"][0], "2024-02-11", scheduled_task
+            scheduled_task["except_dates"][0], "2124-02-11", scheduled_task
         )
 
-        # delete a single event from this schedule, for 0759 GMT+8 12th February 2024
+        # delete a single event from this schedule, for 0759 GMT+8 12th February 2124
         schedule_task_id = scheduled_task["id"]
-        params = {"event_date": "2024-02-12T07:59:00+08:00"}
+        params = {"event_date": "2124-02-12T07:59:00+08:00"}
         self.client.put(
             f"/scheduled_tasks/{schedule_task_id}/clear?{urlencode(params)}"
         )
@@ -377,21 +369,16 @@ class TestScheduledTasksRoute(AppFixture):
         self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
 
         # since the server is operating in GMT+8, the except_date should have
-        # both 11th and 12th February 2024
+        # both 11th and 12th February 2124
         self.assertEqual(len(scheduled_task["except_dates"]), 2, scheduled_task)
-        self.assertTrue("2024-02-11" in scheduled_task["except_dates"], scheduled_task)
-        self.assertTrue("2024-02-12" in scheduled_task["except_dates"], scheduled_task)
+        self.assertTrue("2124-02-11" in scheduled_task["except_dates"], scheduled_task)
+        self.assertTrue("2124-02-12" in scheduled_task["except_dates"], scheduled_task)
 
         # cleanup
         self.client.delete(f"/scheduled_tasks/{schedule_task_id}")
 
     def test_delete_scheduled_task_event_at_local_midnight(self):
-        # testing server operates in GMT+8, all the dates are transmitted
-        # to the server using UTC.
-
-        # every day at 0000 GMT+8 starting from 12th February 2024,
-        # which is 1600 UTC 11th February 2024.
-        scheduled_date_str = "2024-02-11T16:00:00+00:00"
+        scheduled_date_str = "2124-02-12T00:00:00+08:00"
         scheduled_task_description = {
             "task_request": {
                 "category": "test",
@@ -410,10 +397,10 @@ class TestScheduledTasksRoute(AppFixture):
         scheduled_task = resp.json()
         self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
 
-        # delete a single event from this schedule, for 0000 GMT+8 13th February 2024,
-        # which is 1600 UTC 12th February 2024.
+        # delete a single event from this schedule, for 0000 GMT+8 13th February 2124,
+        # which is 1600 UTC 12th February 2124.
         schedule_task_id = scheduled_task["id"]
-        params = {"event_date": "2024-02-12T16:00:00+00:00"}
+        params = {"event_date": "2124-02-12T16:00:00+00:00"}
         self.client.put(
             f"/scheduled_tasks/{schedule_task_id}/clear?{urlencode(params)}"
         )
@@ -425,15 +412,15 @@ class TestScheduledTasksRoute(AppFixture):
         self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
 
         # since the server is operating in GMT+8, the except_date should be
-        # 13th February 2024, and not 12th February 2024
+        # 13th February 2124, and not 12th February 2124
         self.assertEqual(len(scheduled_task["except_dates"]), 1, scheduled_task)
         self.assertEqual(
-            scheduled_task["except_dates"][0], "2024-02-13", scheduled_task
+            scheduled_task["except_dates"][0], "2124-02-13", scheduled_task
         )
 
-        # delete a single event from this schedule, for 0000 GMT+8 14th February 2024
+        # delete a single event from this schedule, for 0000 GMT+8 14th February 2124
         schedule_task_id = scheduled_task["id"]
-        params = {"event_date": "2024-02-14T00:00:00+08:00"}
+        params = {"event_date": "2124-02-14T00:00:00+08:00"}
         self.client.put(
             f"/scheduled_tasks/{schedule_task_id}/clear?{urlencode(params)}"
         )
@@ -444,10 +431,836 @@ class TestScheduledTasksRoute(AppFixture):
         scheduled_task = resp.json()
         self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
 
-        # The except_date should be both 13th and 14th February 2024
+        # The except_date should be both 13th and 14th February 2124
         self.assertEqual(len(scheduled_task["except_dates"]), 2, scheduled_task)
-        self.assertTrue("2024-02-13" in scheduled_task["except_dates"], scheduled_task)
-        self.assertTrue("2024-02-14" in scheduled_task["except_dates"], scheduled_task)
+        self.assertTrue("2124-02-13" in scheduled_task["except_dates"], scheduled_task)
+        self.assertTrue("2124-02-14" in scheduled_task["except_dates"], scheduled_task)
 
         # cleanup
         self.client.delete(f"/scheduled_tasks/{schedule_task_id}")
+
+    def test_edit_scheduled_task(self):
+        scheduled_date_str = "2124-02-10T16:00:00+08:00"
+        task_request = {
+            "category": "test_category",
+            "description": "test_description",
+        }
+        task_schedules = [
+            {
+                "period": "day",
+                "start_from": scheduled_date_str,
+                "at": "16:00",
+            }
+        ]
+
+        scheduled_task_description = {
+            "task_request": task_request,
+            "schedules": task_schedules,
+        }
+        resp = self.client.post("/scheduled_tasks", json=scheduled_task_description)
+        self.assertEqual(201, resp.status_code, resp.json())
+        scheduled_task = resp.json()
+        self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
+        schedule_task_id = scheduled_task["id"]
+        schedules = scheduled_task["schedules"]
+
+        # update task description
+        updated_task_request = {
+            "category": "test_category_updated",
+            "description": "test_description_updated",
+        }
+        scheduled_task_description["task_request"] = updated_task_request
+        resp = self.client.post(
+            f"/scheduled_tasks/{schedule_task_id}/update",
+            json=scheduled_task_description,
+        )
+        self.assertEqual(201, resp.status_code, resp.json())
+
+        # compare updated scheduled task description
+        resp = self.client.get(f"/scheduled_tasks/{schedule_task_id}")
+        self.assertEqual(200, resp.status_code, resp.json())
+        updated_scheduled_task = resp.json()
+        self.assertEqual(
+            updated_scheduled_task["task_request"],
+            updated_task_request,
+            updated_scheduled_task,
+        )
+        self.assertEqual(
+            updated_scheduled_task["schedules"], schedules, updated_scheduled_task
+        )
+
+        # update task schedules in UTC
+        updated_scheduled_date_str = "2124-02-10T12:00:00+00:00"
+        updated_task_schedules = [
+            {
+                "period": "day",
+                "start_from": updated_scheduled_date_str,
+                "at": "20:00",
+            }
+        ]
+        scheduled_task_description["schedules"] = updated_task_schedules
+        resp = self.client.post(
+            f"/scheduled_tasks/{schedule_task_id}/update",
+            json=scheduled_task_description,
+        )
+        self.assertEqual(201, resp.status_code, resp.json())
+
+        # compare updated scheduled task schedules
+        resp = self.client.get(f"/scheduled_tasks/{schedule_task_id}")
+        self.assertEqual(200, resp.status_code, resp.json())
+        updated_scheduled_task = resp.json()
+        self.assertEqual(
+            updated_scheduled_task["task_request"],
+            updated_task_request,
+            updated_scheduled_task,
+        )
+        self.assertNotEqual(
+            updated_scheduled_task["schedules"], schedules, updated_scheduled_task
+        )
+        self.assertEqual(
+            len(updated_scheduled_task["schedules"]), 1, updated_scheduled_task
+        )
+        updated_schedule = updated_scheduled_task["schedules"][0]
+        self.assertEqual(
+            updated_schedule["start_from"], updated_scheduled_date_str, updated_schedule
+        )
+        self.assertEqual(updated_schedule["at"], "20:00", updated_schedule)
+
+        # update task schedules in GMT+8
+        updated_scheduled_date_str = "2124-02-10T21:00:00+08:00"
+        updated_task_schedules = [
+            {
+                "period": "day",
+                "start_from": updated_scheduled_date_str,
+                "at": "21:00",
+            }
+        ]
+        scheduled_task_description["schedules"] = updated_task_schedules
+        resp = self.client.post(
+            f"/scheduled_tasks/{schedule_task_id}/update",
+            json=scheduled_task_description,
+        )
+        self.assertEqual(201, resp.status_code, resp.json())
+
+        # compare updated scheduled task schedules
+        resp = self.client.get(f"/scheduled_tasks/{schedule_task_id}")
+        self.assertEqual(200, resp.status_code, resp.json())
+        updated_scheduled_task = resp.json()
+        self.assertEqual(
+            updated_scheduled_task["task_request"],
+            updated_task_request,
+            updated_scheduled_task,
+        )
+        self.assertNotEqual(
+            updated_scheduled_task["schedules"], schedules, updated_scheduled_task
+        )
+        self.assertEqual(
+            len(updated_scheduled_task["schedules"]), 1, updated_scheduled_task
+        )
+        updated_schedule = updated_scheduled_task["schedules"][0]
+
+        # Start from dates are saved as UTC
+        updated_scheduled_date_utc_str = "2124-02-10T13:00:00+00:00"
+        self.assertEqual(
+            updated_schedule["start_from"],
+            updated_scheduled_date_utc_str,
+            updated_schedule,
+        )
+        self.assertEqual(updated_schedule["at"], "21:00", updated_schedule)
+
+        # cleanup
+        self.client.delete(f"/scheduled_tasks/{schedule_task_id}")
+
+    def test_edit_scheduled_task_event(self):
+        scheduled_date_str = "2124-02-10T10:00:00+08:00"
+        task_request = {
+            "category": "test_category",
+            "description": "test_description",
+        }
+        task_schedules = [
+            {
+                "period": "day",
+                "start_from": scheduled_date_str,
+                "at": "10:00",
+            }
+        ]
+
+        scheduled_task_description = {
+            "task_request": task_request,
+            "schedules": task_schedules,
+        }
+        resp = self.client.post("/scheduled_tasks", json=scheduled_task_description)
+        self.assertEqual(201, resp.status_code, resp.json())
+        scheduled_task = resp.json()
+        self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
+        schedule_task_id = scheduled_task["id"]
+        schedules = scheduled_task["schedules"]
+
+        # update task description, with except date on 12th GMT+8
+        except_scheduled_date_str = "2124-02-12T10:00:00+08:00"
+        updated_task_request = {
+            "category": "test_category_updated",
+            "description": "test_description_updated",
+        }
+        scheduled_task_description["task_request"] = updated_task_request
+
+        # this will be accompanied by an until date of 23:59 12th GMT+8, which
+        # will be saved as 15:59 12th UTC
+        # FIXME this should come in as client dashboard's time zone
+        until_str_utc = "2124-02-12T15:59:59+00:00"
+        updated_task_schedule = task_schedules[0]
+        updated_task_schedule["until"] = until_str_utc
+        scheduled_task_description["schedules"][0] = updated_task_schedule
+
+        params = {"except_date": except_scheduled_date_str}
+        resp = self.client.post(
+            f"/scheduled_tasks/{schedule_task_id}/update?{urlencode(params)}",
+            json=scheduled_task_description,
+        )
+        self.assertEqual(201, resp.status_code, resp.json())
+
+        # since we have an except_date, the original schedule should not change
+        # except an additional except_date
+        resp = self.client.get(f"/scheduled_tasks/{schedule_task_id}")
+        self.assertEqual(200, resp.status_code, resp.json())
+        updated_scheduled_task = resp.json()
+        self.assertEqual(
+            updated_scheduled_task["task_request"], task_request, updated_scheduled_task
+        )
+        self.assertEqual(
+            updated_scheduled_task["schedules"], schedules, updated_scheduled_task
+        )
+        self.assertEqual(
+            len(updated_scheduled_task["except_dates"]), 1, updated_scheduled_task
+        )
+        self.assertEqual(
+            updated_scheduled_task["except_dates"][0],
+            "2124-02-12",
+            updated_scheduled_task,
+        )
+
+        # The new schedule task for that single event should just be a single index increment
+        # This scheduled task with a single event should have the
+        # - updated task description
+        # - no except dates
+        # - correct start_from date
+        # - correct until date in UTC
+        new_scheduled_task_id = schedule_task_id + 1
+        resp = self.client.get(f"/scheduled_tasks/{new_scheduled_task_id}")
+        self.assertEqual(200, resp.status_code, resp.json())
+        updated_scheduled_task = resp.json()
+        self.assertEqual(
+            updated_scheduled_task["task_request"],
+            updated_task_request,
+            updated_scheduled_task,
+        )
+        self.assertEqual(
+            len(updated_scheduled_task["except_dates"]), 0, updated_scheduled_task
+        )
+        single_event_schedules = updated_scheduled_task["schedules"]
+        self.assertEqual(len(single_event_schedules), 1, single_event_schedules)
+        self.assertEqual(
+            single_event_schedules[0]["at"],
+            updated_task_schedule["at"],
+            single_event_schedules,
+        )
+        self.assertEqual(
+            single_event_schedules[0]["period"],
+            updated_task_schedule["period"],
+            single_event_schedules,
+        )
+        self.assertIsNotNone(single_event_schedules[0]["until"])
+        # until date is saved in UTC
+        self.assertEqual(
+            single_event_schedules[0]["until"], until_str_utc, single_event_schedules[0]
+        )
+
+        # cleanup
+        self.client.delete(f"/scheduled_tasks/{schedule_task_id}")
+        self.client.delete(f"/scheduled_tasks/{new_scheduled_task_id}")
+
+    def test_edit_scheduled_task_event_at_eight_am(self):
+        scheduled_date_str = "2124-02-10T08:00:00+08:00"
+        task_request = {
+            "category": "test_category",
+            "description": "test_description",
+        }
+        task_schedules = [
+            {
+                "period": "day",
+                "start_from": scheduled_date_str,
+                "at": "08:00",
+            }
+        ]
+
+        scheduled_task_description = {
+            "task_request": task_request,
+            "schedules": task_schedules,
+        }
+        resp = self.client.post("/scheduled_tasks", json=scheduled_task_description)
+        self.assertEqual(201, resp.status_code, resp.json())
+        scheduled_task = resp.json()
+        self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
+        schedule_task_id = scheduled_task["id"]
+        schedules = scheduled_task["schedules"]
+
+        # update task description, with except date on 12th GMT+8
+        except_scheduled_date_str = "2124-02-12T08:00:00+08:00"
+        updated_task_request = {
+            "category": "test_category_updated",
+            "description": "test_description_updated",
+        }
+        scheduled_task_description["task_request"] = updated_task_request
+
+        # this will be accompanied by an until date of 23:59 12th GMT+8, which
+        # will be saved as 15:59 12th UTC
+        # FIXME this should come in as client dashboard's time zone
+        until_str_utc = "2124-02-12T15:59:59+00:00"
+        updated_task_schedule = task_schedules[0]
+        updated_task_schedule["until"] = until_str_utc
+        scheduled_task_description["schedules"][0] = updated_task_schedule
+
+        params = {"except_date": except_scheduled_date_str}
+        resp = self.client.post(
+            f"/scheduled_tasks/{schedule_task_id}/update?{urlencode(params)}",
+            json=scheduled_task_description,
+        )
+        self.assertEqual(201, resp.status_code, resp.json())
+
+        # since we have an except_date, the original schedule should not change
+        # except an additional except_date
+        resp = self.client.get(f"/scheduled_tasks/{schedule_task_id}")
+        self.assertEqual(200, resp.status_code, resp.json())
+        updated_scheduled_task = resp.json()
+        self.assertEqual(
+            updated_scheduled_task["task_request"], task_request, updated_scheduled_task
+        )
+        self.assertEqual(
+            updated_scheduled_task["schedules"], schedules, updated_scheduled_task
+        )
+        self.assertEqual(
+            len(updated_scheduled_task["except_dates"]), 1, updated_scheduled_task
+        )
+        self.assertEqual(
+            updated_scheduled_task["except_dates"][0],
+            "2124-02-12",
+            updated_scheduled_task,
+        )
+
+        # The new schedule task for that single event should just be a single index increment
+        # This scheduled task with a single event should have the
+        # - updated task description
+        # - no except dates
+        # - correct start_from date
+        # - correct until date
+        new_scheduled_task_id = schedule_task_id + 1
+        resp = self.client.get(f"/scheduled_tasks/{new_scheduled_task_id}")
+        self.assertEqual(200, resp.status_code, resp.json())
+        updated_scheduled_task = resp.json()
+        self.assertEqual(
+            updated_scheduled_task["task_request"],
+            updated_task_request,
+            updated_scheduled_task,
+        )
+        self.assertEqual(
+            len(updated_scheduled_task["except_dates"]), 0, updated_scheduled_task
+        )
+        single_event_schedules = updated_scheduled_task["schedules"]
+        self.assertEqual(len(single_event_schedules), 1, single_event_schedules)
+        self.assertEqual(
+            single_event_schedules[0]["at"],
+            updated_task_schedule["at"],
+            single_event_schedules,
+        )
+        self.assertEqual(
+            single_event_schedules[0]["period"],
+            updated_task_schedule["period"],
+            single_event_schedules,
+        )
+        self.assertIsNotNone(single_event_schedules[0]["until"])
+        # until date is saved in UTC
+        self.assertEqual(
+            single_event_schedules[0]["until"], until_str_utc, single_event_schedules[0]
+        )
+
+        # cleanup
+        self.client.delete(f"/scheduled_tasks/{schedule_task_id}")
+        self.client.delete(f"/scheduled_tasks/{new_scheduled_task_id}")
+
+    def test_edit_scheduled_task_event_after_eight_am(self):
+        scheduled_date_str = "2124-02-11T09:00:00+08:00"
+        task_request = {
+            "category": "test_category",
+            "description": "test_description",
+        }
+        task_schedules = [
+            {
+                "period": "day",
+                "start_from": scheduled_date_str,
+                "at": "09:00",
+            }
+        ]
+
+        scheduled_task_description = {
+            "task_request": task_request,
+            "schedules": task_schedules,
+        }
+        resp = self.client.post("/scheduled_tasks", json=scheduled_task_description)
+        self.assertEqual(201, resp.status_code, resp.json())
+        scheduled_task = resp.json()
+        self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
+        schedule_task_id = scheduled_task["id"]
+        schedules = scheduled_task["schedules"]
+
+        # update task description, with except date on 14th GMT+8
+        except_scheduled_date_str = "2124-02-14T09:00:00+08:00"
+        updated_task_request = {
+            "category": "test_category_updated",
+            "description": "test_description_updated",
+        }
+        scheduled_task_description["task_request"] = updated_task_request
+
+        # this will be accompanied by an until date of 23:59 14th GMT+8, which
+        # will be saved as 15:59 14th UTC
+        # FIXME this should come in as client dashboard's time zone
+        until_str_utc = "2124-02-14T15:59:59+00:00"
+        updated_task_schedule = task_schedules[0]
+        updated_task_schedule["until"] = until_str_utc
+        scheduled_task_description["schedules"][0] = updated_task_schedule
+
+        params = {"except_date": except_scheduled_date_str}
+        resp = self.client.post(
+            f"/scheduled_tasks/{schedule_task_id}/update?{urlencode(params)}",
+            json=scheduled_task_description,
+        )
+        self.assertEqual(201, resp.status_code, resp.json())
+
+        # since we have an except_date, the original schedule should not change
+        # except an additional except_date
+        resp = self.client.get(f"/scheduled_tasks/{schedule_task_id}")
+        self.assertEqual(200, resp.status_code, resp.json())
+        updated_scheduled_task = resp.json()
+        self.assertEqual(
+            updated_scheduled_task["task_request"], task_request, updated_scheduled_task
+        )
+        self.assertEqual(
+            updated_scheduled_task["schedules"], schedules, updated_scheduled_task
+        )
+        self.assertEqual(
+            len(updated_scheduled_task["except_dates"]), 1, updated_scheduled_task
+        )
+        self.assertEqual(
+            updated_scheduled_task["except_dates"][0],
+            "2124-02-14",
+            updated_scheduled_task,
+        )
+
+        # The new schedule task for that single event should just be a single index increment
+        # This scheduled task with a single event should have the
+        # - updated task description
+        # - no except dates
+        # - correct start_from date
+        # - correct until date in UTC
+        new_scheduled_task_id = schedule_task_id + 1
+        resp = self.client.get(f"/scheduled_tasks/{new_scheduled_task_id}")
+        self.assertEqual(200, resp.status_code, resp.json())
+        updated_scheduled_task = resp.json()
+        self.assertEqual(
+            updated_scheduled_task["task_request"],
+            updated_task_request,
+            updated_scheduled_task,
+        )
+        self.assertEqual(
+            len(updated_scheduled_task["except_dates"]), 0, updated_scheduled_task
+        )
+        single_event_schedules = updated_scheduled_task["schedules"]
+        self.assertEqual(len(single_event_schedules), 1, single_event_schedules)
+        self.assertEqual(
+            single_event_schedules[0]["at"],
+            updated_task_schedule["at"],
+            single_event_schedules,
+        )
+        self.assertEqual(
+            single_event_schedules[0]["period"],
+            updated_task_schedule["period"],
+            single_event_schedules,
+        )
+        self.assertIsNotNone(single_event_schedules[0]["until"])
+        # until date is saved in UTC
+        self.assertEqual(
+            single_event_schedules[0]["until"], until_str_utc, single_event_schedules[0]
+        )
+
+        # cleanup
+        self.client.delete(f"/scheduled_tasks/{schedule_task_id}")
+        self.client.delete(f"/scheduled_tasks/{new_scheduled_task_id}")
+
+    def test_edit_scheduled_task_event_before_eight_am(self):
+        scheduled_date_str = "2124-02-16T07:00:00+08:00"
+        task_request = {
+            "category": "test_category",
+            "description": "test_description",
+        }
+        task_schedules = [
+            {
+                "period": "day",
+                "start_from": scheduled_date_str,
+                "at": "07:00",
+            }
+        ]
+
+        scheduled_task_description = {
+            "task_request": task_request,
+            "schedules": task_schedules,
+        }
+        resp = self.client.post("/scheduled_tasks", json=scheduled_task_description)
+        self.assertEqual(201, resp.status_code, resp.json())
+        scheduled_task = resp.json()
+        self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
+        schedule_task_id = scheduled_task["id"]
+        schedules = scheduled_task["schedules"]
+
+        # update task description, with except date on 18th GMT+8
+        except_scheduled_date_str = "2124-02-18T07:00:00+08:00"
+        updated_task_request = {
+            "category": "test_category_updated",
+            "description": "test_description_updated",
+        }
+        scheduled_task_description["task_request"] = updated_task_request
+
+        # this will be accompanied by an until date of 23:59 18th GMT+8, which
+        # will be saved as 15:59 18th UTC
+        # FIXME this should come in as client dashboard's time zone
+        until_str_utc = "2124-02-18T15:59:59+00:00"
+        updated_task_schedule = task_schedules[0]
+        updated_task_schedule["until"] = until_str_utc
+        scheduled_task_description["schedules"][0] = updated_task_schedule
+
+        params = {"except_date": except_scheduled_date_str}
+        resp = self.client.post(
+            f"/scheduled_tasks/{schedule_task_id}/update?{urlencode(params)}",
+            json=scheduled_task_description,
+        )
+        self.assertEqual(201, resp.status_code, resp.json())
+
+        # since we have an except_date, the original schedule should not change
+        # except an additional except_date
+        resp = self.client.get(f"/scheduled_tasks/{schedule_task_id}")
+        self.assertEqual(200, resp.status_code, resp.json())
+        updated_scheduled_task = resp.json()
+        self.assertEqual(
+            updated_scheduled_task["task_request"], task_request, updated_scheduled_task
+        )
+        self.assertEqual(
+            updated_scheduled_task["schedules"], schedules, updated_scheduled_task
+        )
+        self.assertEqual(
+            len(updated_scheduled_task["except_dates"]), 1, updated_scheduled_task
+        )
+        self.assertEqual(
+            updated_scheduled_task["except_dates"][0],
+            "2124-02-18",
+            updated_scheduled_task,
+        )
+
+        # The new schedule task for that single event should just be a single index increment
+        # This scheduled task with a single event should have the
+        # - updated task description
+        # - no except dates
+        # - correct start_from date
+        # - correct until date in UTC
+        new_scheduled_task_id = schedule_task_id + 1
+        resp = self.client.get(f"/scheduled_tasks/{new_scheduled_task_id}")
+        self.assertEqual(200, resp.status_code, resp.json())
+        updated_scheduled_task = resp.json()
+        self.assertEqual(
+            updated_scheduled_task["task_request"],
+            updated_task_request,
+            updated_scheduled_task,
+        )
+        self.assertEqual(
+            len(updated_scheduled_task["except_dates"]), 0, updated_scheduled_task
+        )
+        single_event_schedules = updated_scheduled_task["schedules"]
+        self.assertEqual(len(single_event_schedules), 1, single_event_schedules)
+        self.assertEqual(
+            single_event_schedules[0]["at"],
+            updated_task_schedule["at"],
+            single_event_schedules,
+        )
+        self.assertEqual(
+            single_event_schedules[0]["period"],
+            updated_task_schedule["period"],
+            single_event_schedules,
+        )
+        self.assertIsNotNone(single_event_schedules[0]["until"])
+        # until date is saved in UTC
+        self.assertEqual(
+            single_event_schedules[0]["until"], until_str_utc, single_event_schedules[0]
+        )
+
+        # cleanup
+        self.client.delete(f"/scheduled_tasks/{schedule_task_id}")
+        self.client.delete(f"/scheduled_tasks/{new_scheduled_task_id}")
+
+    def test_edit_scheduled_task_event_at_local_midnight(self):
+        scheduled_date_str = "2124-02-16T00:00:00+08:00"
+        task_request = {
+            "category": "test_category",
+            "description": "test_description",
+        }
+        task_schedules = [
+            {
+                "period": "day",
+                "start_from": scheduled_date_str,
+                "at": "00:00",
+            }
+        ]
+
+        scheduled_task_description = {
+            "task_request": task_request,
+            "schedules": task_schedules,
+        }
+        resp = self.client.post("/scheduled_tasks", json=scheduled_task_description)
+        self.assertEqual(201, resp.status_code, resp.json())
+        scheduled_task = resp.json()
+        self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
+        schedule_task_id = scheduled_task["id"]
+        schedules = scheduled_task["schedules"]
+
+        # update task description, with except date on 18th GMT+8
+        except_scheduled_date_str = "2124-02-18T00:00:00+08:00"
+        updated_task_request = {
+            "category": "test_category_updated",
+            "description": "test_description_updated",
+        }
+        scheduled_task_description["task_request"] = updated_task_request
+
+        # this will be accompanied by an until date of 23:59 18th GMT+8, which
+        # will be saved as 15:59 18th UTC
+        # FIXME this should come in as client dashboard's time zone
+        until_str_utc = "2124-02-18T15:59:59+00:00"
+        updated_task_schedule = task_schedules[0]
+        updated_task_schedule["until"] = until_str_utc
+        scheduled_task_description["schedules"][0] = updated_task_schedule
+
+        params = {"except_date": except_scheduled_date_str}
+        resp = self.client.post(
+            f"/scheduled_tasks/{schedule_task_id}/update?{urlencode(params)}",
+            json=scheduled_task_description,
+        )
+        self.assertEqual(201, resp.status_code, resp.json())
+
+        # since we have an except_date, the original schedule should not change
+        # except an additional except_date
+        resp = self.client.get(f"/scheduled_tasks/{schedule_task_id}")
+        self.assertEqual(200, resp.status_code, resp.json())
+        updated_scheduled_task = resp.json()
+        self.assertEqual(
+            updated_scheduled_task["task_request"], task_request, updated_scheduled_task
+        )
+        self.assertEqual(
+            updated_scheduled_task["schedules"], schedules, updated_scheduled_task
+        )
+        self.assertEqual(
+            len(updated_scheduled_task["except_dates"]), 1, updated_scheduled_task
+        )
+        self.assertEqual(
+            updated_scheduled_task["except_dates"][0],
+            "2124-02-18",
+            updated_scheduled_task,
+        )
+
+        # The new schedule task for that single event should just be a single index increment
+        # This scheduled task with a single event should have the
+        # - updated task description
+        # - no except dates
+        # - correct start_from date
+        # - correct until date in UTC
+        new_scheduled_task_id = schedule_task_id + 1
+        resp = self.client.get(f"/scheduled_tasks/{new_scheduled_task_id}")
+        self.assertEqual(200, resp.status_code, resp.json())
+        updated_scheduled_task = resp.json()
+        self.assertEqual(
+            updated_scheduled_task["task_request"],
+            updated_task_request,
+            updated_scheduled_task,
+        )
+        self.assertEqual(
+            len(updated_scheduled_task["except_dates"]), 0, updated_scheduled_task
+        )
+        single_event_schedules = updated_scheduled_task["schedules"]
+        self.assertEqual(len(single_event_schedules), 1, single_event_schedules)
+        self.assertEqual(
+            single_event_schedules[0]["at"],
+            updated_task_schedule["at"],
+            single_event_schedules,
+        )
+        self.assertEqual(
+            single_event_schedules[0]["period"],
+            updated_task_schedule["period"],
+            single_event_schedules,
+        )
+        self.assertIsNotNone(single_event_schedules[0]["until"])
+        # until date is saved in UTC
+        self.assertEqual(
+            single_event_schedules[0]["until"], until_str_utc, single_event_schedules[0]
+        )
+
+        # cleanup
+        self.client.delete(f"/scheduled_tasks/{schedule_task_id}")
+        self.client.delete(f"/scheduled_tasks/{new_scheduled_task_id}")
+
+    def test_edit_scheduled_task_after_edit_scheduled_task_event(self):
+        scheduled_date_str = "2124-02-11T09:00:00+08:00"
+        task_request = {
+            "category": "test_category",
+            "description": "test_description",
+        }
+        task_schedules = [
+            {
+                "period": "day",
+                "start_from": scheduled_date_str,
+                "at": "09:00",
+            }
+        ]
+
+        scheduled_task_description = {
+            "task_request": task_request,
+            "schedules": task_schedules,
+        }
+        resp = self.client.post("/scheduled_tasks", json=scheduled_task_description)
+        self.assertEqual(201, resp.status_code, resp.json())
+        scheduled_task = resp.json()
+        self.assertEqual(len(scheduled_task["schedules"]), 1, scheduled_task)
+        schedule_task_id = scheduled_task["id"]
+        schedules = scheduled_task["schedules"]
+
+        # update task description, with except date on 14th GMT+8
+        except_scheduled_date_str = "2124-02-14T09:00:00+08:00"
+        updated_task_request = {
+            "category": "test_category_updated",
+            "description": "test_description_updated",
+        }
+        scheduled_task_description["task_request"] = updated_task_request
+
+        # this will be accompanied by an until date of 23:59 14th GMT+8, which
+        # will be saved as 15:59 14th UTC
+        # FIXME this should come in as client dashboard's time zone
+        until_str_utc = "2124-02-14T15:59:59+00:00"
+        updated_task_schedule = task_schedules[0]
+        updated_task_schedule["until"] = until_str_utc
+        scheduled_task_description["schedules"][0] = updated_task_schedule
+
+        params = {"except_date": except_scheduled_date_str}
+        resp = self.client.post(
+            f"/scheduled_tasks/{schedule_task_id}/update?{urlencode(params)}",
+            json=scheduled_task_description,
+        )
+        self.assertEqual(201, resp.status_code, resp.json())
+
+        # since we have an except_date, the original schedule should not change
+        # except an additional except_date
+        resp = self.client.get(f"/scheduled_tasks/{schedule_task_id}")
+        self.assertEqual(200, resp.status_code, resp.json())
+        updated_scheduled_task = resp.json()
+        self.assertEqual(
+            updated_scheduled_task["task_request"], task_request, updated_scheduled_task
+        )
+        self.assertEqual(
+            updated_scheduled_task["schedules"], schedules, updated_scheduled_task
+        )
+        self.assertEqual(
+            len(updated_scheduled_task["except_dates"]), 1, updated_scheduled_task
+        )
+        self.assertEqual(
+            updated_scheduled_task["except_dates"][0],
+            "2124-02-14",
+            updated_scheduled_task,
+        )
+
+        # The new schedule task for that single event should just be a single index increment
+        # This scheduled task with a single event should have the
+        # - updated task description
+        # - no except dates
+        # - correct start_from date
+        # - correct until date in UTC
+        new_scheduled_task_id = schedule_task_id + 1
+        resp = self.client.get(f"/scheduled_tasks/{new_scheduled_task_id}")
+        self.assertEqual(200, resp.status_code, resp.json())
+        updated_scheduled_task = resp.json()
+        self.assertEqual(
+            updated_scheduled_task["task_request"],
+            updated_task_request,
+            updated_scheduled_task,
+        )
+        self.assertEqual(
+            len(updated_scheduled_task["except_dates"]), 0, updated_scheduled_task
+        )
+        single_event_schedules = updated_scheduled_task["schedules"]
+        self.assertEqual(len(single_event_schedules), 1, single_event_schedules)
+        self.assertEqual(
+            single_event_schedules[0]["at"],
+            updated_task_schedule["at"],
+            single_event_schedules,
+        )
+        self.assertEqual(
+            single_event_schedules[0]["period"],
+            updated_task_schedule["period"],
+            single_event_schedules,
+        )
+        self.assertIsNotNone(single_event_schedules[0]["until"])
+        # until date is saved in UTC
+        self.assertEqual(
+            single_event_schedules[0]["until"], until_str_utc, single_event_schedules[0]
+        )
+
+        # update original task schedules in GMT+8
+        updated_scheduled_date_str = "2124-02-11T14:00:00+08:00"
+        updated_task_schedules = [
+            {
+                "period": "day",
+                "start_from": updated_scheduled_date_str,
+                "at": "14:00",
+            }
+        ]
+        scheduled_task_description["schedules"] = updated_task_schedules
+        resp = self.client.post(
+            f"/scheduled_tasks/{schedule_task_id}/update",
+            json=scheduled_task_description,
+        )
+        self.assertEqual(201, resp.status_code, resp.json())
+
+        # compare updated scheduled task schedules
+        resp = self.client.get(f"/scheduled_tasks/{schedule_task_id}")
+        self.assertEqual(200, resp.status_code, resp.json())
+        updated_scheduled_task = resp.json()
+        self.assertEqual(
+            updated_scheduled_task["task_request"],
+            updated_task_request,
+            updated_scheduled_task,
+        )
+        self.assertNotEqual(
+            updated_scheduled_task["schedules"], schedules, updated_scheduled_task
+        )
+        self.assertEqual(
+            len(updated_scheduled_task["schedules"]), 1, updated_scheduled_task
+        )
+        updated_schedule = updated_scheduled_task["schedules"][0]
+        # when editing an entire schedule, the exempted dates are ignored, so it will be empty
+        self.assertEqual(
+            len(updated_scheduled_task["except_dates"]), 0, updated_scheduled_task
+        )
+
+        # FIXME Start from dates are saved as UTC
+        updated_scheduled_date_utc_str = "2124-02-11T06:00:00+00:00"
+        self.assertEqual(
+            updated_schedule["start_from"],
+            updated_scheduled_date_utc_str,
+            updated_schedule,
+        )
+        self.assertEqual(updated_schedule["at"], "14:00", updated_schedule)
+
+        # cleanup
+        self.client.delete(f"/scheduled_tasks/{schedule_task_id}")
+        self.client.delete(f"/scheduled_tasks/{new_scheduled_task_id}")

--- a/packages/dashboard/src/components/tasks/task-schedule.tsx
+++ b/packages/dashboard/src/components/tasks/task-schedule.tsx
@@ -202,7 +202,10 @@ export const TaskSchedule = () => {
 
       let exceptDate: string | undefined = undefined;
       if (eventScope === EventScopes.CURRENT) {
-        exceptDate = exceptDateRef.current.toISOString();
+        exceptDate = toISOStringWithTimezone(exceptDateRef.current);
+        console.debug(`Editing schedule id ${currentScheduleTask.id}, event date ${exceptDate}`);
+      } else {
+        console.debug(`Editing schedule id ${currentScheduleTask.id}`);
       }
 
       await Promise.all(


### PR DESCRIPTION
## What's new

Similar to https://github.com/open-rmf/rmf-web/pull/896, but for schedule editing

* Convert schedule update exempted date to server timezone before appending to except
* make dashboard edit except date have time zone information
* tests

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test