### PR TITLE
Reverting the validation step when a patrol task form is rendered

### DIFF
--- a/packages/react-components/lib/tasks/types/patrol.tsx
+++ b/packages/react-components/lib/tasks/types/patrol.tsx
@@ -125,6 +125,10 @@ export function PatrolTaskForm({
     onChange(desc);
   };
 
+  React.useEffect(() => {
+    onValidate(isPatrolTaskDescriptionValid(taskDesc));
+  }, [taskDesc]);
+
   return (
     <Grid container spacing={theme.spacing(2)} justifyContent="center" alignItems="center">
       <Grid item xs={isScreenHeightLessThan800 ? 8 : 10}>


### PR DESCRIPTION
## What's new

Fixes #1012 

Will look into increasing test coverage for these situations after https://github.com/open-rmf/rmf-web/pull/1007

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test