### PR TITLE
Update default zoom values and default robot shape rotation

### DIFF
--- a/packages/dashboard/src/managers/resource-manager.ts
+++ b/packages/dashboard/src/managers/resource-manager.ts
@@ -85,7 +85,7 @@ export default class ResourceManager {
     this.helpLink = resources.helpLink || 'https://osrf.github.io/ros2multirobotbook/rmf-core.html';
     this.reportIssue = resources.reportIssue || 'https://github.com/open-rmf/rmf-web/issues';
     this.pickupZones = resources.pickupZones || [];
-    this.defaultZoom = resources.defaultZoom ?? 5;
+    this.defaultZoom = resources.defaultZoom ?? 20;
     this.defaultRobotZoom = resources.defaultRobotZoom ?? 40;
     this.attributionPrefix = resources.attributionPrefix || 'OSRC-SG';
     this.cartIds = resources.cartIds || [];

--- a/packages/react-components/lib/map/circle-shape.tsx
+++ b/packages/react-components/lib/map/circle-shape.tsx
@@ -23,8 +23,8 @@ export const CircleShape = ({
 }: CircleShapeProps): JSX.Element => {
   const SCALED_RADIUS = 0.7;
 
-  const rotatedX = position.x + SCALED_RADIUS * Math.cos(rotation.z - Math.PI / 2);
-  const rotatedY = position.y + SCALED_RADIUS * Math.sin(rotation.z - Math.PI / 2);
+  const rotatedX = position.x + SCALED_RADIUS * Math.cos(rotation.z);
+  const rotatedY = position.y + SCALED_RADIUS * Math.sin(rotation.z);
 
   return (
     <>


### PR DESCRIPTION
Update default map zoom to fit office world, and fix circle shape robot rotation

## What's new

* default zoom was too small for office world, changed from 5 to 20
* default robot circle shape was offset by 90 degrees

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test