### PR TITLE
Setting camera target to most negative number to handle arbitrary large maps

### DIFF
--- a/packages/dashboard/src/components/map-app.tsx
+++ b/packages/dashboard/src/components/map-app.tsx
@@ -547,7 +547,7 @@ export const MapApp: StyledComponent<MicroAppProps & MUIStyledCommonProps<Theme>
           }}
           orthographic={true}
         >
-          <CameraControl zoom={zoom} sceneBoundingBox={sceneBoundingBox} />
+          <CameraControl zoom={zoom} />
           {!disabledLayers['Pickup & Dropoff waypoints'] &&
             waypoints
               .filter((waypoint) => waypoint.pickupHandler || waypoint.dropoffHandler)

--- a/packages/dashboard/src/components/map-app.tsx
+++ b/packages/dashboard/src/components/map-app.tsx
@@ -547,7 +547,7 @@ export const MapApp: StyledComponent<MicroAppProps & MUIStyledCommonProps<Theme>
           }}
           orthographic={true}
         >
-          <CameraControl zoom={zoom} />
+          <CameraControl zoom={zoom} sceneBoundingBox={sceneBoundingBox} />
           {!disabledLayers['Pickup & Dropoff waypoints'] &&
             waypoints
               .filter((waypoint) => waypoint.pickupHandler || waypoint.dropoffHandler)

--- a/packages/dashboard/src/components/three-fiber/camera-control.tsx
+++ b/packages/dashboard/src/components/three-fiber/camera-control.tsx
@@ -1,36 +1,25 @@
 import { useFrame, useThree } from '@react-three/fiber';
 import React, { useEffect, useRef } from 'react';
 import { Subscription } from 'rxjs';
-import { Box3, MOUSE, Sphere, Vector3 } from 'three';
+import { MOUSE, Vector3 } from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 import { AppEvents } from '../app-events';
 
 const DEFAULT_ZOOM_IN_CONSTANT = 1.2;
 const DEFAULT_ZOOM_OUT_CONSTANT = 0.8;
-const DEFAULT_CAMERA_TARGET = -10000;
-const DEFAULT_CAMERA_TARGET_MULTIPLIER = -50;
 
 interface CameraControlProps {
   zoom: number;
-  sceneBoundingBox?: Box3;
 }
 
-export const CameraControl: React.FC<CameraControlProps> = ({ zoom, sceneBoundingBox }) => {
+export const CameraControl: React.FC<CameraControlProps> = ({ zoom }) => {
   const { camera, gl } = useThree();
   const controlsRef = useRef<OrbitControls | null>(null);
 
-  const cameraTarget = React.useMemo(() => {
-    if (!sceneBoundingBox) {
-      return DEFAULT_CAMERA_TARGET;
-    }
-    const boundingSphere = sceneBoundingBox.getBoundingSphere(new Sphere());
-    return DEFAULT_CAMERA_TARGET_MULTIPLIER * 2 * boundingSphere.radius;
-  }, [sceneBoundingBox]);
-
   useEffect(() => {
     const controls = new OrbitControls(camera, gl.domElement);
-    controls.target = new Vector3(0, 0, cameraTarget);
+    controls.target = new Vector3(0, 0, -Number.MAX_SAFE_INTEGER);
     controls.enableRotate = false;
     controls.enableDamping = false;
     controls.enableZoom = true;
@@ -90,7 +79,7 @@ export const CameraControl: React.FC<CameraControlProps> = ({ zoom, sceneBoundin
       gl.domElement.removeEventListener('wheel', handleScroll);
       controls.dispose();
     };
-  }, [camera, gl.domElement, cameraTarget]);
+  }, [camera, gl.domElement]);
 
   useEffect(() => {
     camera.zoom = zoom;

--- a/packages/dashboard/src/components/three-fiber/camera-control.tsx
+++ b/packages/dashboard/src/components/three-fiber/camera-control.tsx
@@ -63,7 +63,7 @@ export const CameraControl: React.FC<CameraControlProps> = ({ zoom }) => {
 
   useEffect(() => {
     const controls = new OrbitControls(camera, gl.domElement);
-    controls.target = new Vector3(0, 0, -1000);
+    controls.target = new Vector3(0, 0, -10000);
     controls.enableRotate = false;
     controls.enableDamping = false;
     controls.enableZoom = true;


### PR DESCRIPTION
## What's new

* Tweak camera target to most negative number to better accommodate almost-orthogonal view for extremely large maps
* refactored camera control to prevent creation of camera every time zoom changes

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test