### PR TITLE
Hammer/log user actions

### DIFF
--- a/packages/api-server/api_server/routes/delivery_alerts.py
+++ b/packages/api-server/api_server/routes/delivery_alerts.py
@@ -1,7 +1,11 @@
+from fastapi import Depends
 from rx import operators as rxops
 
+from api_server.authenticator import user_dep
 from api_server.fast_io import FastIORouter, SubscriptionRequest
 from api_server.gateway import rmf_gateway
+from api_server.logger import logger
+from api_server.models import User
 from api_server.models.delivery_alerts import (
     DeliveryAlert,
     action_to_msg,
@@ -26,6 +30,7 @@ async def respond_to_delivery_alert(
     task_id: str,
     action: DeliveryAlert.Action,
     message: str,
+    user: User = Depends(user_dep),
 ):
     delivery_alert = DeliveryAlert(
         id=delivery_alert_id,
@@ -35,6 +40,8 @@ async def respond_to_delivery_alert(
         task_id=task_id,
         message=message,
     )
+    logger.info(f"Delivery alert responded by {user.username}")
+    logger.info(delivery_alert)
     rmf_gateway().respond_to_delivery_alert(
         alert_id=delivery_alert.id,
         category=category_to_msg(delivery_alert.category),

--- a/packages/api-server/api_server/routes/tasks/tasks.py
+++ b/packages/api-server/api_server/routes/tasks/tasks.py
@@ -186,6 +186,7 @@ async def post_activity_discovery(
 async def post_cancel_task(
     request: mdl.CancelTaskRequest = Body(...),
 ):
+    logger.info(request)
     return RawJSONResponse(await tasks_service().call(request.json(exclude_none=True)))
 
 

--- a/packages/dashboard/src/components/tasks/task-cancellation.tsx
+++ b/packages/dashboard/src/components/tasks/task-cancellation.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { AppControllerContext } from '../app-contexts';
 import { AppEvents } from '../app-events';
 import { RmfAppContext } from '../rmf-app';
-import { UserProfileContext } from 'rmf-auth';
+import { UserProfile, UserProfileContext } from 'rmf-auth';
 import { Enforcer } from '../permissions';
 import { makeStyles, createStyles } from '@mui/styles';
 import { ConfirmationDialog } from 'react-components';
@@ -32,7 +32,7 @@ export function TaskCancelButton({
   const classes = useStyles();
   const rmf = React.useContext(RmfAppContext);
   const appController = React.useContext(AppControllerContext);
-  const profile = React.useContext(UserProfileContext);
+  const profile: UserProfile | null = React.useContext(UserProfileContext);
 
   const [taskState, setTaskState] = React.useState<TaskState | null>(null);
   const [openConfirmDialog, setOpenConfirmDialog] = React.useState(false);
@@ -66,6 +66,7 @@ export function TaskCancelButton({
       await rmf.tasksApi?.postCancelTaskTasksCancelTaskPost({
         type: 'cancel_task_request',
         task_id: taskState.booking.id,
+        labels: profile ? [profile.user.username] : undefined,
       });
       appController.showAlert('success', 'Task cancellation requested');
       AppEvents.taskSelect.next(null);
@@ -74,7 +75,7 @@ export function TaskCancelButton({
       appController.showAlert('error', `Failed to cancel task: ${(e as Error).message}`);
     }
     setOpenConfirmDialog(false);
-  }, [appController, taskState, rmf]);
+  }, [appController, taskState, rmf, profile]);
 
   return (
     <>


### PR DESCRIPTION
## What's new

* Add username in task cancellation request label
* Log task cancellation request
* Log delivery alert responses and the user who responded

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test