### PR TITLE
Logging for schedule creation, simplify alert ack

### DIFF
--- a/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
+++ b/packages/api-server/api_server/routes/tasks/scheduled_tasks.py
@@ -149,7 +149,11 @@ async def post_scheduled_task(
             await ttm.ScheduledTaskSchedule.bulk_create(schedules)
 
             await schedule_task(scheduled_task, task_repo)
-        return await ttm.ScheduledTaskPydantic.from_tortoise_orm(scheduled_task)
+        scheduled_task_model = await ttm.ScheduledTaskPydantic.from_tortoise_orm(
+            scheduled_task
+        )
+        logger.info(f"New scheduled task:\n{scheduled_task_model}")
+        return scheduled_task_model
     except schedule.ScheduleError as e:
         raise HTTPException(422, str(e)) from e
 

--- a/packages/dashboard/src/components/tasks/task-alert.tsx
+++ b/packages/dashboard/src/components/tasks/task-alert.tsx
@@ -297,6 +297,7 @@ export function TaskAlertDialog({ alert, removeAlert }: TaskAlertDialogProps): J
             showAlertMessage += ` ${Math.round(ackSecondsAgo)}s ago`;
           }
           showAlert('success', showAlertMessage);
+          removeAlert();
         } else {
           throw new Error(`Failed to acknowledge alert ID ${idToAcknowledge}`);
         }


### PR DESCRIPTION
## What's new

* Logs new scheduled task
* Closes acknowledged task alert after clicking ack (Before this, the alert dialog would only be updated with ack information, so 2 clicks + some delay were needed to fully ack and close a task alert dialog)

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test