### PR TITLE
dashboard: simplify url utils

### DIFF
--- a/packages/dashboard/src/app-config.ts
+++ b/packages/dashboard/src/app-config.ts
@@ -3,7 +3,6 @@ import { getDefaultTaskDefinition, TaskDefinition } from 'react-components';
 
 import testConfig from '../app-config.json';
 import { Authenticator, KeycloakAuthenticator, StubAuthenticator } from './auth';
-import { BasePath } from './util/url';
 
 export interface RobotResource {
   icon?: string;
@@ -85,7 +84,7 @@ const authenticator: Authenticator = (() => {
   if (APP_CONFIG_AUTH_PROVIDER === 'keycloak') {
     return new KeycloakAuthenticator(
       APP_CONFIG.authConfig as KeycloakAuthConfig,
-      `${window.location.origin}${BasePath}/silent-check-sso.html`,
+      `${import.meta.env.BASE_URL}silent-check-sso.html`,
     );
   } else if (APP_CONFIG_AUTH_PROVIDER === 'stub') {
     return new StubAuthenticator();

--- a/packages/dashboard/src/util/url.ts
+++ b/packages/dashboard/src/util/url.ts
@@ -1,7 +1,3 @@
-export const BasePath =
-  import.meta.env.BASE_URL === undefined || import.meta.env.BASE_URL === '/'
-    ? ''
-    : import.meta.env.BASE_URL;
 /**
  * Add /* after /admin to avoid the warning
  * <Routes> (or called `useRoutes()`) at "/admin"
@@ -10,10 +6,10 @@ export const BasePath =
  * This means if you navigate deeper,
  * the parent won't match anymore and therefore the child routes will never render.
  */
-export const DashboardRoute = BasePath === '' ? '/' : BasePath;
-export const LoginRoute = `${BasePath}/login`;
-export const TasksRoute = `${BasePath}/tasks`;
-export const RobotsRoute = `${BasePath}/robots`;
-export const AdminRoute = `${BasePath}/admin/*`;
-export const CustomRoute1 = `${BasePath}/custom1`;
-export const CustomRoute2 = `${BasePath}/custom2`;
+export const DashboardRoute = import.meta.env.BASE_URL;
+export const LoginRoute = `${import.meta.env.BASE_URL}login`;
+export const TasksRoute = `${import.meta.env.BASE_URL}tasks`;
+export const RobotsRoute = `${import.meta.env.BASE_URL}robots`;
+export const AdminRoute = `${import.meta.env.BASE_URL}admin/*`;
+export const CustomRoute1 = `${import.meta.env.BASE_URL}custom1`;
+export const CustomRoute2 = `${import.meta.env.BASE_URL}custom2`;


### PR DESCRIPTION
While not explicitly mentioned, vite docs strongly suggests that `base` must end with a trailing slash https://vitejs.dev/config/shared-options#base. With this assumption, we can simplify how we build urls. This assumption is also required to fix favicon path in #989.