### PR TITLE
Port/double compose delivery

### DIFF
--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -73,8 +73,12 @@ import {
   DeliveryPickupTaskDescription,
   DeliveryPickupTaskForm,
   DeliverySequentialLotPickupTaskDefinition,
+  DoubleComposeDeliveryTaskDefinition,
+  DoubleComposeDeliveryTaskDescription,
+  DoubleComposeDeliveryTaskForm,
   makeDeliveryCustomTaskBookingLabel,
   makeDeliveryPickupTaskBookingLabel,
+  makeDoubleComposeDeliveryTaskBookingLabel,
 } from './types/delivery-custom';
 import {
   makePatrolTaskBookingLabel,
@@ -93,6 +97,7 @@ export interface TaskDefinition {
 export type TaskDescription =
   | DeliveryPickupTaskDescription
   | DeliveryCustomTaskDescription
+  | DoubleComposeDeliveryTaskDescription
   | PatrolTaskDescription
   | DeliveryTaskDescription
   | ComposeCleanTaskDescription;
@@ -584,6 +589,27 @@ export function CreateTaskForm({
             onValidate={onValidate}
           />
         );
+      case DoubleComposeDeliveryTaskDefinition.taskDefinitionId:
+        return (
+          <DoubleComposeDeliveryTaskForm
+            taskDesc={taskRequest.description as DoubleComposeDeliveryTaskDescription}
+            pickupPoints={pickupPoints}
+            cartIds={cartIds}
+            dropoffPoints={dropoffPoints}
+            onChange={(desc: DoubleComposeDeliveryTaskDescription) => {
+              desc.category = taskRequest.description.category;
+              desc.phases[0].activity.description.activities[1].description.category =
+                taskRequest.description.category;
+              desc.phases[3].activity.description.activities[1].description.category =
+                taskRequest.description.category;
+              handleTaskDescriptionChange(
+                DoubleComposeDeliveryTaskDefinition.requestCategory,
+                desc,
+              );
+            }}
+            onValidate={onValidate}
+          />
+        );
       case CustomComposeTaskDefinition.taskDefinitionId:
         return (
           <CustomComposeTaskForm
@@ -657,6 +683,9 @@ export function CreateTaskForm({
         case DeliverySequentialLotPickupTaskDefinition.taskDefinitionId:
         case DeliveryAreaPickupTaskDefinition.taskDefinitionId:
           requestBookingLabel = makeDeliveryCustomTaskBookingLabel(request.description);
+          break;
+        case DoubleComposeDeliveryTaskDefinition.taskDefinitionId:
+          requestBookingLabel = makeDoubleComposeDeliveryTaskBookingLabel(request.description);
           break;
         case PatrolTaskDefinition.taskDefinitionId:
           requestBookingLabel = makePatrolTaskBookingLabel(request.description);
@@ -880,7 +909,12 @@ export function CreateTaskForm({
                       disabled
                     />
                   </Grid>
-                  <Grid item xs={1}>
+                  <Grid
+                    container
+                    xs={isScreenHeightLessThan800 ? 6 : 5}
+                    justifyContent="flex-end"
+                    alignItems="flex-end"
+                  >
                     <Checkbox
                       checked={warnTime !== null}
                       onChange={handleWarnTimeCheckboxChange}
@@ -889,8 +923,6 @@ export function CreateTaskForm({
                         '& .MuiSvgIcon-root': { fontSize: isScreenHeightLessThan800 ? 22 : 32 },
                       }}
                     />
-                  </Grid>
-                  <Grid item xs={isScreenHeightLessThan800 ? 5 : 4}>
                     <DateTimePicker
                       disabled={warnTime === null}
                       value={warnTime}
@@ -994,6 +1026,7 @@ export function CreateTaskForm({
               }
               helperText="Required"
               error={favoriteTaskTitleError}
+              fullWidth
             />
           )}
           {callToDeleteFavoriteTask && (

--- a/packages/react-components/lib/tasks/create-task.tsx
+++ b/packages/react-components/lib/tasks/create-task.tsx
@@ -594,7 +594,6 @@ export function CreateTaskForm({
           <DoubleComposeDeliveryTaskForm
             taskDesc={taskRequest.description as DoubleComposeDeliveryTaskDescription}
             pickupPoints={pickupPoints}
-            cartIds={cartIds}
             dropoffPoints={dropoffPoints}
             onChange={(desc: DoubleComposeDeliveryTaskDescription) => {
               desc.category = taskRequest.description.category;

--- a/packages/react-components/lib/tasks/types/delivery-custom.spec.tsx
+++ b/packages/react-components/lib/tasks/types/delivery-custom.spec.tsx
@@ -1,370 +1,701 @@
 import {
-  deliveryCustomInsertCartId,
-  deliveryCustomInsertDropoff,
-  deliveryCustomInsertOnCancel,
-  deliveryCustomInsertPickup,
+  cartCustomPickupPhaseInsertCartId,
+  cartCustomPickupPhaseInsertPickup,
+  CartPickupPhase,
+  cartPickupPhaseInsertCartId,
+  cartPickupPhaseInsertPickup,
   DeliveryCustomTaskDescription,
-  deliveryInsertCartId,
-  deliveryInsertDropoff,
-  deliveryInsertOnCancel,
-  deliveryInsertPickup,
+  deliveryPhaseInsertDropoff,
+  deliveryPhaseInsertOnCancel,
   DeliveryPickupTaskDescription,
+  DeliveryWithCancellationPhase,
+  DoubleComposeDeliveryTaskDescription,
   makeDefaultDeliveryCustomTaskDescription,
   makeDefaultDeliveryPickupTaskDescription,
+  makeDefaultDoubleComposeDeliveryTaskDescription,
 } from '.';
 
 describe('Custom deliveries', () => {
-  it('delivery pickup', () => {
-    let deliveryPickupTaskDescription: DeliveryPickupTaskDescription | null = null;
-    try {
-      deliveryPickupTaskDescription = JSON.parse(`{
-        "category": "delivery_pickup",
-        "phases": [
-          {
-            "activity": {
-              "category": "sequence",
+  it('create valid pickup phase', () => {
+    const parsedPhase: CartPickupPhase = JSON.parse(`{
+      "activity": {
+        "category": "sequence",
+        "description": {
+          "activities": [
+            {
+              "category": "go_to_place",
+              "description": "test_pickup_place"
+            },
+            {
+              "category": "perform_action",
               "description": {
-                "activities": [
-                  {
-                    "category": "go_to_place",
-                    "description": "test_pickup_place"
-                  },
-                  {
-                    "category": "perform_action",
-                    "description": {
-                      "unix_millis_action_duration_estimate": 60000,
-                      "category": "delivery_pickup",
-                      "description": {
-                        "cart_id": "test_cart_id",
-                        "pickup_lot": "test_pickup_lot"
-                      }
-                    }
-                  }
-                ]
+                "unix_millis_action_duration_estimate": 60000,
+                "category": "delivery_pickup",
+                "description": {
+                  "cart_id": "test_cart_id",
+                  "pickup_lot": "test_pickup_lot"
+                }
               }
             }
-          },
-          {
-            "activity": {
-              "category": "sequence",
+          ]
+        }
+      }
+    }
+    `) as CartPickupPhase;
+
+    const defaultDesc = makeDefaultDeliveryPickupTaskDescription();
+    let insertedPhase = cartPickupPhaseInsertPickup(
+      defaultDesc.phases[0],
+      'test_pickup_place',
+      'test_pickup_lot',
+    );
+    insertedPhase = cartPickupPhaseInsertCartId(insertedPhase, 'test_cart_id');
+    expect(parsedPhase).toEqual(insertedPhase);
+  });
+
+  it('create valid delivery with cancellation phase', () => {
+    const parsedPhase: DeliveryWithCancellationPhase = JSON.parse(`{
+      "activity": {
+        "category": "sequence",
+        "description": {
+          "activities": [
+            {
+              "category": "go_to_place",
+              "description": "test_dropoff_place"
+            }
+          ]
+        }
+      },
+      "on_cancel": [
+        {
+          "category": "sequence",
+          "description": [
+            {
+              "category": "go_to_place",
               "description": {
-                "activities": [
+                "one_of": [
                   {
-                    "category": "go_to_place",
-                    "description": "test_dropoff_place"
+                    "waypoint": "test_waypoint_1"
+                  },
+                  {
+                    "waypoint": "test_waypoint_2"
+                  },
+                  {
+                    "waypoint": "test_waypoint_3"
+                  }
+                ],
+                "constraints": [
+                  {
+                    "category": "prefer_same_map",
+                    "description": ""
                   }
                 ]
               }
             },
-            "on_cancel": [
-              {
-                "category": "sequence",
-                "description": [
-                  {
-                    "category": "go_to_place",
-                    "description": {
-                      "one_of": [
-                        {
-                          "waypoint": "test_waypoint_1"
-                        },
-                        {
-                          "waypoint": "test_waypoint_2"
-                        },
-                        {
-                          "waypoint": "test_waypoint_3"
-                        }
-                      ],
-                      "constraints": [
-                        {
-                          "category": "prefer_same_map",
-                          "description": ""
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "category": "perform_action",
-                    "description": {
-                      "unix_millis_action_duration_estimate": 60000,
-                      "category": "delivery_dropoff",
-                      "description": {}
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "activity": {
-              "category": "sequence",
+            {
+              "category": "perform_action",
               "description": {
-                "activities": [
-                  {
-                    "category": "perform_action",
-                    "description": {
-                      "unix_millis_action_duration_estimate": 60000,
-                      "category": "delivery_dropoff",
-                      "description": {}
-                    }
-                  }
-                ]
+                "unix_millis_action_duration_estimate": 60000,
+                "category": "delivery_dropoff",
+                "description": {}
               }
             }
-          }
-        ]
-      }
-      `) as DeliveryPickupTaskDescription;
-    } catch (e) {
-      deliveryPickupTaskDescription = null;
+          ]
+        }
+      ]
     }
-    expect(deliveryPickupTaskDescription).not.toEqual(null);
+    `) as DeliveryWithCancellationPhase;
 
-    let description = makeDefaultDeliveryPickupTaskDescription();
-    description = deliveryInsertPickup(description, 'test_pickup_place', 'test_pickup_lot');
-    description = deliveryInsertCartId(description, 'test_cart_id');
-    description = deliveryInsertDropoff(description, 'test_dropoff_place');
-    description = deliveryInsertOnCancel(description, [
+    const defaultDesc = makeDefaultDeliveryPickupTaskDescription();
+    let insertedPhase = deliveryPhaseInsertDropoff(defaultDesc.phases[1], 'test_dropoff_place');
+    insertedPhase = deliveryPhaseInsertOnCancel(insertedPhase, [
       'test_waypoint_1',
       'test_waypoint_2',
       'test_waypoint_3',
     ]);
-    expect(deliveryPickupTaskDescription).toEqual(description);
+    expect(parsedPhase).toEqual(insertedPhase);
   });
 
-  it('delivery_sequential_lot_pickup', () => {
-    let deliveryCustomTaskDescription: DeliveryCustomTaskDescription | null = null;
-    try {
-      deliveryCustomTaskDescription = JSON.parse(`{
-        "category": "delivery_sequential_lot_pickup",
-        "phases": [
-          {
-            "activity": {
-              "category": "sequence",
-              "description": {
-                "activities": [
-                  {
-                    "category": "go_to_place",
-                    "description": "test_pickup_place"
-                  },
-                  {
-                    "category": "perform_action",
+  it('create valid delivery pickup task description', () => {
+    const parsedDescription: DeliveryPickupTaskDescription = JSON.parse(`{
+      "category": "delivery_pickup",
+      "phases": [
+        {
+          "activity": {
+            "category": "sequence",
+            "description": {
+              "activities": [
+                {
+                  "category": "go_to_place",
+                  "description": "test_pickup_place"
+                },
+                {
+                  "category": "perform_action",
+                  "description": {
+                    "unix_millis_action_duration_estimate": 60000,
+                    "category": "delivery_pickup",
                     "description": {
-                      "unix_millis_action_duration_estimate": 60000,
-                      "category": "delivery_sequential_lot_pickup",
-                      "description": {
-                        "cart_id": "test_cart_id",
-                        "pickup_zone": "test_pickup_zone"
-                      }
+                      "cart_id": "test_cart_id",
+                      "pickup_lot": "test_pickup_lot"
                     }
                   }
-                ]
-              }
-            }
-          },
-          {
-            "activity": {
-              "category": "sequence",
-              "description": {
-                "activities": [
-                  {
-                    "category": "go_to_place",
-                    "description": "test_dropoff_place"
-                  }
-                ]
-              }
-            },
-            "on_cancel": [
-              {
-                "category": "sequence",
-                "description": [
-                  {
-                    "category": "go_to_place",
-                    "description": {
-                      "one_of": [
-                        {
-                          "waypoint": "test_waypoint_1"
-                        },
-                        {
-                          "waypoint": "test_waypoint_2"
-                        },
-                        {
-                          "waypoint": "test_waypoint_3"
-                        }
-                      ],
-                      "constraints": [
-                        {
-                          "category": "prefer_same_map",
-                          "description": ""
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "category": "perform_action",
-                    "description": {
-                      "unix_millis_action_duration_estimate": 60000,
-                      "category": "delivery_dropoff",
-                      "description": {}
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "activity": {
-              "category": "sequence",
-              "description": {
-                "activities": [
-                  {
-                    "category": "perform_action",
-                    "description": {
-                      "unix_millis_action_duration_estimate": 60000,
-                      "category": "delivery_dropoff",
-                      "description": {}
-                    }
-                  }
-                ]
-              }
+                }
+              ]
             }
           }
-        ]
-      }
-      `) as DeliveryCustomTaskDescription;
-    } catch (e) {
-      deliveryCustomTaskDescription = null;
+        },
+        {
+          "activity": {
+            "category": "sequence",
+            "description": {
+              "activities": [
+                {
+                  "category": "go_to_place",
+                  "description": "test_dropoff_place"
+                }
+              ]
+            }
+          },
+          "on_cancel": [
+            {
+              "category": "sequence",
+              "description": [
+                {
+                  "category": "go_to_place",
+                  "description": {
+                    "one_of": [
+                      {
+                        "waypoint": "test_waypoint_1"
+                      },
+                      {
+                        "waypoint": "test_waypoint_2"
+                      },
+                      {
+                        "waypoint": "test_waypoint_3"
+                      }
+                    ],
+                    "constraints": [
+                      {
+                        "category": "prefer_same_map",
+                        "description": ""
+                      }
+                    ]
+                  }
+                },
+                {
+                  "category": "perform_action",
+                  "description": {
+                    "unix_millis_action_duration_estimate": 60000,
+                    "category": "delivery_dropoff",
+                    "description": {}
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "activity": {
+            "category": "sequence",
+            "description": {
+              "activities": [
+                {
+                  "category": "perform_action",
+                  "description": {
+                    "unix_millis_action_duration_estimate": 60000,
+                    "category": "delivery_dropoff",
+                    "description": {}
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
     }
-    expect(deliveryCustomTaskDescription).not.toEqual(null);
+    `) as DeliveryPickupTaskDescription;
 
-    let description: DeliveryCustomTaskDescription = makeDefaultDeliveryCustomTaskDescription(
+    const description = makeDefaultDeliveryPickupTaskDescription();
+    let pickupPhase = cartPickupPhaseInsertPickup(
+      description.phases[0],
+      'test_pickup_place',
+      'test_pickup_lot',
+    );
+    pickupPhase = cartPickupPhaseInsertCartId(pickupPhase, 'test_cart_id');
+    let deliveryPhase = deliveryPhaseInsertDropoff(description.phases[1], 'test_dropoff_place');
+    deliveryPhase = deliveryPhaseInsertOnCancel(deliveryPhase, [
+      'test_waypoint_1',
+      'test_waypoint_2',
+      'test_waypoint_3',
+    ]);
+    description.phases[0] = pickupPhase;
+    description.phases[1] = deliveryPhase;
+    expect(parsedDescription).toEqual(description);
+  });
+
+  it('create valid delivery_sequential_lot_pickup task description', () => {
+    const parsedDescription: DeliveryCustomTaskDescription = JSON.parse(`{
+      "category": "delivery_sequential_lot_pickup",
+      "phases": [
+        {
+          "activity": {
+            "category": "sequence",
+            "description": {
+              "activities": [
+                {
+                  "category": "go_to_place",
+                  "description": "test_pickup_place"
+                },
+                {
+                  "category": "perform_action",
+                  "description": {
+                    "unix_millis_action_duration_estimate": 60000,
+                    "category": "delivery_sequential_lot_pickup",
+                    "description": {
+                      "cart_id": "test_cart_id",
+                      "pickup_zone": "test_pickup_zone"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "activity": {
+            "category": "sequence",
+            "description": {
+              "activities": [
+                {
+                  "category": "go_to_place",
+                  "description": "test_dropoff_place"
+                }
+              ]
+            }
+          },
+          "on_cancel": [
+            {
+              "category": "sequence",
+              "description": [
+                {
+                  "category": "go_to_place",
+                  "description": {
+                    "one_of": [
+                      {
+                        "waypoint": "test_waypoint_1"
+                      },
+                      {
+                        "waypoint": "test_waypoint_2"
+                      },
+                      {
+                        "waypoint": "test_waypoint_3"
+                      }
+                    ],
+                    "constraints": [
+                      {
+                        "category": "prefer_same_map",
+                        "description": ""
+                      }
+                    ]
+                  }
+                },
+                {
+                  "category": "perform_action",
+                  "description": {
+                    "unix_millis_action_duration_estimate": 60000,
+                    "category": "delivery_dropoff",
+                    "description": {}
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "activity": {
+            "category": "sequence",
+            "description": {
+              "activities": [
+                {
+                  "category": "perform_action",
+                  "description": {
+                    "unix_millis_action_duration_estimate": 60000,
+                    "category": "delivery_dropoff",
+                    "description": {}
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+    `) as DeliveryCustomTaskDescription;
+
+    const description: DeliveryCustomTaskDescription = makeDefaultDeliveryCustomTaskDescription(
       'delivery_sequential_lot_pickup',
     );
-    description = deliveryCustomInsertPickup(description, 'test_pickup_place', 'test_pickup_zone');
-    description = deliveryCustomInsertCartId(description, 'test_cart_id');
-    description = deliveryCustomInsertDropoff(description, 'test_dropoff_place');
-    description = deliveryCustomInsertOnCancel(description, [
+    let pickupPhase = cartCustomPickupPhaseInsertPickup(
+      description.phases[0],
+      'test_pickup_place',
+      'test_pickup_zone',
+    );
+    pickupPhase = cartCustomPickupPhaseInsertCartId(pickupPhase, 'test_cart_id');
+    let deliveryPhase = deliveryPhaseInsertDropoff(description.phases[1], 'test_dropoff_place');
+    deliveryPhase = deliveryPhaseInsertOnCancel(deliveryPhase, [
       'test_waypoint_1',
       'test_waypoint_2',
       'test_waypoint_3',
     ]);
-    expect(deliveryCustomTaskDescription).toEqual(description);
+    description.phases[0] = pickupPhase;
+    description.phases[1] = deliveryPhase;
+    expect(parsedDescription).toEqual(description);
   });
 
-  it('delivery_area_pickup', () => {
-    let deliveryCustomTaskDescription: DeliveryCustomTaskDescription | null = null;
-    try {
-      deliveryCustomTaskDescription = JSON.parse(`{
-        "category": "delivery_area_pickup",
-        "phases": [
-          {
-            "activity": {
-              "category": "sequence",
-              "description": {
-                "activities": [
-                  {
-                    "category": "go_to_place",
-                    "description": "test_pickup_place"
-                  },
-                  {
-                    "category": "perform_action",
+  it('create valid delivery_area_pickup task description', () => {
+    const parsedDescription: DeliveryCustomTaskDescription = JSON.parse(`{
+      "category": "delivery_area_pickup",
+      "phases": [
+        {
+          "activity": {
+            "category": "sequence",
+            "description": {
+              "activities": [
+                {
+                  "category": "go_to_place",
+                  "description": "test_pickup_place"
+                },
+                {
+                  "category": "perform_action",
+                  "description": {
+                    "unix_millis_action_duration_estimate": 60000,
+                    "category": "delivery_area_pickup",
                     "description": {
-                      "unix_millis_action_duration_estimate": 60000,
-                      "category": "delivery_area_pickup",
-                      "description": {
-                        "cart_id": "test_cart_id",
-                        "pickup_zone": "test_pickup_zone"
-                      }
+                      "cart_id": "test_cart_id",
+                      "pickup_zone": "test_pickup_zone"
                     }
                   }
-                ]
-              }
-            }
-          },
-          {
-            "activity": {
-              "category": "sequence",
-              "description": {
-                "activities": [
-                  {
-                    "category": "go_to_place",
-                    "description": "test_dropoff_place"
-                  }
-                ]
-              }
-            },
-            "on_cancel": [
-              {
-                "category": "sequence",
-                "description": [
-                  {
-                    "category": "go_to_place",
-                    "description": {
-                      "one_of": [
-                        {
-                          "waypoint": "test_waypoint_1"
-                        },
-                        {
-                          "waypoint": "test_waypoint_2"
-                        },
-                        {
-                          "waypoint": "test_waypoint_3"
-                        }
-                      ],
-                      "constraints": [
-                        {
-                          "category": "prefer_same_map",
-                          "description": ""
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "category": "perform_action",
-                    "description": {
-                      "unix_millis_action_duration_estimate": 60000,
-                      "category": "delivery_dropoff",
-                      "description": {}
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "activity": {
-              "category": "sequence",
-              "description": {
-                "activities": [
-                  {
-                    "category": "perform_action",
-                    "description": {
-                      "unix_millis_action_duration_estimate": 60000,
-                      "category": "delivery_dropoff",
-                      "description": {}
-                    }
-                  }
-                ]
-              }
+                }
+              ]
             }
           }
-        ]
-      }
-      `) as DeliveryCustomTaskDescription;
-    } catch (e) {
-      deliveryCustomTaskDescription = null;
+        },
+        {
+          "activity": {
+            "category": "sequence",
+            "description": {
+              "activities": [
+                {
+                  "category": "go_to_place",
+                  "description": "test_dropoff_place"
+                }
+              ]
+            }
+          },
+          "on_cancel": [
+            {
+              "category": "sequence",
+              "description": [
+                {
+                  "category": "go_to_place",
+                  "description": {
+                    "one_of": [
+                      {
+                        "waypoint": "test_waypoint_1"
+                      },
+                      {
+                        "waypoint": "test_waypoint_2"
+                      },
+                      {
+                        "waypoint": "test_waypoint_3"
+                      }
+                    ],
+                    "constraints": [
+                      {
+                        "category": "prefer_same_map",
+                        "description": ""
+                      }
+                    ]
+                  }
+                },
+                {
+                  "category": "perform_action",
+                  "description": {
+                    "unix_millis_action_duration_estimate": 60000,
+                    "category": "delivery_dropoff",
+                    "description": {}
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "activity": {
+            "category": "sequence",
+            "description": {
+              "activities": [
+                {
+                  "category": "perform_action",
+                  "description": {
+                    "unix_millis_action_duration_estimate": 60000,
+                    "category": "delivery_dropoff",
+                    "description": {}
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
     }
-    expect(deliveryCustomTaskDescription).not.toEqual(null);
+    `) as DeliveryCustomTaskDescription;
 
-    let description: DeliveryCustomTaskDescription =
+    const description: DeliveryCustomTaskDescription =
       makeDefaultDeliveryCustomTaskDescription('delivery_area_pickup');
-    description = deliveryCustomInsertPickup(description, 'test_pickup_place', 'test_pickup_zone');
-    description = deliveryCustomInsertCartId(description, 'test_cart_id');
-    description = deliveryCustomInsertDropoff(description, 'test_dropoff_place');
-    description = deliveryCustomInsertOnCancel(description, [
+    let pickupPhase = cartCustomPickupPhaseInsertPickup(
+      description.phases[0],
+      'test_pickup_place',
+      'test_pickup_zone',
+    );
+    pickupPhase = cartCustomPickupPhaseInsertCartId(pickupPhase, 'test_cart_id');
+    let deliveryPhase = deliveryPhaseInsertDropoff(description.phases[1], 'test_dropoff_place');
+    deliveryPhase = deliveryPhaseInsertOnCancel(deliveryPhase, [
       'test_waypoint_1',
       'test_waypoint_2',
       'test_waypoint_3',
     ]);
-    expect(deliveryCustomTaskDescription).toEqual(description);
+    description.phases[0] = pickupPhase;
+    description.phases[1] = deliveryPhase;
+    expect(parsedDescription).toEqual(description);
+  });
+
+  it('create valid double_compose_delivery task description', () => {
+    const parsedDescription: DoubleComposeDeliveryTaskDescription = JSON.parse(`{
+      "category": "delivery_pickup",
+      "phases": [
+        {
+          "activity": {
+            "category": "sequence",
+            "description": {
+              "activities": [
+                {
+                  "category": "go_to_place",
+                  "description": "test_first_pickup_place"
+                },
+                {
+                  "category": "perform_action",
+                  "description": {
+                    "unix_millis_action_duration_estimate": 60000,
+                    "category": "delivery_pickup",
+                    "description": {
+                      "cart_id": "test_first_cart_id",
+                      "pickup_lot": "test_first_pickup_lot"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "activity": {
+            "category": "sequence",
+            "description": {
+              "activities": [
+                {
+                  "category": "go_to_place",
+                  "description": "test_first_dropoff_place"
+                }
+              ]
+            }
+          },
+          "on_cancel": [
+            {
+              "category": "sequence",
+              "description": [
+                {
+                  "category": "go_to_place",
+                  "description": {
+                    "one_of": [
+                      {
+                        "waypoint": "test_waypoint_1"
+                      },
+                      {
+                        "waypoint": "test_waypoint_2"
+                      },
+                      {
+                        "waypoint": "test_waypoint_3"
+                      }
+                    ],
+                    "constraints": [
+                      {
+                        "category": "prefer_same_map",
+                        "description": ""
+                      }
+                    ]
+                  }
+                },
+                {
+                  "category": "perform_action",
+                  "description": {
+                    "unix_millis_action_duration_estimate": 60000,
+                    "category": "delivery_dropoff",
+                    "description": {}
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "activity": {
+            "category": "sequence",
+            "description": {
+              "activities": [
+                {
+                  "category": "perform_action",
+                  "description": {
+                    "unix_millis_action_duration_estimate": 60000,
+                    "category": "delivery_dropoff",
+                    "description": {}
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "activity": {
+            "category": "sequence",
+            "description": {
+              "activities": [
+                {
+                  "category": "go_to_place",
+                  "description": "test_second_pickup_place"
+                },
+                {
+                  "category": "perform_action",
+                  "description": {
+                    "unix_millis_action_duration_estimate": 60000,
+                    "category": "delivery_pickup",
+                    "description": {
+                      "cart_id": "test_second_cart_id",
+                      "pickup_lot": "test_second_pickup_lot"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "activity": {
+            "category": "sequence",
+            "description": {
+              "activities": [
+                {
+                  "category": "go_to_place",
+                  "description": "test_second_dropoff_place"
+                }
+              ]
+            }
+          },
+          "on_cancel": [
+            {
+              "category": "sequence",
+              "description": [
+                {
+                  "category": "go_to_place",
+                  "description": {
+                    "one_of": [
+                      {
+                        "waypoint": "test_waypoint_1"
+                      },
+                      {
+                        "waypoint": "test_waypoint_2"
+                      },
+                      {
+                        "waypoint": "test_waypoint_3"
+                      }
+                    ],
+                    "constraints": [
+                      {
+                        "category": "prefer_same_map",
+                        "description": ""
+                      }
+                    ]
+                  }
+                },
+                {
+                  "category": "perform_action",
+                  "description": {
+                    "unix_millis_action_duration_estimate": 60000,
+                    "category": "delivery_dropoff",
+                    "description": {}
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "activity": {
+            "category": "sequence",
+            "description": {
+              "activities": [
+                {
+                  "category": "perform_action",
+                  "description": {
+                    "unix_millis_action_duration_estimate": 60000,
+                    "category": "delivery_dropoff",
+                    "description": {}
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+    `) as DoubleComposeDeliveryTaskDescription;
+
+    const description: DoubleComposeDeliveryTaskDescription =
+      makeDefaultDoubleComposeDeliveryTaskDescription();
+    let firstPickupPhase = cartPickupPhaseInsertPickup(
+      description.phases[0],
+      'test_first_pickup_place',
+      'test_first_pickup_lot',
+    );
+    firstPickupPhase = cartPickupPhaseInsertCartId(firstPickupPhase, 'test_first_cart_id');
+    let firstDeliveryPhase = deliveryPhaseInsertDropoff(
+      description.phases[1],
+      'test_first_dropoff_place',
+    );
+    firstDeliveryPhase = deliveryPhaseInsertOnCancel(firstDeliveryPhase, [
+      'test_waypoint_1',
+      'test_waypoint_2',
+      'test_waypoint_3',
+    ]);
+    let secondPickupPhase = cartPickupPhaseInsertPickup(
+      description.phases[3],
+      'test_second_pickup_place',
+      'test_second_pickup_lot',
+    );
+    secondPickupPhase = cartPickupPhaseInsertCartId(secondPickupPhase, 'test_second_cart_id');
+    let secondDeliveryPhase = deliveryPhaseInsertDropoff(
+      description.phases[4],
+      'test_second_dropoff_place',
+    );
+    secondDeliveryPhase = deliveryPhaseInsertOnCancel(secondDeliveryPhase, [
+      'test_waypoint_1',
+      'test_waypoint_2',
+      'test_waypoint_3',
+    ]);
+    description.phases[0] = firstPickupPhase;
+    description.phases[1] = firstDeliveryPhase;
+    description.phases[3] = secondPickupPhase;
+    description.phases[4] = secondDeliveryPhase;
+    expect(parsedDescription).toEqual(description);
   });
 });

--- a/packages/react-components/lib/tasks/types/delivery-custom.spec.tsx
+++ b/packages/react-components/lib/tasks/types/delivery-custom.spec.tsx
@@ -489,7 +489,7 @@ describe('Custom deliveries', () => {
                     "unix_millis_action_duration_estimate": 60000,
                     "category": "delivery_pickup",
                     "description": {
-                      "cart_id": "test_first_cart_id",
+                      "cart_id": "",
                       "pickup_lot": "test_first_pickup_lot"
                     }
                   }
@@ -580,7 +580,7 @@ describe('Custom deliveries', () => {
                     "unix_millis_action_duration_estimate": 60000,
                     "category": "delivery_pickup",
                     "description": {
-                      "cart_id": "test_second_cart_id",
+                      "cart_id": "",
                       "pickup_lot": "test_second_pickup_lot"
                     }
                   }
@@ -662,12 +662,11 @@ describe('Custom deliveries', () => {
 
     const description: DoubleComposeDeliveryTaskDescription =
       makeDefaultDoubleComposeDeliveryTaskDescription();
-    let firstPickupPhase = cartPickupPhaseInsertPickup(
+    const firstPickupPhase = cartPickupPhaseInsertPickup(
       description.phases[0],
       'test_first_pickup_place',
       'test_first_pickup_lot',
     );
-    firstPickupPhase = cartPickupPhaseInsertCartId(firstPickupPhase, 'test_first_cart_id');
     let firstDeliveryPhase = deliveryPhaseInsertDropoff(
       description.phases[1],
       'test_first_dropoff_place',
@@ -677,12 +676,11 @@ describe('Custom deliveries', () => {
       'test_waypoint_2',
       'test_waypoint_3',
     ]);
-    let secondPickupPhase = cartPickupPhaseInsertPickup(
+    const secondPickupPhase = cartPickupPhaseInsertPickup(
       description.phases[3],
       'test_second_pickup_place',
       'test_second_pickup_lot',
     );
-    secondPickupPhase = cartPickupPhaseInsertCartId(secondPickupPhase, 'test_second_cart_id');
     let secondDeliveryPhase = deliveryPhaseInsertDropoff(
       description.phases[4],
       'test_second_dropoff_place',

--- a/packages/react-components/lib/tasks/types/delivery-custom.tsx
+++ b/packages/react-components/lib/tasks/types/delivery-custom.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import { TaskBookingLabels } from '../booking-label';
 import { TaskDefinition } from '../create-task';
-import { isNonEmptyString } from './utils';
 
 export const DeliveryPickupTaskDefinition: TaskDefinition = {
   taskDefinitionId: 'delivery_pickup',
@@ -20,6 +19,12 @@ export const DeliverySequentialLotPickupTaskDefinition: TaskDefinition = {
 export const DeliveryAreaPickupTaskDefinition: TaskDefinition = {
   taskDefinitionId: 'delivery_area_pickup',
   taskDisplayName: 'Delivery - Area pick up',
+  requestCategory: 'compose',
+};
+
+export const DoubleComposeDeliveryTaskDefinition: TaskDefinition = {
+  taskDefinitionId: 'double-compose-delivery',
+  taskDisplayName: 'Double Compose Delivery',
   requestCategory: 'compose',
 };
 
@@ -61,7 +66,7 @@ interface CartCustomPickupPhase {
   };
 }
 
-interface CartPickupPhase {
+export interface CartPickupPhase {
   activity: {
     category: string;
     description: {
@@ -104,7 +109,7 @@ interface OnCancelDropoff {
   ];
 }
 
-interface DeliveryWithCancellationPhase {
+export interface DeliveryWithCancellationPhase {
   activity: {
     category: string;
     description: {
@@ -141,6 +146,18 @@ export interface DeliveryPickupTaskDescription {
   ];
 }
 
+export interface DoubleComposeDeliveryTaskDescription {
+  category: string;
+  phases: [
+    first_pickup_phase: CartPickupPhase,
+    first_delivery_phase: DeliveryWithCancellationPhase,
+    first_dropoff_phase: CartDropoffPhase,
+    second_pickup_phase: CartPickupPhase,
+    second_delivery_phase: DeliveryWithCancellationPhase,
+    second_dropoff_phase: CartDropoffPhase,
+  ];
+}
+
 export function makeDeliveryPickupTaskBookingLabel(
   task_description: DeliveryPickupTaskDescription,
 ): TaskBookingLabels {
@@ -164,6 +181,26 @@ export function makeDeliveryCustomTaskBookingLabel(
     pickup: pickupDescription.pickup_zone,
     destination: task_description.phases[1].activity.description.activities[0].description,
     cart_id: pickupDescription.cart_id,
+  };
+}
+
+export function makeDoubleComposeDeliveryTaskBookingLabel(
+  task_description: DoubleComposeDeliveryTaskDescription,
+): TaskBookingLabels {
+  const firstPickupDescription =
+    task_description.phases[0].activity.description.activities[1].description.description;
+  const secondPickupDescription =
+    task_description.phases[3].activity.description.activities[1].description.description;
+
+  const pickups = `${firstPickupDescription.pickup_lot}(1), ${secondPickupDescription.pickup_lot}(2)`;
+  const dropoffs = `${task_description.phases[1].activity.description.activities[0].description}(1), ${task_description.phases[4].activity.description.activities[0].description}(2)`;
+  const cartIds = `${firstPickupDescription.pickup_lot}(1), ${secondPickupDescription.cart_id}(2)`;
+
+  return {
+    task_definition_id: task_description.category,
+    pickup: pickups,
+    destination: dropoffs,
+    cart_id: cartIds,
   };
 }
 
@@ -193,6 +230,43 @@ export function makeDeliveryPickupTaskShortDescription(
   }
 
   return '[Unknown] delivery pickup task';
+}
+
+export function makeDoubleComposeDeliveryTaskShortDescription(
+  desc: DoubleComposeDeliveryTaskDescription,
+  taskDisplayName: string | undefined,
+): string {
+  try {
+    const firstGoToPickup: GoToPlaceActivity = desc.phases[0].activity.description.activities[0];
+    const firstPickup: LotPickupActivity = desc.phases[0].activity.description.activities[1];
+    const firstCartId = firstPickup.description.description.cart_id;
+    const firstGoToDropoff: GoToPlaceActivity = desc.phases[1].activity.description.activities[0];
+
+    const secondGoToPickup: GoToPlaceActivity = desc.phases[3].activity.description.activities[0];
+    const secondPickup: LotPickupActivity = desc.phases[3].activity.description.activities[1];
+    const secondCartId = secondPickup.description.description.cart_id;
+    const secondGoToDropoff: GoToPlaceActivity = desc.phases[4].activity.description.activities[0];
+
+    return `[${
+      taskDisplayName ?? DeliveryPickupTaskDefinition.taskDisplayName
+    }] payload [${firstCartId}] from [${firstGoToPickup.description}] to [${
+      firstGoToDropoff.description
+    }], then payload [${secondCartId}] from [${secondGoToPickup.description}] to [${
+      secondGoToDropoff.description
+    }]`;
+  } catch (e) {
+    try {
+      const descriptionString = JSON.stringify(desc);
+      console.error(descriptionString);
+      return descriptionString;
+    } catch (e) {
+      console.error(
+        `Failed to parse task description of double compose delivery task: ${(e as Error).message}`,
+      );
+    }
+  }
+
+  return '[Unknown] double compose delivery task';
 }
 
 export function makeDeliveryCustomTaskShortDescription(
@@ -243,12 +317,42 @@ const isDeliveryPickupTaskDescriptionValid = (
   const pickup = taskDescription.phases[0].activity.description.activities[1];
   const goToDropoff = taskDescription.phases[1].activity.description.activities[0];
   return (
-    isNonEmptyString(goToPickup.description) &&
+    goToPickup.description.length > 0 &&
     Object.keys(pickupPoints).includes(goToPickup.description) &&
     pickupPoints[goToPickup.description] === pickup.description.description.pickup_lot &&
-    isNonEmptyString(pickup.description.description.cart_id) &&
-    isNonEmptyString(goToDropoff.description) &&
+    pickup.description.description.cart_id.length > 0 &&
+    goToDropoff.description.length > 0 &&
     Object.keys(dropoffPoints).includes(goToDropoff.description)
+  );
+};
+
+const isDoubleComposeDeliveryTaskDescriptionValid = (
+  taskDescription: DoubleComposeDeliveryTaskDescription,
+  pickupPoints: Record<string, string>,
+  dropoffPoints: Record<string, string>,
+): boolean => {
+  const firstGoToPickup = taskDescription.phases[0].activity.description.activities[0];
+  const firstPickup = taskDescription.phases[0].activity.description.activities[1];
+  const firstGoToDropoff = taskDescription.phases[1].activity.description.activities[0];
+
+  const secondGoToPickup = taskDescription.phases[3].activity.description.activities[0];
+  const secondPickup = taskDescription.phases[3].activity.description.activities[1];
+  const secondGoToDropoff = taskDescription.phases[4].activity.description.activities[0];
+
+  return (
+    firstGoToPickup.description.length > 0 &&
+    Object.keys(pickupPoints).includes(firstGoToPickup.description) &&
+    pickupPoints[firstGoToPickup.description] === firstPickup.description.description.pickup_lot &&
+    firstPickup.description.description.cart_id.length > 0 &&
+    firstGoToDropoff.description.length > 0 &&
+    Object.keys(dropoffPoints).includes(firstGoToDropoff.description) &&
+    secondGoToPickup.description.length > 0 &&
+    Object.keys(pickupPoints).includes(secondGoToPickup.description) &&
+    pickupPoints[secondGoToPickup.description] ===
+      secondPickup.description.description.pickup_lot &&
+    secondPickup.description.description.cart_id.length > 0 &&
+    secondGoToDropoff.description.length > 0 &&
+    Object.keys(dropoffPoints).includes(secondGoToDropoff.description)
   );
 };
 
@@ -261,47 +365,45 @@ const isDeliveryCustomTaskDescriptionValid = (
   const pickup = taskDescription.phases[0].activity.description.activities[1];
   const goToDropoff = taskDescription.phases[1].activity.description.activities[0];
   return (
-    isNonEmptyString(goToPickup.description) &&
-    isNonEmptyString(pickup.description.description.pickup_zone) &&
+    goToPickup.description.length > 0 &&
+    pickup.description.description.pickup_zone.length > 0 &&
     pickupZones.includes(pickup.description.description.pickup_zone) &&
-    isNonEmptyString(pickup.description.description.cart_id) &&
-    isNonEmptyString(goToDropoff.description) &&
+    pickup.description.description.cart_id.length > 0 &&
+    goToDropoff.description.length > 0 &&
     dropoffPoints.includes(goToDropoff.description)
   );
 };
 
-export function deliveryInsertPickup(
-  taskDescription: DeliveryPickupTaskDescription,
+export function cartPickupPhaseInsertPickup(
+  phase: CartPickupPhase,
   pickupPlace: string,
   pickupLot: string,
-): DeliveryPickupTaskDescription {
-  taskDescription.phases[0].activity.description.activities[0].description = pickupPlace;
-  taskDescription.phases[0].activity.description.activities[1].description.description.pickup_lot =
-    pickupLot;
-  return taskDescription;
+): CartPickupPhase {
+  phase.activity.description.activities[0].description = pickupPlace;
+  phase.activity.description.activities[1].description.description.pickup_lot = pickupLot;
+  return phase;
 }
 
-export function deliveryInsertCartId(
-  taskDescription: DeliveryPickupTaskDescription,
+export function cartPickupPhaseInsertCartId(
+  phase: CartPickupPhase,
   cartId: string,
-): DeliveryPickupTaskDescription {
-  taskDescription.phases[0].activity.description.activities[1].description.description.cart_id =
-    cartId;
-  return taskDescription;
+): CartPickupPhase {
+  phase.activity.description.activities[1].description.description.cart_id = cartId;
+  return phase;
 }
 
-export function deliveryInsertDropoff(
-  taskDescription: DeliveryPickupTaskDescription,
+export function deliveryPhaseInsertDropoff(
+  phase: DeliveryWithCancellationPhase,
   dropoffPlace: string,
-): DeliveryPickupTaskDescription {
-  taskDescription.phases[1].activity.description.activities[0].description = dropoffPlace;
-  return taskDescription;
+): DeliveryWithCancellationPhase {
+  phase.activity.description.activities[0].description = dropoffPlace;
+  return phase;
 }
 
-export function deliveryInsertOnCancel(
-  taskDescription: DeliveryPickupTaskDescription,
+export function deliveryPhaseInsertOnCancel(
+  phase: DeliveryWithCancellationPhase,
   onCancelPlaces: string[],
-): DeliveryPickupTaskDescription {
+): DeliveryWithCancellationPhase {
   const goToOneOfThePlaces: GoToOneOfThePlacesActivity = {
     category: 'go_to_place',
     description: {
@@ -330,8 +432,8 @@ export function deliveryInsertOnCancel(
     category: 'sequence',
     description: [goToOneOfThePlaces, deliveryDropoff],
   };
-  taskDescription.phases[1].on_cancel = [onCancelDropoff];
-  return taskDescription;
+  phase.on_cancel = [onCancelDropoff];
+  return phase;
 }
 
 interface DeliveryPickupTaskFormProps {
@@ -369,15 +471,23 @@ export function DeliveryPickupTaskForm({
           value={taskDesc.phases[0].activity.description.activities[0].description}
           onInputChange={(_ev, newValue) => {
             const pickupLot = pickupPoints[newValue] ?? '';
-            let newTaskDesc = { ...taskDesc };
-            newTaskDesc = deliveryInsertPickup(newTaskDesc, newValue, pickupLot);
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[0] = cartPickupPhaseInsertPickup(
+              newTaskDesc.phases[0],
+              newValue,
+              pickupLot,
+            );
             onInputChange(newTaskDesc);
           }}
           onBlur={(ev) => {
             const place = (ev.target as HTMLInputElement).value;
             const pickupLot = pickupPoints[place] ?? '';
-            let newTaskDesc = { ...taskDesc };
-            newTaskDesc = deliveryInsertPickup(newTaskDesc, place, pickupLot);
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[0] = cartPickupPhaseInsertPickup(
+              newTaskDesc.phases[0],
+              place,
+              pickupLot,
+            );
             onInputChange(newTaskDesc);
           }}
           sx={{
@@ -412,13 +522,16 @@ export function DeliveryPickupTaskForm({
           }
           getOptionLabel={(option) => option}
           onInputChange={(_ev, newValue) => {
-            let newTaskDesc = { ...taskDesc };
-            newTaskDesc = deliveryInsertCartId(newTaskDesc, newValue);
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[0] = cartPickupPhaseInsertCartId(newTaskDesc.phases[0], newValue);
             onInputChange(newTaskDesc);
           }}
           onBlur={(ev) => {
-            let newTaskDesc = { ...taskDesc };
-            newTaskDesc = deliveryInsertCartId(newTaskDesc, (ev.target as HTMLInputElement).value);
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[0] = cartPickupPhaseInsertCartId(
+              newTaskDesc.phases[0],
+              (ev.target as HTMLInputElement).value,
+            );
             onInputChange(newTaskDesc);
           }}
           sx={{
@@ -449,13 +562,16 @@ export function DeliveryPickupTaskForm({
           options={Object.keys(dropoffPoints).sort()}
           value={taskDesc.phases[1].activity.description.activities[0].description}
           onInputChange={(_ev, newValue) => {
-            let newTaskDesc = { ...taskDesc };
-            newTaskDesc = deliveryInsertDropoff(newTaskDesc, newValue);
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[1] = deliveryPhaseInsertDropoff(newTaskDesc.phases[1], newValue);
             onInputChange(newTaskDesc);
           }}
           onBlur={(ev) => {
-            let newTaskDesc = { ...taskDesc };
-            newTaskDesc = deliveryInsertDropoff(newTaskDesc, (ev.target as HTMLInputElement).value);
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[1] = deliveryPhaseInsertDropoff(
+              newTaskDesc.phases[1],
+              (ev.target as HTMLInputElement).value,
+            );
             onInputChange(newTaskDesc);
           }}
           sx={{
@@ -483,71 +599,321 @@ export function DeliveryPickupTaskForm({
   );
 }
 
-export function deliveryCustomInsertPickup(
-  taskDescription: DeliveryCustomTaskDescription,
+interface DoubleComposeDeliveryTaskFormProps {
+  taskDesc: DoubleComposeDeliveryTaskDescription;
+  pickupPoints: Record<string, string>;
+  cartIds: string[];
+  dropoffPoints: Record<string, string>;
+  onChange(taskDesc: DoubleComposeDeliveryTaskDescription): void;
+  onValidate(valid: boolean): void;
+}
+
+export function DoubleComposeDeliveryTaskForm({
+  taskDesc,
+  pickupPoints = {},
+  cartIds = [],
+  dropoffPoints = {},
+  onChange,
+  onValidate,
+}: DoubleComposeDeliveryTaskFormProps): React.JSX.Element {
+  const theme = useTheme();
+  const isScreenHeightLessThan800 = useMediaQuery('(max-height:800px)');
+  const onInputChange = (desc: DoubleComposeDeliveryTaskDescription) => {
+    onValidate(isDoubleComposeDeliveryTaskDescriptionValid(desc, pickupPoints, dropoffPoints));
+    onChange(desc);
+  };
+
+  return (
+    <Grid container spacing={theme.spacing(2)} justifyContent="left" alignItems="center">
+      <Grid item xs={5}>
+        <Autocomplete
+          id="first-pickup-location"
+          freeSolo
+          fullWidth
+          options={Object.keys(pickupPoints).sort()}
+          value={taskDesc.phases[0].activity.description.activities[0].description}
+          onInputChange={(_ev, newValue) => {
+            const pickupLot = pickupPoints[newValue] ?? '';
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[0] = cartPickupPhaseInsertPickup(
+              newTaskDesc.phases[0],
+              newValue,
+              pickupLot,
+            );
+            onInputChange(newTaskDesc);
+          }}
+          onBlur={(ev) => {
+            const place = (ev.target as HTMLInputElement).value;
+            const pickupLot = pickupPoints[place] ?? '';
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[0] = cartPickupPhaseInsertPickup(
+              newTaskDesc.phases[0],
+              place,
+              pickupLot,
+            );
+            onInputChange(newTaskDesc);
+          }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              height: isScreenHeightLessThan800 ? '3rem' : '3.5rem',
+              fontSize: isScreenHeightLessThan800 ? 14 : 20,
+            },
+          }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Cart pickup (1)"
+              required
+              InputLabelProps={{ style: { fontSize: isScreenHeightLessThan800 ? 14 : 20 } }}
+              error={
+                !Object.keys(pickupPoints).includes(
+                  taskDesc.phases[0].activity.description.activities[0].description,
+                )
+              }
+            />
+          )}
+        />
+      </Grid>
+      <Grid item xs={5}>
+        <Autocomplete
+          id="first-dropoff-location"
+          freeSolo
+          fullWidth
+          options={Object.keys(dropoffPoints).sort()}
+          value={taskDesc.phases[1].activity.description.activities[0].description}
+          onInputChange={(_ev, newValue) => {
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[1] = deliveryPhaseInsertDropoff(newTaskDesc.phases[1], newValue);
+            onInputChange(newTaskDesc);
+          }}
+          onBlur={(ev) => {
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[1] = deliveryPhaseInsertDropoff(
+              newTaskDesc.phases[1],
+              (ev.target as HTMLInputElement).value,
+            );
+            onInputChange(newTaskDesc);
+          }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              height: isScreenHeightLessThan800 ? '3rem' : '3.5rem',
+              fontSize: isScreenHeightLessThan800 ? 14 : 20,
+            },
+          }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Cart dropoff (1)"
+              required
+              InputLabelProps={{ style: { fontSize: isScreenHeightLessThan800 ? 14 : 20 } }}
+              error={
+                !Object.keys(dropoffPoints).includes(
+                  taskDesc.phases[1].activity.description.activities[0].description,
+                )
+              }
+            />
+          )}
+        />
+      </Grid>
+      <Grid item xs={2}>
+        <Autocomplete
+          id="first-cart-id"
+          freeSolo
+          fullWidth
+          options={cartIds}
+          value={
+            taskDesc.phases[0].activity.description.activities[1].description.description.cart_id
+          }
+          getOptionLabel={(option) => option}
+          onInputChange={(_ev, newValue) => {
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[0] = cartPickupPhaseInsertCartId(newTaskDesc.phases[0], newValue);
+            onInputChange(newTaskDesc);
+          }}
+          onBlur={(ev) => {
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[0] = cartPickupPhaseInsertCartId(
+              newTaskDesc.phases[0],
+              (ev.target as HTMLInputElement).value,
+            );
+            onInputChange(newTaskDesc);
+          }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              height: isScreenHeightLessThan800 ? '3rem' : '3.5rem',
+              fontSize: isScreenHeightLessThan800 ? 14 : 20,
+            },
+          }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Cart ID (1)"
+              required
+              InputLabelProps={{ style: { fontSize: isScreenHeightLessThan800 ? 14 : 20 } }}
+              error={
+                taskDesc.phases[0].activity.description.activities[1].description.description
+                  .cart_id.length === 0
+              }
+            />
+          )}
+        />
+      </Grid>
+      <Grid item xs={5}>
+        <Autocomplete
+          id="second-pickup-location"
+          freeSolo
+          fullWidth
+          options={Object.keys(pickupPoints).sort()}
+          value={taskDesc.phases[3].activity.description.activities[0].description}
+          onInputChange={(_ev, newValue) => {
+            const pickupLot = pickupPoints[newValue] ?? '';
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[3] = cartPickupPhaseInsertPickup(
+              newTaskDesc.phases[3],
+              newValue,
+              pickupLot,
+            );
+            onInputChange(newTaskDesc);
+          }}
+          onBlur={(ev) => {
+            const place = (ev.target as HTMLInputElement).value;
+            const pickupLot = pickupPoints[place] ?? '';
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[3] = cartPickupPhaseInsertPickup(
+              newTaskDesc.phases[3],
+              place,
+              pickupLot,
+            );
+            onInputChange(newTaskDesc);
+          }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              height: isScreenHeightLessThan800 ? '3rem' : '3.5rem',
+              fontSize: isScreenHeightLessThan800 ? 14 : 20,
+            },
+          }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Cart pickup (2)"
+              required
+              InputLabelProps={{ style: { fontSize: isScreenHeightLessThan800 ? 14 : 20 } }}
+              error={
+                !Object.keys(pickupPoints).includes(
+                  taskDesc.phases[3].activity.description.activities[0].description,
+                )
+              }
+            />
+          )}
+        />
+      </Grid>
+      <Grid item xs={5}>
+        <Autocomplete
+          id="second-dropoff-location"
+          freeSolo
+          fullWidth
+          options={Object.keys(dropoffPoints).sort()}
+          value={taskDesc.phases[4].activity.description.activities[0].description}
+          onInputChange={(_ev, newValue) => {
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[4] = deliveryPhaseInsertDropoff(newTaskDesc.phases[4], newValue);
+            onInputChange(newTaskDesc);
+          }}
+          onBlur={(ev) => {
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[4] = deliveryPhaseInsertDropoff(
+              newTaskDesc.phases[4],
+              (ev.target as HTMLInputElement).value,
+            );
+            onInputChange(newTaskDesc);
+          }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              height: isScreenHeightLessThan800 ? '3rem' : '3.5rem',
+              fontSize: isScreenHeightLessThan800 ? 14 : 20,
+            },
+          }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Cart dropoff (2)"
+              required
+              InputLabelProps={{ style: { fontSize: isScreenHeightLessThan800 ? 14 : 20 } }}
+              error={
+                !Object.keys(dropoffPoints).includes(
+                  taskDesc.phases[4].activity.description.activities[0].description,
+                )
+              }
+            />
+          )}
+        />
+      </Grid>
+      <Grid item xs={2}>
+        <Autocomplete
+          id="second-cart-id"
+          freeSolo
+          fullWidth
+          options={cartIds}
+          value={
+            taskDesc.phases[3].activity.description.activities[1].description.description.cart_id
+          }
+          getOptionLabel={(option) => option}
+          onInputChange={(_ev, newValue) => {
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[3] = cartPickupPhaseInsertCartId(newTaskDesc.phases[3], newValue);
+            onInputChange(newTaskDesc);
+          }}
+          onBlur={(ev) => {
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[3] = cartPickupPhaseInsertCartId(
+              newTaskDesc.phases[3],
+              (ev.target as HTMLInputElement).value,
+            );
+            onInputChange(newTaskDesc);
+          }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              height: isScreenHeightLessThan800 ? '3rem' : '3.5rem',
+              fontSize: isScreenHeightLessThan800 ? 14 : 20,
+            },
+          }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Cart ID (2)"
+              required
+              InputLabelProps={{ style: { fontSize: isScreenHeightLessThan800 ? 14 : 20 } }}
+              error={
+                taskDesc.phases[3].activity.description.activities[1].description.description
+                  .cart_id.length === 0
+              }
+            />
+          )}
+        />
+      </Grid>
+    </Grid>
+  );
+}
+
+export function cartCustomPickupPhaseInsertPickup(
+  phase: CartCustomPickupPhase,
   pickupPlace: string,
   pickupZone: string,
-): DeliveryCustomTaskDescription {
-  taskDescription.phases[0].activity.description.activities[0].description = pickupPlace;
-  taskDescription.phases[0].activity.description.activities[1].description.description.pickup_zone =
-    pickupZone;
-  return taskDescription;
+): CartCustomPickupPhase {
+  phase.activity.description.activities[0].description = pickupPlace;
+  phase.activity.description.activities[1].description.description.pickup_zone = pickupZone;
+  return phase;
 }
 
-export function deliveryCustomInsertCartId(
-  taskDescription: DeliveryCustomTaskDescription,
+export function cartCustomPickupPhaseInsertCartId(
+  phase: CartCustomPickupPhase,
   cartId: string,
-): DeliveryCustomTaskDescription {
-  taskDescription.phases[0].activity.description.activities[1].description.description.cart_id =
-    cartId;
-  return taskDescription;
+): CartCustomPickupPhase {
+  phase.activity.description.activities[1].description.description.cart_id = cartId;
+  return phase;
 }
 
-export function deliveryCustomInsertDropoff(
-  taskDescription: DeliveryCustomTaskDescription,
-  dropoffPlace: string,
-): DeliveryCustomTaskDescription {
-  taskDescription.phases[1].activity.description.activities[0].description = dropoffPlace;
-  return taskDescription;
-}
-
-export function deliveryCustomInsertOnCancel(
-  taskDescription: DeliveryCustomTaskDescription,
-  onCancelPlaces: string[],
-): DeliveryCustomTaskDescription {
-  const goToOneOfThePlaces: GoToOneOfThePlacesActivity = {
-    category: 'go_to_place',
-    description: {
-      one_of: onCancelPlaces.map((placeName) => {
-        return {
-          waypoint: placeName,
-        };
-      }),
-      constraints: [
-        {
-          category: 'prefer_same_map',
-          description: '',
-        },
-      ],
-    },
-  };
-  const deliveryDropoff: DropoffActivity = {
-    category: 'perform_action',
-    description: {
-      unix_millis_action_duration_estimate: 60000,
-      category: 'delivery_dropoff',
-      description: {},
-    },
-  };
-  const onCancelDropoff: OnCancelDropoff = {
-    category: 'sequence',
-    description: [goToOneOfThePlaces, deliveryDropoff],
-  };
-  taskDescription.phases[1].on_cancel = [onCancelDropoff];
-  return taskDescription;
-}
-
-interface DeliveryCustomProps {
+export interface DeliveryCustomProps {
   taskDesc: DeliveryCustomTaskDescription;
   pickupZones: string[];
   cartIds: string[];
@@ -581,14 +947,22 @@ export function DeliveryCustomTaskForm({
           options={pickupZones.sort()}
           value={taskDesc.phases[0].activity.description.activities[0].description}
           onInputChange={(_ev, newValue) => {
-            let newTaskDesc = { ...taskDesc };
-            newTaskDesc = deliveryCustomInsertPickup(newTaskDesc, newValue, newValue);
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[0] = cartCustomPickupPhaseInsertPickup(
+              newTaskDesc.phases[0],
+              newValue,
+              newValue,
+            );
             onInputChange(newTaskDesc);
           }}
           onBlur={(ev) => {
             const zone = (ev.target as HTMLInputElement).value;
-            let newTaskDesc = { ...taskDesc };
-            newTaskDesc = deliveryCustomInsertPickup(newTaskDesc, zone, zone);
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[0] = cartCustomPickupPhaseInsertPickup(
+              newTaskDesc.phases[0],
+              zone,
+              zone,
+            );
             onInputChange(newTaskDesc);
           }}
           sx={{
@@ -623,14 +997,17 @@ export function DeliveryCustomTaskForm({
           }
           getOptionLabel={(option) => option}
           onInputChange={(_ev, newValue) => {
-            let newTaskDesc = { ...taskDesc };
-            newTaskDesc = deliveryCustomInsertCartId(newTaskDesc, newValue);
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[0] = cartCustomPickupPhaseInsertCartId(
+              newTaskDesc.phases[0],
+              newValue,
+            );
             onInputChange(newTaskDesc);
           }}
           onBlur={(ev) => {
-            let newTaskDesc = { ...taskDesc };
-            newTaskDesc = deliveryCustomInsertCartId(
-              newTaskDesc,
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[0] = cartCustomPickupPhaseInsertCartId(
+              newTaskDesc.phases[0],
               (ev.target as HTMLInputElement).value,
             );
             onInputChange(newTaskDesc);
@@ -663,14 +1040,14 @@ export function DeliveryCustomTaskForm({
           options={dropoffPoints.sort()}
           value={taskDesc.phases[1].activity.description.activities[0].description}
           onInputChange={(_ev, newValue) => {
-            let newTaskDesc = { ...taskDesc };
-            newTaskDesc = deliveryCustomInsertDropoff(newTaskDesc, newValue);
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[1] = deliveryPhaseInsertDropoff(newTaskDesc.phases[1], newValue);
             onInputChange(newTaskDesc);
           }}
           onBlur={(ev) => {
-            let newTaskDesc = { ...taskDesc };
-            newTaskDesc = deliveryCustomInsertDropoff(
-              newTaskDesc,
+            const newTaskDesc = { ...taskDesc };
+            newTaskDesc.phases[1] = deliveryPhaseInsertDropoff(
+              newTaskDesc.phases[1],
               (ev.target as HTMLInputElement).value,
             );
             onInputChange(newTaskDesc);
@@ -704,6 +1081,124 @@ export function makeDefaultDeliveryPickupTaskDescription(): DeliveryPickupTaskDe
   return {
     category: 'delivery_pickup',
     phases: [
+      {
+        activity: {
+          category: 'sequence',
+          description: {
+            activities: [
+              {
+                category: 'go_to_place',
+                description: '',
+              },
+              {
+                category: 'perform_action',
+                description: {
+                  unix_millis_action_duration_estimate: 60000,
+                  category: 'delivery_pickup',
+                  description: {
+                    cart_id: '',
+                    pickup_lot: '',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+      {
+        activity: {
+          category: 'sequence',
+          description: {
+            activities: [
+              {
+                category: 'go_to_place',
+                description: '',
+              },
+            ],
+          },
+        },
+        on_cancel: [],
+      },
+      {
+        activity: {
+          category: 'sequence',
+          description: {
+            activities: [
+              {
+                category: 'perform_action',
+                description: {
+                  unix_millis_action_duration_estimate: 60000,
+                  category: 'delivery_dropoff',
+                  description: {},
+                },
+              },
+            ],
+          },
+        },
+      },
+    ],
+  };
+}
+
+export function makeDefaultDoubleComposeDeliveryTaskDescription(): DoubleComposeDeliveryTaskDescription {
+  return {
+    category: 'delivery_pickup',
+    phases: [
+      {
+        activity: {
+          category: 'sequence',
+          description: {
+            activities: [
+              {
+                category: 'go_to_place',
+                description: '',
+              },
+              {
+                category: 'perform_action',
+                description: {
+                  unix_millis_action_duration_estimate: 60000,
+                  category: 'delivery_pickup',
+                  description: {
+                    cart_id: '',
+                    pickup_lot: '',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+      {
+        activity: {
+          category: 'sequence',
+          description: {
+            activities: [
+              {
+                category: 'go_to_place',
+                description: '',
+              },
+            ],
+          },
+        },
+        on_cancel: [],
+      },
+      {
+        activity: {
+          category: 'sequence',
+          description: {
+            activities: [
+              {
+                category: 'perform_action',
+                description: {
+                  unix_millis_action_duration_estimate: 60000,
+                  category: 'delivery_dropoff',
+                  description: {},
+                },
+              },
+            ],
+          },
+        },
+      },
       {
         activity: {
           category: 'sequence',

--- a/packages/react-components/lib/tasks/types/delivery-custom.tsx
+++ b/packages/react-components/lib/tasks/types/delivery-custom.tsx
@@ -194,13 +194,11 @@ export function makeDoubleComposeDeliveryTaskBookingLabel(
 
   const pickups = `${firstPickupDescription.pickup_lot}(1), ${secondPickupDescription.pickup_lot}(2)`;
   const dropoffs = `${task_description.phases[1].activity.description.activities[0].description}(1), ${task_description.phases[4].activity.description.activities[0].description}(2)`;
-  const cartIds = `${firstPickupDescription.pickup_lot}(1), ${secondPickupDescription.cart_id}(2)`;
 
   return {
     task_definition_id: task_description.category,
     pickup: pickups,
     destination: dropoffs,
-    cart_id: cartIds,
   };
 }
 
@@ -238,20 +236,14 @@ export function makeDoubleComposeDeliveryTaskShortDescription(
 ): string {
   try {
     const firstGoToPickup: GoToPlaceActivity = desc.phases[0].activity.description.activities[0];
-    const firstPickup: LotPickupActivity = desc.phases[0].activity.description.activities[1];
-    const firstCartId = firstPickup.description.description.cart_id;
     const firstGoToDropoff: GoToPlaceActivity = desc.phases[1].activity.description.activities[0];
 
     const secondGoToPickup: GoToPlaceActivity = desc.phases[3].activity.description.activities[0];
-    const secondPickup: LotPickupActivity = desc.phases[3].activity.description.activities[1];
-    const secondCartId = secondPickup.description.description.cart_id;
     const secondGoToDropoff: GoToPlaceActivity = desc.phases[4].activity.description.activities[0];
 
-    return `[${
-      taskDisplayName ?? DeliveryPickupTaskDefinition.taskDisplayName
-    }] payload [${firstCartId}] from [${firstGoToPickup.description}] to [${
-      firstGoToDropoff.description
-    }], then payload [${secondCartId}] from [${secondGoToPickup.description}] to [${
+    return `[${taskDisplayName ?? DeliveryPickupTaskDefinition.taskDisplayName}] from [${
+      firstGoToPickup.description
+    }] to [${firstGoToDropoff.description}], then from [${secondGoToPickup.description}] to [${
       secondGoToDropoff.description
     }]`;
   } catch (e) {
@@ -343,14 +335,12 @@ const isDoubleComposeDeliveryTaskDescriptionValid = (
     firstGoToPickup.description.length > 0 &&
     Object.keys(pickupPoints).includes(firstGoToPickup.description) &&
     pickupPoints[firstGoToPickup.description] === firstPickup.description.description.pickup_lot &&
-    firstPickup.description.description.cart_id.length > 0 &&
     firstGoToDropoff.description.length > 0 &&
     Object.keys(dropoffPoints).includes(firstGoToDropoff.description) &&
     secondGoToPickup.description.length > 0 &&
     Object.keys(pickupPoints).includes(secondGoToPickup.description) &&
     pickupPoints[secondGoToPickup.description] ===
       secondPickup.description.description.pickup_lot &&
-    secondPickup.description.description.cart_id.length > 0 &&
     secondGoToDropoff.description.length > 0 &&
     Object.keys(dropoffPoints).includes(secondGoToDropoff.description)
   );
@@ -602,7 +592,6 @@ export function DeliveryPickupTaskForm({
 interface DoubleComposeDeliveryTaskFormProps {
   taskDesc: DoubleComposeDeliveryTaskDescription;
   pickupPoints: Record<string, string>;
-  cartIds: string[];
   dropoffPoints: Record<string, string>;
   onChange(taskDesc: DoubleComposeDeliveryTaskDescription): void;
   onValidate(valid: boolean): void;
@@ -611,7 +600,6 @@ interface DoubleComposeDeliveryTaskFormProps {
 export function DoubleComposeDeliveryTaskForm({
   taskDesc,
   pickupPoints = {},
-  cartIds = [],
   dropoffPoints = {},
   onChange,
   onValidate,
@@ -625,7 +613,7 @@ export function DoubleComposeDeliveryTaskForm({
 
   return (
     <Grid container spacing={theme.spacing(2)} justifyContent="left" alignItems="center">
-      <Grid item xs={5}>
+      <Grid item xs={6}>
         <Autocomplete
           id="first-pickup-location"
           freeSolo
@@ -674,7 +662,7 @@ export function DoubleComposeDeliveryTaskForm({
           )}
         />
       </Grid>
-      <Grid item xs={5}>
+      <Grid item xs={6}>
         <Autocomplete
           id="first-dropoff-location"
           freeSolo
@@ -715,50 +703,7 @@ export function DoubleComposeDeliveryTaskForm({
           )}
         />
       </Grid>
-      <Grid item xs={2}>
-        <Autocomplete
-          id="first-cart-id"
-          freeSolo
-          fullWidth
-          options={cartIds}
-          value={
-            taskDesc.phases[0].activity.description.activities[1].description.description.cart_id
-          }
-          getOptionLabel={(option) => option}
-          onInputChange={(_ev, newValue) => {
-            const newTaskDesc = { ...taskDesc };
-            newTaskDesc.phases[0] = cartPickupPhaseInsertCartId(newTaskDesc.phases[0], newValue);
-            onInputChange(newTaskDesc);
-          }}
-          onBlur={(ev) => {
-            const newTaskDesc = { ...taskDesc };
-            newTaskDesc.phases[0] = cartPickupPhaseInsertCartId(
-              newTaskDesc.phases[0],
-              (ev.target as HTMLInputElement).value,
-            );
-            onInputChange(newTaskDesc);
-          }}
-          sx={{
-            '& .MuiOutlinedInput-root': {
-              height: isScreenHeightLessThan800 ? '3rem' : '3.5rem',
-              fontSize: isScreenHeightLessThan800 ? 14 : 20,
-            },
-          }}
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label="Cart ID (1)"
-              required
-              InputLabelProps={{ style: { fontSize: isScreenHeightLessThan800 ? 14 : 20 } }}
-              error={
-                taskDesc.phases[0].activity.description.activities[1].description.description
-                  .cart_id.length === 0
-              }
-            />
-          )}
-        />
-      </Grid>
-      <Grid item xs={5}>
+      <Grid item xs={6}>
         <Autocomplete
           id="second-pickup-location"
           freeSolo
@@ -807,7 +752,7 @@ export function DoubleComposeDeliveryTaskForm({
           )}
         />
       </Grid>
-      <Grid item xs={5}>
+      <Grid item xs={6}>
         <Autocomplete
           id="second-dropoff-location"
           freeSolo
@@ -843,49 +788,6 @@ export function DoubleComposeDeliveryTaskForm({
                 !Object.keys(dropoffPoints).includes(
                   taskDesc.phases[4].activity.description.activities[0].description,
                 )
-              }
-            />
-          )}
-        />
-      </Grid>
-      <Grid item xs={2}>
-        <Autocomplete
-          id="second-cart-id"
-          freeSolo
-          fullWidth
-          options={cartIds}
-          value={
-            taskDesc.phases[3].activity.description.activities[1].description.description.cart_id
-          }
-          getOptionLabel={(option) => option}
-          onInputChange={(_ev, newValue) => {
-            const newTaskDesc = { ...taskDesc };
-            newTaskDesc.phases[3] = cartPickupPhaseInsertCartId(newTaskDesc.phases[3], newValue);
-            onInputChange(newTaskDesc);
-          }}
-          onBlur={(ev) => {
-            const newTaskDesc = { ...taskDesc };
-            newTaskDesc.phases[3] = cartPickupPhaseInsertCartId(
-              newTaskDesc.phases[3],
-              (ev.target as HTMLInputElement).value,
-            );
-            onInputChange(newTaskDesc);
-          }}
-          sx={{
-            '& .MuiOutlinedInput-root': {
-              height: isScreenHeightLessThan800 ? '3rem' : '3.5rem',
-              fontSize: isScreenHeightLessThan800 ? 14 : 20,
-            },
-          }}
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label="Cart ID (2)"
-              required
-              InputLabelProps={{ style: { fontSize: isScreenHeightLessThan800 ? 14 : 20 } }}
-              error={
-                taskDesc.phases[3].activity.description.activities[1].description.description
-                  .cart_id.length === 0
               }
             />
           )}

--- a/packages/react-components/lib/tasks/types/delivery.tsx
+++ b/packages/react-components/lib/tasks/types/delivery.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { PositiveIntField } from '../../form-inputs';
 import { TaskBookingLabels } from '../booking-label';
 import { TaskDefinition } from '../create-task';
-import { isNonEmptyString, isPositiveNumber } from './utils';
 
 export const DeliveryTaskDefinition: TaskDefinition = {
   taskDefinitionId: 'delivery',
@@ -39,10 +38,10 @@ export function makeDeliveryTaskBookingLabel(
 
 function isTaskPlaceValid(place: TaskPlace): boolean {
   return (
-    isNonEmptyString(place.place) &&
-    isNonEmptyString(place.handler) &&
-    isNonEmptyString(place.payload.sku) &&
-    isPositiveNumber(place.payload.quantity)
+    place.place.length > 0 &&
+    place.handler.length > 0 &&
+    place.payload.sku.length > 0 &&
+    place.payload.quantity > 0
   );
 }
 

--- a/packages/react-components/lib/tasks/types/utils.ts
+++ b/packages/react-components/lib/tasks/types/utils.ts
@@ -23,24 +23,19 @@ import {
   DeliveryAreaPickupTaskDefinition,
   DeliveryPickupTaskDefinition,
   DeliverySequentialLotPickupTaskDefinition,
+  DoubleComposeDeliveryTaskDefinition,
   makeDefaultDeliveryCustomTaskDescription,
   makeDefaultDeliveryPickupTaskDescription,
+  makeDefaultDoubleComposeDeliveryTaskDescription,
   makeDeliveryCustomTaskShortDescription,
   makeDeliveryPickupTaskShortDescription,
+  makeDoubleComposeDeliveryTaskShortDescription,
 } from './delivery-custom';
 import {
   makeDefaultPatrolTaskDescription,
   makePatrolTaskShortDescription,
   PatrolTaskDefinition,
 } from './patrol';
-
-export function isNonEmptyString(value: string): boolean {
-  return value.length > 0;
-}
-
-export function isPositiveNumber(value: number): boolean {
-  return value > 0;
-}
 
 function rawStringFromJsonRequest(taskRequest: TaskRequest): string | undefined {
   try {
@@ -84,6 +79,11 @@ export function getShortDescription(
     case DeliverySequentialLotPickupTaskDefinition.taskDefinitionId:
     case DeliveryAreaPickupTaskDefinition.taskDefinitionId:
       return makeDeliveryCustomTaskShortDescription(taskRequest.description, taskDisplayName);
+    case DoubleComposeDeliveryTaskDefinition.taskDefinitionId:
+      return makeDoubleComposeDeliveryTaskShortDescription(
+        taskRequest.description,
+        taskDisplayName,
+      );
     case CustomComposeTaskDefinition.taskDefinitionId:
       return makeCustomComposeTaskShortDescription(taskRequest.description);
     default:
@@ -101,6 +101,8 @@ export function getDefaultTaskDefinition(taskDefinitionId: string): TaskDefiniti
       return DeliverySequentialLotPickupTaskDefinition;
     case DeliveryAreaPickupTaskDefinition.taskDefinitionId:
       return DeliveryAreaPickupTaskDefinition;
+    case DoubleComposeDeliveryTaskDefinition.taskDefinitionId:
+      return DoubleComposeDeliveryTaskDefinition;
     case DeliveryTaskDefinition.taskDefinitionId:
       return DeliveryTaskDefinition;
     case PatrolTaskDefinition.taskDefinitionId:
@@ -122,6 +124,8 @@ export function getDefaultTaskDescription(
     case DeliverySequentialLotPickupTaskDefinition.taskDefinitionId:
     case DeliveryAreaPickupTaskDefinition.taskDefinitionId:
       return makeDefaultDeliveryCustomTaskDescription(taskDefinitionId);
+    case DoubleComposeDeliveryTaskDefinition.taskDefinitionId:
+      return makeDefaultDoubleComposeDeliveryTaskDescription();
     case DeliveryTaskDefinition.taskDefinitionId:
       return makeDefaultDeliveryTaskDescription();
     case PatrolTaskDefinition.taskDefinitionId:


### PR DESCRIPTION
## What's new

* Port https://github.com/open-rmf/rmf-web/pull/963
* Port https://github.com/open-rmf/rmf-web/pull/967

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test