### PR TITLE
dashboard: better json schema

### DIFF
--- a/packages/dashboard/app-config.schema.json
+++ b/packages/dashboard/app-config.schema.json
@@ -190,7 +190,7 @@
             "additionalProperties": {
                 "$ref": "#/definitions/Resources"
             },
-            "description": "Set various resources (icons, logo etc) used. Different resource can be used based on\nthe theme, `default` is always required.",
+            "description": "Set various resources (icons, logo etc) used. Different resource can be used based on the theme, `default` is always required.",
             "properties": {
                 "default": {
                     "$ref": "#/definitions/Resources"

--- a/packages/dashboard/app-config.schema.json
+++ b/packages/dashboard/app-config.schema.json
@@ -5,6 +5,7 @@
             "description": "These will be injected at build time, they CANNOT be changed after the bundle is built.",
             "properties": {
                 "adminTab": {
+                    "description": "Whether the admin tab should be enabled, defaults to false.",
                     "type": "boolean"
                 },
                 "authProvider": {
@@ -15,9 +16,11 @@
                     "type": "string"
                 },
                 "baseUrl": {
+                    "description": "The base url that the app is served from, this MUST end with a slash.",
                     "type": "string"
                 },
                 "customTabs": {
+                    "description": "Whether custom tabs should be enabled, defaults to false.",
                     "type": "boolean"
                 }
             },
@@ -136,7 +139,7 @@
             "type": "array"
         },
         "attributionPrefix": {
-            "description": "Branding to be shown on the order of the map.",
+            "description": "Branding to be shown on the corner of the map.",
             "type": "string"
         },
         "authConfig": {

--- a/packages/dashboard/app-config.schema.json
+++ b/packages/dashboard/app-config.schema.json
@@ -26,6 +26,17 @@
             ],
             "type": "object"
         },
