### PR TITLE
Hammer/decommission

### DIFF
--- a/packages/api-client/lib/openapi/api.ts
+++ b/packages/api-client/lib/openapi/api.ts
@@ -6728,6 +6728,74 @@ export class DoorsApi extends BaseAPI {
 export const FleetsApiAxiosParamCreator = function (configuration?: Configuration) {
   return {
     /**
+     *
+     * @summary Decommission Robot
+     * @param {string} name
+     * @param {string} robotName
+     * @param {string} id
+     * @param {Array<string>} requestBody
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    decommissionRobotFleetsNameDecommissionPost: async (
+      name: string,
+      robotName: string,
+      id: string,
+      requestBody: Array<string>,
+      options: AxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'name' is not null or undefined
+      assertParamExists('decommissionRobotFleetsNameDecommissionPost', 'name', name);
+      // verify required parameter 'robotName' is not null or undefined
+      assertParamExists('decommissionRobotFleetsNameDecommissionPost', 'robotName', robotName);
+      // verify required parameter 'id' is not null or undefined
+      assertParamExists('decommissionRobotFleetsNameDecommissionPost', 'id', id);
+      // verify required parameter 'requestBody' is not null or undefined
+      assertParamExists('decommissionRobotFleetsNameDecommissionPost', 'requestBody', requestBody);
+      const localVarPath = `/fleets/{name}/decommission`.replace(
+        `{${'name'}}`,
+        encodeURIComponent(String(name)),
+      );
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
+
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      if (robotName !== undefined) {
+        localVarQueryParameter['robot_name'] = robotName;
+      }
+
+      if (id !== undefined) {
+        localVarQueryParameter['id'] = id;
+      }
+
+      localVarHeaderParameter['Content-Type'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        requestBody,
+        localVarRequestOptions,
+        configuration,
+      );
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
      * Available in socket.io
      * @summary Get Fleet Log
      * @param {string} name
@@ -6847,6 +6915,74 @@ export const FleetsApiAxiosParamCreator = function (configuration?: Configuratio
         options: localVarRequestOptions,
       };
     },
+    /**
+     *
+     * @summary Reinstate Robot
+     * @param {string} name
+     * @param {string} robotName
+     * @param {string} id
+     * @param {Array<string>} requestBody
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    reinstateRobotFleetsNameReinstatePost: async (
+      name: string,
+      robotName: string,
+      id: string,
+      requestBody: Array<string>,
+      options: AxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'name' is not null or undefined
+      assertParamExists('reinstateRobotFleetsNameReinstatePost', 'name', name);
+      // verify required parameter 'robotName' is not null or undefined
+      assertParamExists('reinstateRobotFleetsNameReinstatePost', 'robotName', robotName);
+      // verify required parameter 'id' is not null or undefined
+      assertParamExists('reinstateRobotFleetsNameReinstatePost', 'id', id);
+      // verify required parameter 'requestBody' is not null or undefined
+      assertParamExists('reinstateRobotFleetsNameReinstatePost', 'requestBody', requestBody);
+      const localVarPath = `/fleets/{name}/reinstate`.replace(
+        `{${'name'}}`,
+        encodeURIComponent(String(name)),
+      );
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
+
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      if (robotName !== undefined) {
+        localVarQueryParameter['robot_name'] = robotName;
+      }
+
+      if (id !== undefined) {
+        localVarQueryParameter['id'] = id;
+      }
+
+      localVarHeaderParameter['Content-Type'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        requestBody,
+        localVarRequestOptions,
+        configuration,
+      );
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
   };
 };
 
@@ -6857,6 +6993,33 @@ export const FleetsApiAxiosParamCreator = function (configuration?: Configuratio
 export const FleetsApiFp = function (configuration?: Configuration) {
   const localVarAxiosParamCreator = FleetsApiAxiosParamCreator(configuration);
   return {
+    /**
+     *
+     * @summary Decommission Robot
+     * @param {string} name
+     * @param {string} robotName
+     * @param {string} id
+     * @param {Array<string>} requestBody
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async decommissionRobotFleetsNameDecommissionPost(
+      name: string,
+      robotName: string,
+      id: string,
+      requestBody: Array<string>,
+      options?: AxiosRequestConfig,
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.decommissionRobotFleetsNameDecommissionPost(
+          name,
+          robotName,
+          id,
+          requestBody,
+          options,
+        );
+      return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+    },
     /**
      * Available in socket.io
      * @summary Get Fleet Log
@@ -6921,6 +7084,33 @@ export const FleetsApiFp = function (configuration?: Configuration) {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getFleetsFleetsGet(options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
     },
+    /**
+     *
+     * @summary Reinstate Robot
+     * @param {string} name
+     * @param {string} robotName
+     * @param {string} id
+     * @param {Array<string>} requestBody
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async reinstateRobotFleetsNameReinstatePost(
+      name: string,
+      robotName: string,
+      id: string,
+      requestBody: Array<string>,
+      options?: AxiosRequestConfig,
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.reinstateRobotFleetsNameReinstatePost(
+          name,
+          robotName,
+          id,
+          requestBody,
+          options,
+        );
+      return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+    },
   };
 };
 
@@ -6935,6 +7125,27 @@ export const FleetsApiFactory = function (
 ) {
   const localVarFp = FleetsApiFp(configuration);
   return {
+    /**
+     *
+     * @summary Decommission Robot
+     * @param {string} name
+     * @param {string} robotName
+     * @param {string} id
+     * @param {Array<string>} requestBody
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    decommissionRobotFleetsNameDecommissionPost(
+      name: string,
+      robotName: string,
+      id: string,
+      requestBody: Array<string>,
+      options?: any,
+    ): AxiosPromise<any> {
+      return localVarFp
+        .decommissionRobotFleetsNameDecommissionPost(name, robotName, id, requestBody, options)
+        .then((request) => request(axios, basePath));
+    },
     /**
      * Available in socket.io
      * @summary Get Fleet Log
@@ -6978,6 +7189,27 @@ export const FleetsApiFactory = function (
     ): AxiosPromise<Array<ApiServerModelsRmfApiFleetStateFleetState>> {
       return localVarFp.getFleetsFleetsGet(options).then((request) => request(axios, basePath));
     },
+    /**
+     *
+     * @summary Reinstate Robot
+     * @param {string} name
+     * @param {string} robotName
+     * @param {string} id
+     * @param {Array<string>} requestBody
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    reinstateRobotFleetsNameReinstatePost(
+      name: string,
+      robotName: string,
+      id: string,
+      requestBody: Array<string>,
+      options?: any,
+    ): AxiosPromise<any> {
+      return localVarFp
+        .reinstateRobotFleetsNameReinstatePost(name, robotName, id, requestBody, options)
+        .then((request) => request(axios, basePath));
+    },
   };
 };
 
@@ -6988,6 +7220,29 @@ export const FleetsApiFactory = function (
  * @extends {BaseAPI}
  */
 export class FleetsApi extends BaseAPI {
+  /**
+   *
+   * @summary Decommission Robot
+   * @param {string} name
+   * @param {string} robotName
+   * @param {string} id
+   * @param {Array<string>} requestBody
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof FleetsApi
+   */
+  public decommissionRobotFleetsNameDecommissionPost(
+    name: string,
+    robotName: string,
+    id: string,
+    requestBody: Array<string>,
+    options?: AxiosRequestConfig,
+  ) {
+    return FleetsApiFp(this.configuration)
+      .decommissionRobotFleetsNameDecommissionPost(name, robotName, id, requestBody, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
   /**
    * Available in socket.io
    * @summary Get Fleet Log
@@ -7027,6 +7282,29 @@ export class FleetsApi extends BaseAPI {
   public getFleetsFleetsGet(options?: AxiosRequestConfig) {
     return FleetsApiFp(this.configuration)
       .getFleetsFleetsGet(options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   *
+   * @summary Reinstate Robot
+   * @param {string} name
+   * @param {string} robotName
+   * @param {string} id
+   * @param {Array<string>} requestBody
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof FleetsApi
+   */
+  public reinstateRobotFleetsNameReinstatePost(
+    name: string,
+    robotName: string,
+    id: string,
+    requestBody: Array<string>,
+    options?: AxiosRequestConfig,
+  ) {
+    return FleetsApiFp(this.configuration)
+      .reinstateRobotFleetsNameReinstatePost(name, robotName, id, requestBody, options)
       .then((request) => request(this.axios, this.basePath));
   }
 }

--- a/packages/api-client/lib/openapi/api.ts
+++ b/packages/api-client/lib/openapi/api.ts
@@ -6917,7 +6917,7 @@ export const FleetsApiAxiosParamCreator = function (configuration?: Configuratio
     },
     /**
      *
-     * @summary Reinstate Robot
+     * @summary Recommission Robot
      * @param {string} name
      * @param {string} robotName
      * @param {string} id
@@ -6925,7 +6925,7 @@ export const FleetsApiAxiosParamCreator = function (configuration?: Configuratio
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    reinstateRobotFleetsNameReinstatePost: async (
+    recommissionRobotFleetsNameRecommissionPost: async (
       name: string,
       robotName: string,
       id: string,
@@ -6933,14 +6933,14 @@ export const FleetsApiAxiosParamCreator = function (configuration?: Configuratio
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       // verify required parameter 'name' is not null or undefined
-      assertParamExists('reinstateRobotFleetsNameReinstatePost', 'name', name);
+      assertParamExists('recommissionRobotFleetsNameRecommissionPost', 'name', name);
       // verify required parameter 'robotName' is not null or undefined
-      assertParamExists('reinstateRobotFleetsNameReinstatePost', 'robotName', robotName);
+      assertParamExists('recommissionRobotFleetsNameRecommissionPost', 'robotName', robotName);
       // verify required parameter 'id' is not null or undefined
-      assertParamExists('reinstateRobotFleetsNameReinstatePost', 'id', id);
+      assertParamExists('recommissionRobotFleetsNameRecommissionPost', 'id', id);
       // verify required parameter 'requestBody' is not null or undefined
-      assertParamExists('reinstateRobotFleetsNameReinstatePost', 'requestBody', requestBody);
-      const localVarPath = `/fleets/{name}/reinstate`.replace(
+      assertParamExists('recommissionRobotFleetsNameRecommissionPost', 'requestBody', requestBody);
+      const localVarPath = `/fleets/{name}/recommission`.replace(
         `{${'name'}}`,
         encodeURIComponent(String(name)),
       );
@@ -7086,7 +7086,7 @@ export const FleetsApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @summary Reinstate Robot
+     * @summary Recommission Robot
      * @param {string} name
      * @param {string} robotName
      * @param {string} id
@@ -7094,7 +7094,7 @@ export const FleetsApiFp = function (configuration?: Configuration) {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    async reinstateRobotFleetsNameReinstatePost(
+    async recommissionRobotFleetsNameRecommissionPost(
       name: string,
       robotName: string,
       id: string,
@@ -7102,7 +7102,7 @@ export const FleetsApiFp = function (configuration?: Configuration) {
       options?: AxiosRequestConfig,
     ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
       const localVarAxiosArgs =
-        await localVarAxiosParamCreator.reinstateRobotFleetsNameReinstatePost(
+        await localVarAxiosParamCreator.recommissionRobotFleetsNameRecommissionPost(
           name,
           robotName,
           id,
@@ -7191,7 +7191,7 @@ export const FleetsApiFactory = function (
     },
     /**
      *
-     * @summary Reinstate Robot
+     * @summary Recommission Robot
      * @param {string} name
      * @param {string} robotName
      * @param {string} id
@@ -7199,7 +7199,7 @@ export const FleetsApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    reinstateRobotFleetsNameReinstatePost(
+    recommissionRobotFleetsNameRecommissionPost(
       name: string,
       robotName: string,
       id: string,
@@ -7207,7 +7207,7 @@ export const FleetsApiFactory = function (
       options?: any,
     ): AxiosPromise<any> {
       return localVarFp
-        .reinstateRobotFleetsNameReinstatePost(name, robotName, id, requestBody, options)
+        .recommissionRobotFleetsNameRecommissionPost(name, robotName, id, requestBody, options)
         .then((request) => request(axios, basePath));
     },
   };
@@ -7287,7 +7287,7 @@ export class FleetsApi extends BaseAPI {
 
   /**
    *
-   * @summary Reinstate Robot
+   * @summary Recommission Robot
    * @param {string} name
    * @param {string} robotName
    * @param {string} id
@@ -7296,7 +7296,7 @@ export class FleetsApi extends BaseAPI {
    * @throws {RequiredError}
    * @memberof FleetsApi
    */
-  public reinstateRobotFleetsNameReinstatePost(
+  public recommissionRobotFleetsNameRecommissionPost(
     name: string,
     robotName: string,
     id: string,
@@ -7304,7 +7304,7 @@ export class FleetsApi extends BaseAPI {
     options?: AxiosRequestConfig,
   ) {
     return FleetsApiFp(this.configuration)
-      .reinstateRobotFleetsNameReinstatePost(name, robotName, id, requestBody, options)
+      .recommissionRobotFleetsNameRecommissionPost(name, robotName, id, requestBody, options)
       .then((request) => request(this.axios, this.basePath));
   }
 }

--- a/packages/api-client/lib/version.ts
+++ b/packages/api-client/lib/version.ts
@@ -3,6 +3,6 @@ import { version as rmfModelVer } from 'rmf-models';
 
 export const version = {
   rmfModels: rmfModelVer,
-  rmfServer: '1403b63032764b781ef1ba349e50a9d895204bbb',
+  rmfServer: '34dddd0f57849d3f20130beb3207442035f00fad',
   openapiGenerator: '6.2.1',
 };

--- a/packages/api-client/lib/version.ts
+++ b/packages/api-client/lib/version.ts
@@ -3,6 +3,6 @@ import { version as rmfModelVer } from 'rmf-models';
 
 export const version = {
   rmfModels: rmfModelVer,
-  rmfServer: '34dddd0f57849d3f20130beb3207442035f00fad',
+  rmfServer: '25278f990733e040aa02e542391dd2abf1807775',
   openapiGenerator: '6.2.1',
 };

--- a/packages/api-client/schema/index.ts
+++ b/packages/api-client/schema/index.ts
@@ -1823,6 +1823,80 @@ export default {
         },
       },
     },
+    '/fleets/{name}/decommission': {
+      post: {
+        tags: ['Fleets'],
+        summary: 'Decommission Robot',
+        operationId: 'decommission_robot_fleets__name__decommission_post',
+        parameters: [
+          { required: true, schema: { title: 'Name', type: 'string' }, name: 'name', in: 'path' },
+          {
+            required: true,
+            schema: { title: 'Robot Name', type: 'string' },
+            name: 'robot_name',
+            in: 'query',
+          },
+          { required: true, schema: { title: 'Id', type: 'string' }, name: 'id', in: 'query' },
+        ],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: { title: 'Labels', type: 'array', items: { type: 'string' } },
+            },
+          },
+          required: true,
+        },
+        responses: {
+          '200': {
+            description: 'Successful Response',
+            content: { 'application/json': { schema: {} } },
+          },
+          '422': {
+            description: 'Validation Error',
+            content: {
+              'application/json': { schema: { $ref: '#/components/schemas/HTTPValidationError' } },
+            },
+          },
+        },
+      },
+    },
+    '/fleets/{name}/reinstate': {
+      post: {
+        tags: ['Fleets'],
+        summary: 'Reinstate Robot',
+        operationId: 'reinstate_robot_fleets__name__reinstate_post',
+        parameters: [
+          { required: true, schema: { title: 'Name', type: 'string' }, name: 'name', in: 'path' },
+          {
+            required: true,
+            schema: { title: 'Robot Name', type: 'string' },
+            name: 'robot_name',
+            in: 'query',
+          },
+          { required: true, schema: { title: 'Id', type: 'string' }, name: 'id', in: 'query' },
+        ],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: { title: 'Labels', type: 'array', items: { type: 'string' } },
+            },
+          },
+          required: true,
+        },
+        responses: {
+          '200': {
+            description: 'Successful Response',
+            content: { 'application/json': { schema: {} } },
+          },
+          '422': {
+            description: 'Validation Error',
+            content: {
+              'application/json': { schema: { $ref: '#/components/schemas/HTTPValidationError' } },
+            },
+          },
+        },
+      },
+    },
     '/admin/users': {
       get: {
         tags: ['Admin'],

--- a/packages/api-client/schema/index.ts
+++ b/packages/api-client/schema/index.ts
@@ -1860,11 +1860,11 @@ export default {
         },
       },
     },
