### PR TITLE
Remove offset based on text length

### DIFF
--- a/packages/rmf-dashboard-framework/src/components/map/text-maker.tsx
+++ b/packages/rmf-dashboard-framework/src/components/map/text-maker.tsx
@@ -21,11 +21,10 @@ export const TextThreeRendering = ({ position, text }: TextThreeRenderingProps):
   };
 
   const scaleFactor = isHovered ? 2 : 1.0;
-  const positionX = text && text.length > 5 ? -2 : -1;
   return (
     <>
       <mesh position={position}>
-        <mesh position={[positionX, 0, positionZ]}>
+        <mesh position={[0, 0, positionZ]}>
           {text && (
             <Html zIndexRange={[0, 0, 1]}>
               {text && (


### PR DESCRIPTION
## What's new

Resolves https://github.com/open-rmf/rmf-web/issues/1034
* removes an offset for labels based on text length, it will be more intuitive that the text is left-justified at the center of the rendering

## Before
![Screenshot_20241125_171228](https://github.com/user-attachments/assets/876169c7-d1ba-479f-83dc-981a33a50b60)
![Screenshot_20241125_171250](https://github.com/user-attachments/assets/3a552d3a-bd5c-4407-be69-5c79b1cbd545)

## After
![Screenshot_20241125_171149](https://github.com/user-attachments/assets/112440e2-7146-42b3-bf70-92d43191b280)
![Screenshot_20241125_171320](https://github.com/user-attachments/assets/b8ad4a1c-898c-4faf-b755-e7f5464401f1)

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test