### PR TITLE
api-server: catch invalid token error

### DIFF
--- a/packages/api-server/api_server/authenticator.py
+++ b/packages/api-server/api_server/authenticator.py
@@ -70,7 +70,7 @@ class JwtAuthenticator:
             user = await self._get_user(claims)
 
             return user
-        except jwt.DecodeError as e:
+        except jwt.InvalidTokenError as e:
             raise AuthenticationError(str(e)) from e
 
     def fastapi_dep(self) -> Callable[..., Union[Coroutine[Any, Any, User], User]]:


### PR DESCRIPTION
## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

`DecodeError` is not broad enough to catch errors that might cause auth to fail (e.g. expired tokens). The result is that the error is uncaught and the server returns 500. This fixes it so it properly return 401.

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
