### PR TITLE
Hammer/leave out phases

### DIFF
--- a/packages/api-client/lib/openapi/api.ts
+++ b/packages/api-client/lib/openapi/api.ts
@@ -7842,6 +7842,64 @@ export const TasksApiAxiosParamCreator = function (configuration?: Configuration
     },
     /**
      *
+     * @summary Export Task States
+     * @param {string} [startTimeBetween]          The period of starting time to fetch, in unix millis.          This must be a comma separated string, \&#39;X,Y\&#39; to fetch between X millis and Y millis inclusive.          Example:             \&quot;1000,2000\&quot; - Fetches logs between unix millis 1000 and 2000.
+     * @param {number} [limit] defaults to 100
+     * @param {number} [offset] defaults to 0
+     * @param {string} [orderBy] common separated list of fields to order by, prefix with \&#39;-\&#39; to sort descendingly.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    exportTaskStatesTasksexportGet: async (
+      startTimeBetween?: string,
+      limit?: number,
+      offset?: number,
+      orderBy?: string,
+      options: AxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      const localVarPath = `/tasksexport`;
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
+
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      if (startTimeBetween !== undefined) {
+        localVarQueryParameter['start_time_between'] = startTimeBetween;
+      }
+
+      if (limit !== undefined) {
+        localVarQueryParameter['limit'] = limit;
+      }
+
+      if (offset !== undefined) {
+        localVarQueryParameter['offset'] = offset;
+      }
+
+      if (orderBy !== undefined) {
+        localVarQueryParameter['order_by'] = orderBy;
+      }
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     *
      * @summary Get Favorites Tasks
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -9027,6 +9085,32 @@ export const TasksApiFp = function (configuration?: Configuration) {
     },
     /**
      *
+     * @summary Export Task States
+     * @param {string} [startTimeBetween]          The period of starting time to fetch, in unix millis.          This must be a comma separated string, \&#39;X,Y\&#39; to fetch between X millis and Y millis inclusive.          Example:             \&quot;1000,2000\&quot; - Fetches logs between unix millis 1000 and 2000.
+     * @param {number} [limit] defaults to 100
+     * @param {number} [offset] defaults to 0
+     * @param {string} [orderBy] common separated list of fields to order by, prefix with \&#39;-\&#39; to sort descendingly.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async exportTaskStatesTasksexportGet(
+      startTimeBetween?: string,
+      limit?: number,
+      offset?: number,
+      orderBy?: string,
+      options?: AxiosRequestConfig,
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<TaskState>>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.exportTaskStatesTasksexportGet(
+        startTimeBetween,
+        limit,
+        offset,
+        orderBy,
+        options,
+      );
+      return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+    },
+    /**
+     *
      * @summary Get Favorites Tasks
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -9548,6 +9632,27 @@ export const TasksApiFactory = function (
     },
     /**
      *
+     * @summary Export Task States
+     * @param {string} [startTimeBetween]          The period of starting time to fetch, in unix millis.          This must be a comma separated string, \&#39;X,Y\&#39; to fetch between X millis and Y millis inclusive.          Example:             \&quot;1000,2000\&quot; - Fetches logs between unix millis 1000 and 2000.
+     * @param {number} [limit] defaults to 100
+     * @param {number} [offset] defaults to 0
+     * @param {string} [orderBy] common separated list of fields to order by, prefix with \&#39;-\&#39; to sort descendingly.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    exportTaskStatesTasksexportGet(
+      startTimeBetween?: string,
+      limit?: number,
+      offset?: number,
+      orderBy?: string,
+      options?: any,
+    ): AxiosPromise<Array<TaskState>> {
+      return localVarFp
+        .exportTaskStatesTasksexportGet(startTimeBetween, limit, offset, orderBy, options)
+        .then((request) => request(axios, basePath));
+    },
+    /**
+     *
      * @summary Get Favorites Tasks
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -9988,6 +10093,29 @@ export class TasksApi extends BaseAPI {
   ) {
     return TasksApiFp(this.configuration)
       .deleteFavoriteTaskFavoriteTasksFavoriteTaskIdDelete(favoriteTaskId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   *
+   * @summary Export Task States
+   * @param {string} [startTimeBetween]          The period of starting time to fetch, in unix millis.          This must be a comma separated string, \&#39;X,Y\&#39; to fetch between X millis and Y millis inclusive.          Example:             \&quot;1000,2000\&quot; - Fetches logs between unix millis 1000 and 2000.
+   * @param {number} [limit] defaults to 100
+   * @param {number} [offset] defaults to 0
+   * @param {string} [orderBy] common separated list of fields to order by, prefix with \&#39;-\&#39; to sort descendingly.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof TasksApi
+   */
+  public exportTaskStatesTasksexportGet(
+    startTimeBetween?: string,
+    limit?: number,
+    offset?: number,
+    orderBy?: string,
+    options?: AxiosRequestConfig,
+  ) {
+    return TasksApiFp(this.configuration)
+      .exportTaskStatesTasksexportGet(startTimeBetween, limit, offset, orderBy, options)
       .then((request) => request(this.axios, this.basePath));
   }
 

