### PR TITLE
Update pnpm lock file to handle patchedDependencies difference

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
 
 patchedDependencies:
   '@react-three/fiber':
-    hash: 72hazlorpk2kzn3denlucgiftu
+    hash: 7de2f0a9a40358b4ac231c4e50a83c068e7c2ae8597b7eab93350c067b61a9af
     path: patches/@react-three__fiber.patch
 
 importers:
@@ -160,10 +160,10 @@ importers:
         version: 6.19.0(@emotion/react@11.13.0(@types/react@18.3.3)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.0(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1))(@mui/material@5.16.1(@emotion/react@11.13.0(@types/react@18.3.3)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.0(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@5.16.1(@emotion/react@11.13.0(@types/react@18.3.3)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.0(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(date-fns@2.30.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-three/drei':
         specifier: ^9.103.0
-        version: 9.108.3(@react-three/fiber@8.16.8(patch_hash=72hazlorpk2kzn3denlucgiftu)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1))(@types/react@18.3.3)(@types/three@0.166.0)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1)
+        version: 9.108.3(@react-three/fiber@8.16.8(patch_hash=7de2f0a9a40358b4ac231c4e50a83c068e7c2ae8597b7eab93350c067b61a9af)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1))(@types/react@18.3.3)(@types/three@0.166.0)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1)
       '@react-three/fiber':
         specifier: ^8.16.1
-        version: 8.16.8(patch_hash=72hazlorpk2kzn3denlucgiftu)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1)
+        version: 8.16.8(patch_hash=7de2f0a9a40358b4ac231c4e50a83c068e7c2ae8597b7eab93350c067b61a9af)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1)
       '@types/crc':
         specifier: ^3.4.0
         version: 3.8.3
@@ -6946,25 +6946,25 @@ snapshots:
       '@react-spring/types': 9.6.1
       react: 18.3.1
 
-  '@react-spring/three@9.6.1(@react-three/fiber@8.16.8(patch_hash=72hazlorpk2kzn3denlucgiftu)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1))(react@18.3.1)(three@0.166.1)':
+  '@react-spring/three@9.6.1(@react-three/fiber@8.16.8(patch_hash=7de2f0a9a40358b4ac231c4e50a83c068e7c2ae8597b7eab93350c067b61a9af)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1))(react@18.3.1)(three@0.166.1)':
     dependencies:
       '@react-spring/animated': 9.6.1(react@18.3.1)
       '@react-spring/core': 9.6.1(react@18.3.1)
       '@react-spring/shared': 9.6.1(react@18.3.1)
       '@react-spring/types': 9.6.1
-      '@react-three/fiber': 8.16.8(patch_hash=72hazlorpk2kzn3denlucgiftu)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1)
+      '@react-three/fiber': 8.16.8(patch_hash=7de2f0a9a40358b4ac231c4e50a83c068e7c2ae8597b7eab93350c067b61a9af)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1)
       react: 18.3.1
       three: 0.166.1
 
   '@react-spring/types@9.6.1': {}
 
-  '@react-three/drei@9.108.3(@react-three/fiber@8.16.8(patch_hash=72hazlorpk2kzn3denlucgiftu)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1))(@types/react@18.3.3)(@types/three@0.166.0)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1)':
+  '@react-three/drei@9.108.3(@react-three/fiber@8.16.8(patch_hash=7de2f0a9a40358b4ac231c4e50a83c068e7c2ae8597b7eab93350c067b61a9af)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1))(@types/react@18.3.3)(@types/three@0.166.0)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@mediapipe/tasks-vision': 0.10.8
       '@monogrid/gainmap-js': 3.0.5(three@0.166.1)
-      '@react-spring/three': 9.6.1(@react-three/fiber@8.16.8(patch_hash=72hazlorpk2kzn3denlucgiftu)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1))(react@18.3.1)(three@0.166.1)
-      '@react-three/fiber': 8.16.8(patch_hash=72hazlorpk2kzn3denlucgiftu)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1)
+      '@react-spring/three': 9.6.1(@react-three/fiber@8.16.8(patch_hash=7de2f0a9a40358b4ac231c4e50a83c068e7c2ae8597b7eab93350c067b61a9af)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1))(react@18.3.1)(three@0.166.1)
+      '@react-three/fiber': 8.16.8(patch_hash=7de2f0a9a40358b4ac231c4e50a83c068e7c2ae8597b7eab93350c067b61a9af)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1)
       '@use-gesture/react': 10.3.1(react@18.3.1)
       camera-controls: 2.8.5(three@0.166.1)
       cross-env: 7.0.3
@@ -6993,7 +6993,7 @@ snapshots:
       - '@types/three'
       - immer
 
-  '@react-three/fiber@8.16.8(patch_hash=72hazlorpk2kzn3denlucgiftu)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1)':
+  '@react-three/fiber@8.16.8(patch_hash=7de2f0a9a40358b4ac231c4e50a83c068e7c2ae8597b7eab93350c067b61a9af)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@types/react-reconciler': 0.26.7


### PR DESCRIPTION
## What's new

Update pnpm lock file to handle `patchedDependencies`.

Resolves the issue faced in deployment template, also fixed by https://github.com/open-rmf/rmf_deployment_template/pull/46

## Self-checks

- [ ] I have prototyped this new feature (if necessary) on Figma 
- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test