### PR TITLE
dashboard: fix route path

### DIFF
--- a/packages/dashboard/src/components/rmf-dashboard.tsx
+++ b/packages/dashboard/src/components/rmf-dashboard.tsx
@@ -275,7 +275,7 @@ function DashboardContents({
   extraAppbarItems,
 }: DashboardContentsProps) {
   const location = useLocation();
-  const currentTab = tabs.find((t) => matchPath(t.route, location.pathname));
+  const currentTab = tabs.find((t) => matchPath(`${baseUrl}${t.route}`, location.pathname));
 
   const [pendingTransition, startTransition] = useTransition();
   const navigate = useNavigate();

--- a/packages/dashboard/src/components/rmf-dashboard.tsx
+++ b/packages/dashboard/src/components/rmf-dashboard.tsx
@@ -335,6 +335,7 @@ function DashboardContents({
             />
           ))}
         </Route>
+        <Route path="*" element={<NotFound />} />
       </Route>
       <Route path="*" element={<NotFound />} />
     </Routes>


### PR DESCRIPTION
Fix an issue where the tab detection fails to account for the base url.
Fix issue where the "not found" page is not shown on paths below base url that is not defined.