### PR TITLE
Allow pydantic 2.8.2 to be installed after python 3.8 following pypi

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -705,7 +705,7 @@
                 "sha256:6f62c13d067b0755ad1c21a34bdd06c0c12625a22b0fc09c6b149816604f7c2a",
                 "sha256:73ee9fddd406dc318b885c7a2eab8a6472b68b8fb5ba8150949fc3db939f23c8"
             ],
-            "markers": "python_version >= '3.12' and python_version < '4.0'",
+            "markers": "python_version >= '3.8' and python_version < '4.0'",
             "version": "==2.8.2"
         },
         "pydantic-core": {


### PR DESCRIPTION
## What's new

This fixes the issue of `pipenv-install` setting up `pydantic==1.10.7` when developing locally on Ubuntu Jammy + ROS 2 Humble.

It is a little odd that setting up the web stack in docker doesn't run into this issue.

Updated the markers to follow https://pypi.org/project/pydantic/. The markers are listed based on the environment where `pipenv lock` was run, resulting in `python >= 3.12`

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test