+        "FleetResource": {
+            "properties": {
+                "default": {
+                    "$ref": "#/definitions/RobotResource"
+                }
+            },
+            "required": [
+                "default"
+            ],
+            "type": "object"
+        },
         "KeycloakAuthConfig": {
             "properties": {
                 "clientId": {
@@ -56,27 +67,13 @@
             ],
             "type": "object"
         },
-        "Record<\"default\",Resources>": {
-            "properties": {
-                "default": {
-                    "$ref": "#/definitions/Resources"
-                }
-            },
-            "required": [
-                "default"
-            ],
-            "type": "object"
-        },
-        "Record<string,FleetResource>": {
-            "type": "object"
-        },
-        "Record<string,Resources>": {
-            "type": "object"
-        },
         "Resources": {
             "properties": {
                 "fleets": {
-                    "$ref": "#/definitions/Record<string,FleetResource>"
+                    "additionalProperties": {
+                        "$ref": "#/definitions/FleetResource"
+                    },
+                    "type": "object"
                 },
                 "logos": {
                     "$ref": "#/definitions/LogoResource"
@@ -86,6 +83,17 @@
                 "fleets",
                 "logos"
             ],
+            "type": "object"
+        },
+        "RobotResource": {
+            "properties": {
+                "icon": {
+                    "type": "string"
+                },
+                "scale": {
+                    "type": "number"
+                }
+            },
             "type": "object"
         },
         "StubAuthConfig": {
@@ -157,14 +165,18 @@
             "type": "string"
         },
         "resources": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/Record<string,Resources>"
-                },
-                {
-                    "$ref": "#/definitions/Record<\"default\",Resources>"
+            "additionalProperties": {
+                "$ref": "#/definitions/Resources"
+            },
+            "properties": {
+                "default": {
+                    "$ref": "#/definitions/Resources"
                 }
-            ]
+            },
+            "required": [
+                "default"
+            ],
+            "type": "object"
         },
         "rmfServerUrl": {
             "type": "string"

--- a/packages/dashboard/app-config.schema.json
+++ b/packages/dashboard/app-config.schema.json
@@ -2,6 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "BuildConfig": {
+            "description": "These will be injected at build time, they CANNOT be changed after the bundle is built.",
             "properties": {
                 "adminTab": {
                     "type": "boolean"
@@ -59,6 +60,7 @@
         "LogoResource": {
             "properties": {
                 "header": {
+                    "description": "Path to an image to be used as the logo on the app bar.",
                     "type": "string"
                 }
             },
@@ -88,9 +90,11 @@
         "RobotResource": {
             "properties": {
                 "icon": {
+                    "description": "Path to an image to be used as the robot's icon.",
                     "type": "string"
                 },
                 "scale": {
+                    "description": "Scale of the image to match the robot's dimensions.",
                     "type": "number"
                 }
             },
@@ -100,11 +104,20 @@
             "type": "object"
         },
         "TaskResource": {
+            "description": "Configuration for task definitions.",
             "properties": {
                 "displayName": {
+                    "description": "Configure the display name for the task definition.",
                     "type": "string"
                 },
                 "taskDefinitionId": {
+                    "description": "The task definition to configure.",
+                    "enum": [
+                        "compose-clean",
+                        "custom_compose",
+                        "delivery",
+                        "patrol"
+                    ],
                     "type": "string"
                 }
             },
@@ -116,12 +129,14 @@
     },
     "properties": {
         "allowedTasks": {
+            "description": "List of allowed tasks that can be requested",
             "items": {
                 "$ref": "#/definitions/TaskResource"
             },
             "type": "array"
         },
         "attributionPrefix": {
+            "description": "Branding to be shown on the order of the map.",
             "type": "string"
         },
         "authConfig": {
@@ -132,7 +147,8 @@
                 {
                     "$ref": "#/definitions/KeycloakAuthConfig"
                 }
-            ]
+            ],
+            "description": "Config for the authentication provider."
         },
         "buildConfig": {
             "$ref": "#/definitions/BuildConfig"
@@ -144,30 +160,37 @@
             "type": "array"
         },
         "defaultMapLevel": {
+            "description": "The default level to be selected when the map is initially loaded.",
             "type": "string"
         },
         "defaultRobotZoom": {
+            "description": "The default zoom level when a robot is focused on the map.",
             "type": "number"
         },
         "defaultZoom": {
+            "description": "The default zoom level when the map is initially loaded.",
             "type": "number"
         },
         "helpLink": {
+            "description": "Url to be linked for the \"help\" button.",
             "type": "string"
         },
         "pickupZones": {
+            "description": "List of available pickup zones used for delivery tasks.",
             "items": {
                 "type": "string"
             },
             "type": "array"
         },
         "reportIssue": {
+            "description": "Url to be linked for the \"report issue\" button.",
             "type": "string"
         },
         "resources": {
             "additionalProperties": {
                 "$ref": "#/definitions/Resources"
             },
+            "description": "Set various resources (icons, logo etc) used. Different resource can be used based on\nthe theme, `default` is always required.",
             "properties": {
                 "default": {
                     "$ref": "#/definitions/Resources"
@@ -179,9 +202,11 @@
             "type": "object"
         },
         "rmfServerUrl": {
+            "description": "Url of the RMF api server.",
             "type": "string"
         },
         "trajectoryServerUrl": {
+            "description": "Url of the RMF trajectory server.",
             "type": "string"
         }
     },

--- a/packages/dashboard/src/app-config.ts
+++ b/packages/dashboard/src/app-config.ts
@@ -132,9 +132,21 @@ export interface RuntimeConfig {
  * These will be injected at build time, they CANNOT be changed after the bundle is built.
  */
 export interface BuildConfig {
+  /**
+   * The base url that the app is served from, this MUST end with a slash.
+   */
   baseUrl: string;
+
   authProvider: 'keycloak' | 'stub';
+
+  /**
+   * Whether custom tabs should be enabled, defaults to false.
+   */
   customTabs?: boolean;
+
+  /**
+   * Whether the admin tab should be enabled, defaults to false.
+   */
   adminTab?: boolean;
 }
 

--- a/packages/dashboard/src/app-config.ts
+++ b/packages/dashboard/src/app-config.ts
@@ -119,8 +119,7 @@ export interface RuntimeConfig {
   allowedTasks: TaskResource[];
 
   /**
-   * Set various resources (icons, logo etc) used. Different resource can be used based on
-   * the theme, `default` is always required.
+   * Set various resources (icons, logo etc) used. Different resource can be used based on the theme, `default` is always required.
    */
   resources: { [theme: string]: Resources; default: Resources };
 

--- a/packages/dashboard/src/app-config.ts
+++ b/packages/dashboard/src/app-config.ts
@@ -18,7 +18,7 @@ export interface LogoResource {
 }
 
 export interface Resources {
-  fleets: Record<string, FleetResource>;
+  fleets: { [fleetName: string]: FleetResource };
   logos: LogoResource;
 }
 
@@ -47,7 +47,7 @@ export interface RuntimeConfig {
   attributionPrefix: string;
   defaultMapLevel: string;
   allowedTasks: TaskResource[];
-  resources: Record<string, Resources> & Record<'default', Resources>;
+  resources: { [theme: string]: Resources; default: Resources };
   // FIXME(koonpeng): this is used for very specific tasks, should be removed when mission
   // system is implemented.
   cartIds: string[];

--- a/packages/dashboard/src/app-config.ts
+++ b/packages/dashboard/src/app-config.ts
@@ -5,15 +5,27 @@ import testConfig from '../app-config.json';
 import { Authenticator, KeycloakAuthenticator, StubAuthenticator } from './auth';
 
 export interface RobotResource {
+  /**
+   * Path to an image to be used as the robot's icon.
+   */
   icon?: string;
+
+  /**
+   * Scale of the image to match the robot's dimensions.
+   */
   scale?: number;
 }
 
 export interface FleetResource {
+  // TODO(koonpeng): configure robot resources based on robot model.
+  // [robotModel: string]: RobotResource;
   default: RobotResource;
 }
 
 export interface LogoResource {
+  /**
+   * Path to an image to be used as the logo on the app bar.
+   */
   header: string;
 }
 
@@ -22,8 +34,18 @@ export interface Resources {
   logos: LogoResource;
 }
 
+/**
+ * Configuration for task definitions.
+ */
 export interface TaskResource {
-  taskDefinitionId: string;
+  /**
+   * The task definition to configure.
+   */
+  taskDefinitionId: 'patrol' | 'delivery' | 'compose-clean' | 'custom_compose';
+
+  /**
+   * Configure the display name for the task definition.
+   */
   displayName?: string;
 }
 
@@ -35,25 +57,81 @@ export interface KeycloakAuthConfig {
   clientId: string;
 }
 
+/**
+ * These config are exposed as a global variable. They can be changed after the bundle is built.
+ * To do so, use a placeholder value like `__RMF_SERVER_URL__` and do a search and replace on
+ * `index.html` before serving.
+ */
 export interface RuntimeConfig {
+  /**
+   * Url of the RMF api server.
+   */
   rmfServerUrl: string;
+
+  /**
+   * Url of the RMF trajectory server.
+   */
   trajectoryServerUrl: string;
+
+  /**
+   * Config for the authentication provider.
+   */
   authConfig: KeycloakAuthConfig | StubAuthConfig;
+
+  /**
+   * Url to be linked for the "help" button.
+   */
   helpLink: string;
+
+  /**
+   * Url to be linked for the "report issue" button.
+   */
   reportIssue: string;
-  pickupZones: string[];
+
+  /**
+   * List of available pickup zones used for delivery tasks.
+   */
+  pickupZones: string[]; // FIXME(koonpeng): Should be part of task definition
+
+  /**
+   * The default zoom level when the map is initially loaded.
+   */
   defaultZoom: number;
+
+  /**
+   * The default zoom level when a robot is focused on the map.
+   */
   defaultRobotZoom: number;
+
+  /**
+   * Branding to be shown on the order of the map.
+   */
   attributionPrefix: string;
+
+  /**
+   * The default level to be selected when the map is initially loaded.
+   */
   defaultMapLevel: string;
+
+  /**
+   * List of allowed tasks that can be requested
+   */
   allowedTasks: TaskResource[];
+
+  /**
+   * Set various resources (icons, logo etc) used. Different resource can be used based on
+   * the theme, `default` is always required.
+   */
   resources: { [theme: string]: Resources; default: Resources };
+
   // FIXME(koonpeng): this is used for very specific tasks, should be removed when mission
   // system is implemented.
   cartIds: string[];
 }
 
-// these will be injected as defines and potentially be tree shaken out
+/**
+ * These will be injected at build time, they CANNOT be changed after the bundle is built.
+ */
 export interface BuildConfig {
   baseUrl: string;
   authProvider: 'keycloak' | 'stub';

--- a/packages/dashboard/src/app-config.ts
+++ b/packages/dashboard/src/app-config.ts
@@ -17,7 +17,7 @@ export interface RobotResource {
 }
 
 export interface FleetResource {
-  // TODO(koonpeng): configure robot resources based on robot model.
+  // TODO(koonpeng): configure robot resources based on robot model, this will require https://github.com/open-rmf/rmf_api_msgs/blob/main/rmf_api_msgs/schemas/robot_state.json to expose the robot model.
   // [robotModel: string]: RobotResource;
   default: RobotResource;
 }

--- a/packages/dashboard/src/app-config.ts
+++ b/packages/dashboard/src/app-config.ts
@@ -60,7 +60,7 @@ export interface KeycloakAuthConfig {
 /**
  * These config are exposed as a global variable. They can be changed after the bundle is built.
  * To do so, use a placeholder value like `__RMF_SERVER_URL__` and do a search and replace on
- * `index.html` before serving.
+ * `index.html` before serving it.
  */
 export interface RuntimeConfig {
   /**
@@ -104,7 +104,7 @@ export interface RuntimeConfig {
   defaultRobotZoom: number;
 
   /**
-   * Branding to be shown on the order of the map.
+   * Branding to be shown on the corner of the map.
    */
   attributionPrefix: string;
 


### PR DESCRIPTION
1. Add docs.
2. Use inline object over `Record` so that the generated json schema is strictly typed.