### PR TITLE
Display lift session ID for lift summary

### DIFF
--- a/packages/dashboard/src/components/lift-summary.tsx
+++ b/packages/dashboard/src/components/lift-summary.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { Dialog, DialogContent, DialogTitle, Divider, TextField } from '@mui/material';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  TextField,
+  useMediaQuery,
+} from '@mui/material';
 import { Theme } from '@mui/material/styles';
 import { RmfAppContext } from './rmf-app';
 import { getApiErrorMessage } from './utils';
@@ -25,6 +32,7 @@ interface LiftSummaryProps {
 }
 
 export const LiftSummary = ({ onClose, lift }: LiftSummaryProps): JSX.Element => {
+  const isScreenHeightLessThan800 = useMediaQuery('(max-height:800px)');
   const classes = useStyles();
   const rmf = React.useContext(RmfAppContext);
   const [liftData, setLiftData] = React.useState<LiftTableData>({
@@ -83,9 +91,14 @@ export const LiftSummary = ({ onClose, lift }: LiftSummaryProps): JSX.Element =>
         onClose();
       }}
       fullWidth
-      maxWidth="sm"
+      maxWidth={isScreenHeightLessThan800 ? 'xs' : 'sm'}
     >
-      <DialogTitle align="center">Lift summary</DialogTitle>
+      <DialogTitle
+        align="center"
+        sx={{ fontSize: isScreenHeightLessThan800 ? '1.2rem' : '1.5rem' }}
+      >
+        Lift summary
+      </DialogTitle>
       <Divider />
       <DialogContent>
         {Object.entries(liftData).map(([key, value]) => {
@@ -128,6 +141,11 @@ export const LiftSummary = ({ onClose, lift }: LiftSummaryProps): JSX.Element =>
                 maxRows={4}
                 margin="dense"
                 value={displayValue}
+                sx={{
+                  '& .MuiFilledInput-root': {
+                    fontSize: isScreenHeightLessThan800 ? '0.8rem' : '1.15',
+                  },
+                }}
               />
             </div>
           );

--- a/packages/dashboard/src/components/lift-summary.tsx
+++ b/packages/dashboard/src/components/lift-summary.tsx
@@ -35,6 +35,7 @@ export const LiftSummary = ({ onClose, lift }: LiftSummaryProps): JSX.Element =>
     destinationFloor: '',
     doorState: 0,
     motionState: 0,
+    sessionId: '',
     lift: lift,
   });
 
@@ -54,6 +55,7 @@ export const LiftSummary = ({ onClose, lift }: LiftSummaryProps): JSX.Element =>
             destinationFloor: liftState.destination_floor,
             doorState: liftState.door_state,
             motionState: liftState.motion_state,
+            sessionId: liftState.session_id,
             lift: lift,
           });
         });

--- a/packages/react-components/lib/lifts/lift-table-datagrid.tsx
+++ b/packages/react-components/lib/lifts/lift-table-datagrid.tsx
@@ -24,6 +24,7 @@ export interface LiftTableData {
   destinationFloor?: string;
   doorState: number;
   motionState: number;
+  sessionId?: string;
   lift: Lift;
   onRequestSubmit?(
     event: React.FormEvent,


### PR DESCRIPTION
## What's new

In scenarios with multiple robots sharing a lift, it is not evident to the user which robot has control of the lift if they are all queuing up for it. This will allow users to recognize which robot has control and be able to recover from manual interventions by cancelling the correct robot's task.

* Displaying lift summary again
* Adding session ID into summary information

![image](https://github.com/open-rmf/rmf-web/assets/5383623/14eb1f04-1d43-442b-affd-4d355c5fc9f0)

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test