### PR TITLE
Allow configurable alert audio when alert occurs

### DIFF
--- a/packages/dashboard/app-config.schema.json
+++ b/packages/dashboard/app-config.schema.json
@@ -135,6 +135,10 @@
         }
     },
     "properties": {
+        "alertAudioPath": {
+            "description": "Url to a .wav file to be played when an alert occurs on the dashboard.",
+            "type": "string"
+        },
         "allowedTasks": {
             "description": "List of allowed tasks that can be requested",
             "items": {

--- a/packages/dashboard/src/app-config.ts
+++ b/packages/dashboard/src/app-config.ts
@@ -126,6 +126,11 @@ export interface RuntimeConfig {
   allowedTasks: TaskResource[];
 
   /**
+   * Url to a .wav file to be played when an alert occurs on the dashboard.
+   */
+  alertAudioPath?: string;
+
+  /**
    * Set various resources (icons, logo etc) used. Different resource can be used based on the theme, `default` is always required.
    */
   resources: { [theme: string]: Resources; default: Resources };

--- a/packages/dashboard/src/components/alert-manager.tsx
+++ b/packages/dashboard/src/components/alert-manager.tsx
@@ -20,6 +20,7 @@ import React from 'react';
 import { base } from 'react-components';
 import { Subscription } from 'rxjs';
 
+import { AppConfigContext } from '../app-config';
 import { AppControllerContext } from './app-contexts';
 import { AppEvents } from './app-events';
 import { RmfAppContext } from './rmf-app';
@@ -256,6 +257,10 @@ const AlertDialog = React.memo((props: AlertDialogProps) => {
 export const AlertManager = React.memo(() => {
   const rmf = React.useContext(RmfAppContext);
   const [openAlerts, setOpenAlerts] = React.useState<Record<string, AlertRequest>>({});
+  const appConfig = React.useContext(AppConfigContext);
+  const alertAudio: HTMLAudioElement | undefined = appConfig.alertAudioPath
+    ? new Audio(appConfig.alertAudioPath)
+    : undefined;
 
   React.useEffect(() => {
     if (!rmf) {
@@ -285,9 +290,14 @@ export const AlertManager = React.memo(() => {
           `Alert [${alertRequest.id}]: was responded with [${resp.response}] at ${resp.unix_millis_response_time}`,
         );
       } catch (e) {
-        console.log(
-          `Error retrieving alert response of ID ${alertRequest.id}, ${(e as Error).message}`,
+        console.debug(
+          `Failed to retrieve alert response of ID ${alertRequest.id}, ${(e as Error).message}`,
         );
+
+        if (alertAudio) {
+          alertAudio.play();
+        }
+
         setOpenAlerts((prev) => {
           return {
             ...prev,


### PR DESCRIPTION
## What's new

Configurable audio file URL to be played when alerts occur, no alert audio will be played by default.

Use `alertAudioPath` in the app config, for example

```
{
  ....,
  "alertAudioPath": "https://github.com/adafruit/Adafruit-Sound-Samples/raw/7675c60a47c025ab62f77b699d6460d22bb963b1/sonic-pi/elec_ping.wav",
  ....
}
```

This can also be a relative path, when the audio file is downloaded to `dashboard/public/resources/elec_ping.wav`

```
{
  ....,
  "alertAudioPath": "/resources/elec_ping.wav",
  ....
}
```

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test