### PR TITLE
fixed robots label position.

### DIFF
--- a/packages/rmf-dashboard-framework/src/components/map/robot-three-maker.tsx
+++ b/packages/rmf-dashboard-framework/src/components/map/robot-three-maker.tsx
@@ -122,11 +122,11 @@ export const RobotThreeMaker = ({
         </mesh>
       )}
       {robotLabel && fontPath && fontPath.length > 0 ? (
-        <Text color="black" font={fontPath} fontSize={0.5} position={[0, 0, 1]}>
+        <Text color="black" font={fontPath} fontSize={0.5} position={position}>
           {robot.name}
         </Text>
       ) : robotLabel ? (
-        <TextThreeRendering position={[0, 0, 1]} text={robot.name} />
+        <TextThreeRendering position={[position.x, position.y, 1]} text={robot.name} />
       ) : null}
       {imageUrl ? (
         <RobotImageMaker


### PR DESCRIPTION
## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion
Hello,
In the RMF Web Map, the robot labels appear in the top-left corner of the screen.
<img width="518" alt="robots_labels" src="https://github.com/user-attachments/assets/9cf38474-7f5c-4f7c-a251-cad1a0915c66">

I have fixed this by changing the position of the labels. Could you please merge this fix?
<img width="517" alt="robots_labels_fixed" src="https://github.com/user-attachments/assets/be47e235-b9d9-4661-8b8c-64a78c2f19d1">

Thank you.
