### PR TITLE
Remove background loading if no tasks were found

### DIFF
--- a/packages/dashboard/src/components/tasks/tasks-app.tsx
+++ b/packages/dashboard/src/components/tasks/tasks-app.tsx
@@ -23,6 +23,7 @@ import {
   Tasks,
   Window,
 } from 'react-components';
+import { AppControllerContext } from '../app-contexts';
 import { AppEvents } from '../app-events';
 import { MicroAppProps } from '../micro-app';
 import { RmfAppContext } from '../rmf-app';
@@ -83,6 +84,7 @@ export const TasksApp = React.memo(
       ref: React.Ref<HTMLDivElement>,
     ) => {
       const rmf = React.useContext(RmfAppContext);
+      const appController = React.useContext(AppControllerContext);
       const [autoRefresh, setAutoRefresh] = React.useState(true);
       const [refreshTaskAppCount, setRefreshTaskAppCount] = React.useState(0);
       const [selectedPanelIndex, setSelectedPanelIndex] = React.useState(TaskTablePanel.QueueTable);
@@ -312,6 +314,8 @@ export const TasksApp = React.memo(
         const pastMonthTasks = await getPastMonthTasks(now);
 
         if (!pastMonthTasks || !pastMonthTasks.length) {
+          appController.showAlert('error', 'No tasks found over the past month.');
+          AppEvents.loadingBackdrop.next(false);
           return;
         }
         if (minimal) {


### PR DESCRIPTION
## What's new

Fix issue where export loading screen goes on forever when no export tasks are available.

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test