--- a/packages/api-client/lib/version.ts
+++ b/packages/api-client/lib/version.ts
@@ -3,6 +3,6 @@ import { version as rmfModelVer } from 'rmf-models';
 
 export const version = {
   rmfModels: rmfModelVer,
-  rmfServer: '1403b63032764b781ef1ba349e50a9d895204bbb',
+  rmfServer: '6402b5053724949d3735bd1a56cc2b105f2d43e5',
   openapiGenerator: '6.2.1',
 };

--- a/packages/api-client/schema/index.ts
+++ b/packages/api-client/schema/index.ts
@@ -854,6 +854,86 @@ export default {
         },
       },
     },
+    '/tasksexport': {
+      get: {
+        tags: ['Tasks'],
+        summary: 'Export Task States',
+        operationId: 'export_task_states_tasksexport_get',
+        parameters: [
+          {
+            description:
+              '\n        The period of starting time to fetch, in unix millis.\n\n        This must be a comma separated string, \'X,Y\' to fetch between X millis and Y millis inclusive.\n\n        Example:\n            "1000,2000" - Fetches logs between unix millis 1000 and 2000.\n        ',
+            required: false,
+            schema: {
+              title: 'Start Time Between',
+              type: 'string',
+              description:
+                '\n        The period of starting time to fetch, in unix millis.\n\n        This must be a comma separated string, \'X,Y\' to fetch between X millis and Y millis inclusive.\n\n        Example:\n            "1000,2000" - Fetches logs between unix millis 1000 and 2000.\n        ',
+            },
+            name: 'start_time_between',
+            in: 'query',
+          },
+          {
+            description: 'defaults to 100',
+            required: false,
+            schema: {
+              title: 'Limit',
+              maximum: 1000.0,
+              exclusiveMinimum: 0.0,
+              type: 'integer',
+              description: 'defaults to 100',
+            },
+            name: 'limit',
+            in: 'query',
+          },
+          {
+            description: 'defaults to 0',
+            required: false,
+            schema: {
+              title: 'Offset',
+              minimum: 0.0,
+              type: 'integer',
+              description: 'defaults to 0',
+            },
+            name: 'offset',
+            in: 'query',
+          },
+          {
+            description:
+              "common separated list of fields to order by, prefix with '-' to sort descendingly.",
+            required: false,
+            schema: {
+              title: 'Order By',
+              type: 'string',
+              description:
+                "common separated list of fields to order by, prefix with '-' to sort descendingly.",
+            },
+            name: 'order_by',
+            in: 'query',
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Successful Response',
+            content: {
+              'application/json': {
+                schema: {
+                  title: 'Response Export Task States Tasksexport Get',
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/TaskState' },
+                },
+              },
+            },
+          },
+          '422': {
+            description: 'Validation Error',
+            content: {
+              'application/json': { schema: { $ref: '#/components/schemas/HTTPValidationError' } },
+            },
+          },
+        },
+      },
+    },
     '/tasks/{task_id}/state': {
       get: {
         tags: ['Tasks'],

--- a/packages/api-server/api_server/routes/tasks/tasks.py
+++ b/packages/api-server/api_server/routes/tasks/tasks.py
@@ -146,7 +146,27 @@ async def query_task_states(
                 continue
             filters["status__in"].append(mdl.Status(status_string))
 
-    return await task_repo.query_task_states(DbTaskState.filter(**filters), pagination)
+    return await task_repo.query_task_states(
+        DbTaskState.filter(**filters), pagination, False
+    )
+
+
+@router.get("export", response_model=List[mdl.TaskState])
+async def export_task_states(
+    task_repo: TaskRepository = Depends(task_repo_dep),
+    start_time_between: Optional[Tuple[datetime, datetime]] = Depends(
+        start_time_between_query
+    ),
+    pagination: mdl.Pagination = Depends(pagination_query),
+):
+    filters = {}
+    if start_time_between is not None:
+        filters["unix_millis_start_time__gte"] = start_time_between[0]
+        filters["unix_millis_start_time__lte"] = start_time_between[1]
+
+    return await task_repo.query_task_states(
+        DbTaskState.filter(**filters), pagination, True
+    )
 
 
 @router.get("/{task_id}/state", response_model=mdl.TaskState)

--- a/packages/dashboard/src/components/tasks/tasks-app.tsx
+++ b/packages/dashboard/src/components/tasks/tasks-app.tsx
@@ -253,17 +253,8 @@ export const TasksApp = React.memo(
         let queryIndex = 0;
         do {
           queries = (
-            await rmf.tasksApi.queryTaskStatesTasksGet(
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined,
+            await rmf.tasksApi.exportTaskStatesTasksexportGet(
               `${currentMillis - oneMonthMillis},${currentMillis}`,
-              undefined,
               QueryLimit,
               queryIndex * QueryLimit,
               '-unix_millis_start_time',


### PR DESCRIPTION
## What's new

* Added new endpoint specifically for task state export
* Removes phases from task states during query, only leaving them in for task state exports

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test