-    '/fleets/{name}/reinstate': {
+    '/fleets/{name}/recommission': {
       post: {
         tags: ['Fleets'],
-        summary: 'Reinstate Robot',
-        operationId: 'reinstate_robot_fleets__name__reinstate_post',
+        summary: 'Recommission Robot',
+        operationId: 'recommission_robot_fleets__name__recommission_post',
         parameters: [
           { required: true, schema: { title: 'Name', type: 'string' }, name: 'name', in: 'path' },
           {

--- a/packages/api-server/api_server/gateway.py
+++ b/packages/api-server/api_server/gateway.py
@@ -112,7 +112,7 @@ class RmfGateway:
 
         self._decommission_robot_request = ros_node().create_publisher(
             RmfInterruptRequest,
-            "decommission_robot",
+            "robot_decommission_request",
             rclpy.qos.QoSProfile(
                 history=rclpy.qos.HistoryPolicy.KEEP_LAST,
                 depth=10,

--- a/packages/api-server/api_server/gateway.py
+++ b/packages/api-server/api_server/gateway.py
@@ -26,6 +26,7 @@ from rmf_fleet_msgs.msg import DeliveryAlert as RmfDeliveryAlert
 from rmf_fleet_msgs.msg import DeliveryAlertAction as RmfDeliveryAlertAction
 from rmf_fleet_msgs.msg import DeliveryAlertCategory as RmfDeliveryAlertCategory
 from rmf_fleet_msgs.msg import DeliveryAlertTier as RmfDeliveryAlertTier
+from rmf_fleet_msgs.msg import InterruptRequest as RmfInterruptRequest
 from rmf_ingestor_msgs.msg import IngestorState as RmfIngestorState
 from rmf_lift_msgs.msg import LiftRequest as RmfLiftRequest
 from rmf_lift_msgs.msg import LiftState as RmfLiftState
@@ -101,6 +102,17 @@ class RmfGateway:
         self._delivery_alert_response = ros_node().create_publisher(
             RmfDeliveryAlert,
             "delivery_alert_response",
+            rclpy.qos.QoSProfile(
+                history=rclpy.qos.HistoryPolicy.KEEP_LAST,
+                depth=10,
+                reliability=rclpy.qos.ReliabilityPolicy.RELIABLE,
+                durability=rclpy.qos.DurabilityPolicy.TRANSIENT_LOCAL,
+            ),
+        )
+
+        self._decommission_robot_request = ros_node().create_publisher(
+            RmfInterruptRequest,
+            "decommission_robot",
             rclpy.qos.QoSProfile(
                 history=rclpy.qos.HistoryPolicy.KEEP_LAST,
                 depth=10,
@@ -281,6 +293,36 @@ class RmfGateway:
         msg.action = RmfDeliveryAlertAction(value=action)
         msg.message = message
         self._delivery_alert_response.publish(msg)
+
+    def decommission_robot(
+        self,
+        fleet_name: str,
+        robot_name: str,
+        id: str,
+        labels: List[str],
+    ):
+        msg = RmfInterruptRequest()
+        msg.fleet_name = fleet_name
+        msg.robot_name = robot_name
+        msg.interrupt_id = id
+        msg.labels = labels
+        msg.type = msg.TYPE_INTERRUPT
+        self._decommission_robot_request.publish(msg)
+
+    def reinstate_robot(
+        self,
+        fleet_name: str,
+        robot_name: str,
+        id: str,
+        labels: List[str],
+    ):
+        msg = RmfInterruptRequest()
+        msg.fleet_name = fleet_name
+        msg.robot_name = robot_name
+        msg.interrupt_id = id
+        msg.labels = labels
+        msg.type = msg.TYPE_RESUME
+        self._decommission_robot_request.publish(msg)
 
 
 _rmf_gateway: RmfGateway

--- a/packages/api-server/api_server/routes/fleets.py
+++ b/packages/api-server/api_server/routes/fleets.py
@@ -86,8 +86,8 @@ async def decommission_robot(
     )
 
 
-@router.post("/{name}/reinstate")
-async def reinstate_robot(
+@router.post("/{name}/recommission")
+async def recommission_robot(
     name: str,
     robot_name: str,
     id: str,
@@ -95,7 +95,7 @@ async def reinstate_robot(
     user: User = Depends(user_dep),
 ):
     # TODO: check if this robot exists
-    logger.info(f"Reinstating {robot_name} of {name} called by ${user.username}")
+    logger.info(f"Recommissioning {robot_name} of {name} called by ${user.username}")
     rmf_gateway().reinstate_robot(
         fleet_name=name, robot_name=robot_name, id=id, labels=labels
     )

--- a/packages/dashboard/src/components/app-events.ts
+++ b/packages/dashboard/src/components/app-events.ts
@@ -17,6 +17,7 @@ export const AppEvents = {
   ingestorSelect: new Subject<Ingestor | null>(),
   robotSelect: new Subject<[fleetName: string, robotName: string] | null>(),
   taskSelect: new Subject<TaskState | null>(),
+  refreshRobotApp: new Subject<void>(),
   refreshTaskApp: new Subject<void>(),
   refreshFavoriteTasks: new Subject<void>(),
   refreshTaskSchedule: new Subject<void>(),

--- a/packages/dashboard/src/components/robots/robot-decommission.tsx
+++ b/packages/dashboard/src/components/robots/robot-decommission.tsx
@@ -1,0 +1,159 @@
+import { Button, ButtonProps, Theme, Tooltip, Typography } from '@mui/material';
+import { RobotState, Status2 } from 'api-client';
+import React from 'react';
+import { AppControllerContext } from '../app-contexts';
+import { RmfAppContext } from '../rmf-app';
+import { UserProfile, UserProfileContext } from 'rmf-auth';
+import { makeStyles, createStyles } from '@mui/styles';
+import { ConfirmationDialog } from 'react-components';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    enableHover: {
+      '&.Mui-disabled': {
+        pointerEvents: 'auto',
+      },
+    },
+  }),
+);
+
+export interface RobotDecommissionButtonProp extends ButtonProps {
+  fleet: string;
+  robotState: RobotState | null;
+}
+
+export function RobotDecommissionButton({
+  fleet,
+  robotState,
+  ...otherProps
+}: RobotDecommissionButtonProp): JSX.Element {
+  const classes = useStyles();
+  const rmf = React.useContext(RmfAppContext);
+  const appController = React.useContext(AppControllerContext);
+  const profile: UserProfile | null = React.useContext(UserProfileContext);
+
+  enum ConfirmDialogType {
+    None,
+    Decommission,
+    Reinstate,
+  }
+  const [openConfirmDialog, setOpenConfirmDialog] = React.useState<ConfirmDialogType>(
+    ConfirmDialogType.None,
+  );
+
+  const robotDecommissioned =
+    robotState && robotState.status && robotState.status === Status2.Uninitialized;
+  // TODO: use authz for decommissioning robot
+  // const userCanDecommissionRobot = profile && Enforcer.canDecommissionRobot(profile);
+
+  const handleDecommission = React.useCallback<React.MouseEventHandler>(async () => {
+    if (!robotState || !robotState.name) {
+      return;
+    }
+    try {
+      if (!rmf) {
+        throw new Error('fleets api not available');
+      }
+      const id = `decommission-${fleet}-${robotState.name}-${Date.now()}`;
+      const labels = profile ? [profile.user.username] : [];
+      await rmf.fleetsApi?.decommissionRobotFleetsNameDecommissionPost(
+        fleet,
+        robotState.name,
+        id,
+        labels,
+      );
+      appController.showAlert('success', `Decommission of ${fleet}:${robotState.name} requested`);
+    } catch (e) {
+      appController.showAlert(
+        'error',
+        `Failed to decommission ${fleet}:${robotState.name}: ${(e as Error).message}`,
+      );
+    }
+    setOpenConfirmDialog(ConfirmDialogType.None);
+  }, [appController, fleet, robotState, rmf, profile, ConfirmDialogType]);
+
+  const handleReinstate = React.useCallback<React.MouseEventHandler>(async () => {
+    if (!robotState || !robotState.name) {
+      return;
+    }
+    try {
+      if (!rmf) {
+        throw new Error('fleets api not available');
+      }
+      const id = `reinstate-${fleet}-${robotState.name}-${Date.now()}`;
+      const labels = profile ? [profile.user.username] : [];
+      await rmf.fleetsApi?.reinstateRobotFleetsNameReinstatePost(
+        fleet,
+        robotState.name,
+        id,
+        labels,
+      );
+      appController.showAlert('success', `Reinstatement of ${fleet}:${robotState.name} requested`);
+    } catch (e) {
+      appController.showAlert(
+        'error',
+        `Failed to reinstate ${fleet}:${robotState.name}: ${(e as Error).message}`,
+      );
+    }
+    setOpenConfirmDialog(ConfirmDialogType.None);
+  }, [appController, fleet, robotState, rmf, profile, ConfirmDialogType]);
+
+  return (
+    <>
+      {robotDecommissioned ? (
+        <Button
+          onClick={() => setOpenConfirmDialog(ConfirmDialogType.Reinstate)}
+          autoFocus
+          {...otherProps}
+        >
+          {'Reinstate robot'}
+        </Button>
+      ) : robotState && !robotDecommissioned ? (
+        <Button
+          onClick={() => setOpenConfirmDialog(ConfirmDialogType.Decommission)}
+          autoFocus
+          {...otherProps}
+        >
+          {'Decommission robot'}
+        </Button>
+      ) : (
+        <Tooltip title={`Robot from fleet ${fleet} cannot be decommissioned/reinstated.`}>
+          <Button disabled className={classes['enableHover']} {...otherProps}>
+            {'Decommission/Reinstate robot'}
+          </Button>
+        </Tooltip>
+      )}
+      {openConfirmDialog === ConfirmDialogType.Decommission ? (
+        <ConfirmationDialog
+          confirmText="Confirm"
+          cancelText="Cancel"
+          open={openConfirmDialog === ConfirmDialogType.Decommission}
+          title={`Decommission [${fleet}:${robotState?.name || 'n/a'}]`}
+          submitting={undefined}
+          onClose={() => {
+            setOpenConfirmDialog(ConfirmDialogType.None);
+          }}
+          onSubmit={handleDecommission}
+        >
+          <Typography>Confirm decommission robot?</Typography>
+        </ConfirmationDialog>
+      ) : openConfirmDialog === ConfirmDialogType.Reinstate ? (
+        <ConfirmationDialog
+          confirmText="Confirm"
+          cancelText="Cancel"
+          open={openConfirmDialog === ConfirmDialogType.Reinstate}
+          title={`Reinstate [${fleet}:${robotState?.name || 'n/a'}]`}
+          submitting={undefined}
+          onClose={() => {
+            setOpenConfirmDialog(ConfirmDialogType.None);
+          }}
+          onSubmit={handleReinstate}
+        >
+          <Typography>Confirm reinstate robot?</Typography>
+        </ConfirmationDialog>
+      ) : (
+        <></>
+      )}
+    </>
+  );
+}

--- a/packages/dashboard/src/components/robots/robot-decommission.tsx
+++ b/packages/dashboard/src/components/robots/robot-decommission.tsx
@@ -1,4 +1,5 @@
 import { Button, ButtonProps, Theme, Tooltip, Typography } from '@mui/material';
+import { AppEvents } from '../app-events';
 import { RobotState, Status2 } from 'api-client';
 import React from 'react';
 import { AppControllerContext } from '../app-contexts';
@@ -69,10 +70,11 @@ export function RobotDecommissionButton({
         `Failed to decommission ${fleet}:${robotState.name}: ${(e as Error).message}`,
       );
     }
+    AppEvents.refreshRobotApp.next();
     setOpenConfirmDialog(ConfirmDialogType.None);
   }, [appController, fleet, robotState, rmf, profile, ConfirmDialogType]);
 
-  const handleReinstate = React.useCallback<React.MouseEventHandler>(async () => {
+  const handleRecommission = React.useCallback<React.MouseEventHandler>(async () => {
     if (!robotState || !robotState.name) {
       return;
     }
@@ -80,21 +82,22 @@ export function RobotDecommissionButton({
       if (!rmf) {
         throw new Error('fleets api not available');
       }
-      const id = `reinstate-${fleet}-${robotState.name}-${Date.now()}`;
+      const id = `recommission-${fleet}-${robotState.name}-${Date.now()}`;
       const labels = profile ? [profile.user.username] : [];
-      await rmf.fleetsApi?.reinstateRobotFleetsNameReinstatePost(
+      await rmf.fleetsApi?.recommissionRobotFleetsNameRecommissionPost(
         fleet,
         robotState.name,
         id,
         labels,
       );
-      appController.showAlert('success', `Reinstatement of ${fleet}:${robotState.name} requested`);
+      appController.showAlert('success', `Recommission of ${fleet}:${robotState.name} requested`);
     } catch (e) {
       appController.showAlert(
         'error',
-        `Failed to reinstate ${fleet}:${robotState.name}: ${(e as Error).message}`,
+        `Failed to recommission ${fleet}:${robotState.name}: ${(e as Error).message}`,
       );
     }
+    AppEvents.refreshRobotApp.next();
     setOpenConfirmDialog(ConfirmDialogType.None);
   }, [appController, fleet, robotState, rmf, profile, ConfirmDialogType]);
 
@@ -106,7 +109,7 @@ export function RobotDecommissionButton({
           autoFocus
           {...otherProps}
         >
-          {'Reinstate robot'}
+          {'Recommission robot'}
         </Button>
       ) : robotState && !robotDecommissioned ? (
         <Button
@@ -117,9 +120,9 @@ export function RobotDecommissionButton({
           {'Decommission robot'}
         </Button>
       ) : (
-        <Tooltip title={`Robot from fleet ${fleet} cannot be decommissioned/reinstated.`}>
+        <Tooltip title={`Robot from fleet ${fleet} cannot be decommissioned/recommissioned.`}>
           <Button disabled className={classes['enableHover']} {...otherProps}>
-            {'Decommission/Reinstate robot'}
+            {'Decommission/Recommission robot'}
           </Button>
         </Tooltip>
       )}
@@ -147,7 +150,7 @@ export function RobotDecommissionButton({
           onClose={() => {
             setOpenConfirmDialog(ConfirmDialogType.None);
           }}
-          onSubmit={handleReinstate}
+          onSubmit={handleRecommission}
         >
           <Typography>Confirm reinstate robot?</Typography>
         </ConfirmationDialog>

--- a/packages/dashboard/src/components/robots/robot-summary.tsx
+++ b/packages/dashboard/src/components/robots/robot-summary.tsx
@@ -33,6 +33,7 @@ import {
   BatteryUnknown,
 } from '@mui/icons-material';
 import { TaskCancelButton } from '../tasks/task-cancellation';
+import { RobotDecommissionButton } from './robot-decommission';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -292,6 +293,17 @@ export const RobotSummary = React.memo(({ onClose, robot }: RobotSummaryProps) =
       )}
       <DialogContent>{returnDialogContent()}</DialogContent>
       <DialogActions sx={{ justifyContent: 'center' }}>
+        <RobotDecommissionButton
+          fleet={robot.fleet}
+          robotState={robotState}
+          size="small"
+          variant="contained"
+          color="secondary"
+          sx={{
+            fontSize: isScreenHeightLessThan800 ? '0.8rem' : '1rem',
+            padding: isScreenHeightLessThan800 ? '4px 8px' : '6px 12px',
+          }}
+        />
         <TaskCancelButton
           taskId={taskState ? taskState.booking.id : null}
           size="small"

--- a/packages/dashboard/src/components/robots/robots-app.tsx
+++ b/packages/dashboard/src/components/robots/robots-app.tsx
@@ -76,10 +76,18 @@ export const RobotsApp = createMicroApp('Robots', () => {
       await refreshRobotTable();
     })();
 
+    // Set up the refresh trigger subscription
+    const sub = AppEvents.refreshRobotApp.subscribe({
+      next: async () => {
+        await refreshRobotTable();
+      },
+    });
+
     // Set up regular interval to refresh table
     const refreshInterval = window.setInterval(refreshRobotTable, RefreshRobotTableInterval);
     return () => {
       clearInterval(refreshInterval);
+      sub.unsubscribe();
     };
   }, [rmf]);
 

--- a/packages/react-components/lib/robots/robot-table-datagrid.tsx
+++ b/packages/react-components/lib/robots/robot-table-datagrid.tsx
@@ -42,6 +42,9 @@ export function RobotDataGridTable({ onRobotClick, robots }: RobotDataGridTableP
       const working = {
         color: theme.palette.success.main,
       };
+      const disabled = {
+        color: theme.palette.grey.A400,
+      };
       const defaultColor = {
         color: theme.palette.warning.main,
       };
@@ -49,6 +52,9 @@ export function RobotDataGridTable({ onRobotClick, robots }: RobotDataGridTableP
       switch (params.row.status) {
         case Status2.Error:
           return error;
+        case Status2.Offline:
+        case Status2.Uninitialized:
+          return disabled;
         case Status2.Charging:
           return charging;
         case Status2.Working:


### PR DESCRIPTION
## What's new

* New REST endpoint and gateway to handle decommission/recommission of robots, using `rmf_fleet_msgs/msg/InterruptRequest`
* Basic decommission button
* `decommission` is only allowed when the robot is available and the status is not `uninitialized`
* `recommission` is only allowed when the robot is available and the status is `uninitialized`
* Test with `rmf_demos` `feature/decommission` branch, https://github.com/open-rmf/rmf_demos/tree/feature/decommission (still using unstable API, not to be merged)

![image](https://github.com/open-rmf/rmf-web/assets/5383623/5d6c5d78-19d3-47b0-b367-1afa25090be8)

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test