### PR TITLE
Hammer/adapter lift request qos

### DIFF
--- a/packages/api-server/api_server/gateway.py
+++ b/packages/api-server/api_server/gateway.py
@@ -68,8 +68,16 @@ class RmfGateway:
         self._door_req = ros_node().create_publisher(
             RmfDoorRequest, "adapter_door_requests", 10
         )
-        self._lift_req = ros_node().create_publisher(
-            RmfLiftRequest, "adapter_lift_requests", 10
+
+        transient_qos = rclpy.qos.QoSProfile(
+            history=rclpy.qos.HistoryPolicy.KEEP_LAST,
+            depth=100,
+            reliability=rclpy.qos.ReliabilityPolicy.RELIABLE,
+            durability=rclpy.qos.DurabilityPolicy.TRANSIENT_LOCAL,
+        )
+
+        self._adapter_lift_req = ros_node().create_publisher(
+            RmfLiftRequest, "adapter_lift_requests", transient_qos
         )
         self._submit_task_srv = ros_node().create_client(RmfSubmitTask, "submit_task")
         self._cancel_task_srv = ros_node().create_client(RmfCancelTask, "cancel_task")
@@ -175,7 +183,7 @@ class RmfGateway:
             destination_floor=destination,
             door_state=door_mode,
         )
-        self._lift_req.publish(msg)
+        self._adapter_lift_req.publish(msg)
 
 
 _rmf_gateway: RmfGateway


### PR DESCRIPTION
## What's new

Ported from `deploy/hammer`, make the lift request qos transient local, having this publisher volatile and the subscription on `rmf_ros2` transient local means communication does not take place and the lift request widget does not actually work. 

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [x] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

I tested this locally and without the fix the widget doesn't work, with it requests are respected.