### PR TITLE
feat(api-server): accept namespaced preferred_username claim fallback

### DIFF
--- a/packages/api-server/README.md
+++ b/packages/api-server/README.md
@@ -121,7 +121,9 @@ OpenID Connect does not define the format of the access token, the canonical way
 
 The access token must include the `preferred_username` claim. It will be used to determine an user's authorization levels.
 
-If your identity provider issues access tokens that namespace standard OIDC claims (e.g. Auth0, Okta, and AWS Cognito do this for the `client_credentials` flow, in line with [RFC 9068 §2.2](https://www.rfc-editor.org/rfc/rfc9068.html#section-2.2)), set the optional `preferred_username_claim_namespace` config value to the namespace prefix used by your provider. The authenticator will then check `f"{namespace}preferred_username"` as a fallback when the bare `preferred_username` claim is absent.
+If your identity provider strips standard OIDC claims (such as `preferred_username`) from access tokens issued via the OAuth 2.0 `client_credentials` (M2M) flow and requires custom claims to use a collision-resistant namespaced name, set the optional `preferred_username_claim_namespace` config value to the namespace prefix used by your provider. The authenticator will then check `f"{namespace}preferred_username"` as a fallback when the bare `preferred_username` claim is absent.
+
+This pattern aligns with [RFC 9068 §2.2.2](https://www.rfc-editor.org/rfc/rfc9068.html#section-2.2.2) (which requires that arbitrary attributes in JWT access tokens have "collision resistant" names) and [RFC 7519 §4.2](https://www.rfc-editor.org/rfc/rfc7519.html#section-4.2) (which defines "Collision-Resistant Name" via Public Claim Names). [Auth0 enforces this policy explicitly](https://auth0.com/docs/secure/tokens/json-web-tokens/create-namespaced-custom-claims) for access tokens with a custom API audience — non-namespaced custom claims on standard OIDC names are silently dropped. Operators on other providers with comparable collision-avoidance policies may also benefit; leaving the value unset preserves the current behavior.
 
 ## Roles, Actions and Authorization Group
 

--- a/packages/api-server/README.md
+++ b/packages/api-server/README.md
@@ -121,6 +121,8 @@ OpenID Connect does not define the format of the access token, the canonical way
 
 The access token must include the `preferred_username` claim. It will be used to determine an user's authorization levels.
 
+If your identity provider issues access tokens that namespace standard OIDC claims (e.g. Auth0, Okta, and AWS Cognito do this for the `client_credentials` flow, in line with [RFC 9068 §2.2](https://www.rfc-editor.org/rfc/rfc9068.html#section-2.2)), set the optional `preferred_username_claim_namespace` config value to the namespace prefix used by your provider. The authenticator will then check `f"{namespace}preferred_username"` as a fallback when the bare `preferred_username` claim is absent.
+
 ## Roles, Actions and Authorization Group
 
 An user's permission to perform certain actions on a protected resource is determined by 3 values, role, action, and authorization group of the resource. A resource belongs to one authorization group and an user can belong to multiple roles. An user has access to perform an action on a resource if any of their roles has permission to perform the action on the authorization group which the resource belongs to. An admin always have permission to perform any action on any group.

--- a/packages/api-server/api_server/app_config.py
+++ b/packages/api-server/api_server/app_config.py
@@ -23,6 +23,7 @@ class AppConfig:
     iss: str
     ros_args: list[str]
     timezone: str
+    preferred_username_claim_namespace: str | None = None
 
     def __post_init__(self):
         self.public_url = urllib.parse.urlparse(cast(str, self.public_url))

--- a/packages/api-server/api_server/authenticator.py
+++ b/packages/api-server/api_server/authenticator.py
@@ -30,24 +30,40 @@ class JwtAuthenticator:
         iss: str,
         *,
         oidc_url: str = "",
+        preferred_username_claim_namespace: str | None = None,
     ):
         """
         Authenticates with a JWT token, the client must send an auth params with
         a "token" key.
         :param pem_file: path to a pem encoded certificate used to verify a token.
+        :param preferred_username_claim_namespace: optional namespace prefix used
+            as a fallback when looking up the `preferred_username` claim. Some
+            identity providers (e.g. Auth0, Okta, AWS Cognito) silently filter
+            non-namespaced standard OIDC claims from access tokens issued via
+            the OAuth 2.0 `client_credentials` (M2M) flow, in line with
+            RFC 9068 §2.2's "namespaced naming scheme" guidance for private
+            claims. When set, the authenticator will look up
+            `f"{preferred_username_claim_namespace}preferred_username"` if the
+            bare `preferred_username` claim is absent.
         """
         self.aud = aud
         self.iss = iss
         self.oidc_url = oidc_url
+        self.preferred_username_claim_namespace = preferred_username_claim_namespace
         self._key_or_secret = key_or_secret
 
     async def _get_user(self, claims: dict) -> User:
-        if not "preferred_username" in claims:
+        username = claims.get("preferred_username")
+        if not username and self.preferred_username_claim_namespace:
+            namespaced_claim = (
+                f"{self.preferred_username_claim_namespace}preferred_username"
+            )
+            username = claims.get(namespaced_claim)
+        if not username:
             raise AuthenticationError(
                 "expected 'preferred_username' username claim to be present"
             )
 
-        username = claims["preferred_username"]
         # FIXME(koonpeng): We should use the "userId" as the identifier. Some idP may allow
         # duplicated usernames.
         user = await User.load_or_create_from_db(username)
@@ -101,6 +117,7 @@ if app_config.jwt_public_key:
             app_config.aud,
             app_config.iss,
             oidc_url=app_config.oidc_url or "",
+            preferred_username_claim_namespace=app_config.preferred_username_claim_namespace,
         )
 elif app_config.jwt_secret:
     authenticator = JwtAuthenticator(
@@ -108,6 +125,7 @@ elif app_config.jwt_secret:
         app_config.aud,
         app_config.iss,
         oidc_url=app_config.oidc_url or "",
+        preferred_username_claim_namespace=app_config.preferred_username_claim_namespace,
     )
 else:
     raise ValueError("either jwt_public_key or jwt_secret is required")

--- a/packages/api-server/api_server/authenticator.py
+++ b/packages/api-server/api_server/authenticator.py
@@ -38,11 +38,11 @@ class JwtAuthenticator:
         :param pem_file: path to a pem encoded certificate used to verify a token.
         :param preferred_username_claim_namespace: optional namespace prefix used
             as a fallback when looking up the `preferred_username` claim. Some
-            identity providers (e.g. Auth0, Okta, AWS Cognito) silently filter
-            non-namespaced standard OIDC claims from access tokens issued via
-            the OAuth 2.0 `client_credentials` (M2M) flow, in line with
-            RFC 9068 §2.2's "namespaced naming scheme" guidance for private
-            claims. When set, the authenticator will look up
+            identity providers (verified for Auth0) silently filter non-
+            namespaced custom claims on standard OIDC names from access tokens
+            issued via the OAuth 2.0 `client_credentials` (M2M) flow, in line
+            with the collision-resistant-name guidance in RFC 9068 §2.2.2 and
+            RFC 7519 §4.2. When set, the authenticator will look up
             `f"{preferred_username_claim_namespace}preferred_username"` if the
             bare `preferred_username` claim is absent.
         """

--- a/packages/api-server/api_server/default_config.py
+++ b/packages/api-server/api_server/default_config.py
@@ -30,15 +30,15 @@ config = {
     # Used to verify the "iss" claim
     "iss": "stub",
     # Optional namespace prefix used as a fallback when looking up the
-    # `preferred_username` claim. Some identity providers (e.g. Auth0, Okta,
-    # AWS Cognito) silently filter non-namespaced standard OIDC claims from
-    # access tokens issued via the OAuth 2.0 `client_credentials` (M2M) flow,
-    # in line with RFC 9068 §2.2's "namespaced naming scheme" guidance for
-    # private claims. When set, the authenticator will look up
-    # `f"{preferred_username_claim_namespace}preferred_username"` if the
-    # bare `preferred_username` claim is absent. The trailing slash (or `/`
-    # separator) should be included in the namespace value if desired, e.g.
-    # `"https://example.com/"` so the resolved claim becomes
+    # `preferred_username` claim. Some identity providers (verified for
+    # Auth0) silently filter non-namespaced custom claims on standard OIDC
+    # names from access tokens issued via the OAuth 2.0 `client_credentials`
+    # (M2M) flow, in line with the collision-resistant-name guidance in
+    # RFC 9068 §2.2.2 and RFC 7519 §4.2. When set, the authenticator will
+    # look up `f"{preferred_username_claim_namespace}preferred_username"`
+    # if the bare `preferred_username` claim is absent. The trailing slash
+    # (or `/` separator) should be included in the namespace value if
+    # desired, e.g. `"https://example.com/"` so the resolved claim becomes
     # `"https://example.com/preferred_username"`.
     "preferred_username_claim_namespace": None,
     # list of arguments passed to the ros node, "--ros-args" is automatically prepended to the list.

--- a/packages/api-server/api_server/default_config.py
+++ b/packages/api-server/api_server/default_config.py
@@ -29,6 +29,18 @@ config = {
     # url or string that identifies the entity that issued the jwt token
     # Used to verify the "iss" claim
     "iss": "stub",
+    # Optional namespace prefix used as a fallback when looking up the
+    # `preferred_username` claim. Some identity providers (e.g. Auth0, Okta,
+    # AWS Cognito) silently filter non-namespaced standard OIDC claims from
+    # access tokens issued via the OAuth 2.0 `client_credentials` (M2M) flow,
+    # in line with RFC 9068 §2.2's "namespaced naming scheme" guidance for
+    # private claims. When set, the authenticator will look up
+    # `f"{preferred_username_claim_namespace}preferred_username"` if the
+    # bare `preferred_username` claim is absent. The trailing slash (or `/`
+    # separator) should be included in the namespace value if desired, e.g.
+    # `"https://example.com/"` so the resolved claim becomes
+    # `"https://example.com/preferred_username"`.
+    "preferred_username_claim_namespace": None,
     # list of arguments passed to the ros node, "--ros-args" is automatically prepended to the list.
     # e.g.
     #   Run with sim time: ["-p", "use_sim_time:=true"]

--- a/packages/api-server/api_server/test_authenticator.py
+++ b/packages/api-server/api_server/test_authenticator.py
@@ -1,72 +1,89 @@
 import unittest
 from unittest.mock import AsyncMock, patch
 
+import jwt
+
 from api_server.authenticator import AuthenticationError, JwtAuthenticator
 from api_server.models import User
+
+
+SECRET = "test-secret"
+AUD = "rmf_api_server"
+ISS = "test"
 
 
 def _make_authenticator(
     *, preferred_username_claim_namespace: str | None = None
 ) -> JwtAuthenticator:
     return JwtAuthenticator(
-        "test-secret",
-        aud="rmf_api_server",
-        iss="test",
+        SECRET,
+        aud=AUD,
+        iss=ISS,
         preferred_username_claim_namespace=preferred_username_claim_namespace,
     )
 
 
-class TestGetUser(unittest.IsolatedAsyncioTestCase):
+def _make_token(extra_claims: dict) -> str:
+    """Encode a HS256 JWT with the test secret + standard aud/iss + extra claims."""
+    claims = {"aud": AUD, "iss": ISS, **extra_claims}
+    return jwt.encode(claims, SECRET, algorithm="HS256")
+
+
+class TestVerifyToken(unittest.IsolatedAsyncioTestCase):
     async def test_bare_preferred_username_claim_is_accepted(self):
         authenticator = _make_authenticator()
+        token = _make_token({"preferred_username": "alice"})
         with patch.object(
             User,
             "load_or_create_from_db",
             new=AsyncMock(return_value=User(username="alice")),
         ) as mock_load:
-            user = await authenticator._get_user({"preferred_username": "alice"})
+            user = await authenticator.verify_token(token)
         self.assertEqual(user.username, "alice")
         mock_load.assert_awaited_once_with("alice")
 
     async def test_missing_claim_raises_authentication_error(self):
         authenticator = _make_authenticator()
+        token = _make_token({})
         with self.assertRaises(AuthenticationError):
-            await authenticator._get_user({})
+            await authenticator.verify_token(token)
 
     async def test_namespaced_claim_used_as_fallback_when_namespace_configured(self):
         authenticator = _make_authenticator(
             preferred_username_claim_namespace="https://example.com/"
         )
-        claims = {"https://example.com/preferred_username": "bob"}
+        token = _make_token({"https://example.com/preferred_username": "bob"})
         with patch.object(
             User,
             "load_or_create_from_db",
             new=AsyncMock(return_value=User(username="bob")),
         ) as mock_load:
-            user = await authenticator._get_user(claims)
+            user = await authenticator.verify_token(token)
         self.assertEqual(user.username, "bob")
         mock_load.assert_awaited_once_with("bob")
 
     async def test_namespaced_claim_ignored_when_namespace_not_configured(self):
         authenticator = _make_authenticator()
-        claims = {"https://example.com/preferred_username": "bob"}
+        token = _make_token({"https://example.com/preferred_username": "bob"})
         with self.assertRaises(AuthenticationError):
-            await authenticator._get_user(claims)
+            await authenticator.verify_token(token)
 
     async def test_bare_claim_preferred_over_namespaced_claim(self):
         authenticator = _make_authenticator(
             preferred_username_claim_namespace="https://example.com/"
         )
-        claims = {
-            "preferred_username": "alice",
-            "https://example.com/preferred_username": "bob",
-        }
+        token = _make_token(
+            {
+                "preferred_username": "alice",
+                "https://example.com/preferred_username": "bob",
+            }
+        )
         with patch.object(
             User,
             "load_or_create_from_db",
             new=AsyncMock(return_value=User(username="alice")),
         ) as mock_load:
-            user = await authenticator._get_user(claims)
+            user = await authenticator.verify_token(token)
         self.assertEqual(user.username, "alice")
         mock_load.assert_awaited_once_with("alice")
 

--- a/packages/api-server/api_server/test_authenticator.py
+++ b/packages/api-server/api_server/test_authenticator.py
@@ -1,0 +1,75 @@
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from api_server.authenticator import AuthenticationError, JwtAuthenticator
+from api_server.models import User
+
+
+def _make_authenticator(
+    *, preferred_username_claim_namespace: str | None = None
+) -> JwtAuthenticator:
+    return JwtAuthenticator(
+        "test-secret",
+        aud="rmf_api_server",
+        iss="test",
+        preferred_username_claim_namespace=preferred_username_claim_namespace,
+    )
+
+
+class TestGetUser(unittest.IsolatedAsyncioTestCase):
+    async def test_bare_preferred_username_claim_is_accepted(self):
+        authenticator = _make_authenticator()
+        with patch.object(
+            User,
+            "load_or_create_from_db",
+            new=AsyncMock(return_value=User(username="alice")),
+        ) as mock_load:
+            user = await authenticator._get_user({"preferred_username": "alice"})
+        self.assertEqual(user.username, "alice")
+        mock_load.assert_awaited_once_with("alice")
+
+    async def test_missing_claim_raises_authentication_error(self):
+        authenticator = _make_authenticator()
+        with self.assertRaises(AuthenticationError):
+            await authenticator._get_user({})
+
+    async def test_namespaced_claim_used_as_fallback_when_namespace_configured(self):
+        authenticator = _make_authenticator(
+            preferred_username_claim_namespace="https://example.com/"
+        )
+        claims = {"https://example.com/preferred_username": "bob"}
+        with patch.object(
+            User,
+            "load_or_create_from_db",
+            new=AsyncMock(return_value=User(username="bob")),
+        ) as mock_load:
+            user = await authenticator._get_user(claims)
+        self.assertEqual(user.username, "bob")
+        mock_load.assert_awaited_once_with("bob")
+
+    async def test_namespaced_claim_ignored_when_namespace_not_configured(self):
+        authenticator = _make_authenticator()
+        claims = {"https://example.com/preferred_username": "bob"}
+        with self.assertRaises(AuthenticationError):
+            await authenticator._get_user(claims)
+
+    async def test_bare_claim_preferred_over_namespaced_claim(self):
+        authenticator = _make_authenticator(
+            preferred_username_claim_namespace="https://example.com/"
+        )
+        claims = {
+            "preferred_username": "alice",
+            "https://example.com/preferred_username": "bob",
+        }
+        with patch.object(
+            User,
+            "load_or_create_from_db",
+            new=AsyncMock(return_value=User(username="alice")),
+        ) as mock_load:
+            user = await authenticator._get_user(claims)
+        self.assertEqual(user.username, "alice")
+        mock_load.assert_awaited_once_with("alice")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The current authenticator requires a non-namespaced `preferred_username` claim in access tokens:

```python
# packages/api-server/api_server/authenticator.py
if not "preferred_username" in claims:
    raise AuthenticationError(
        "expected 'preferred_username' username claim to be present"
    )
```

For access tokens issued via the OAuth 2.0 `client_credentials` (M2M) flow, **Auth0 cannot put `preferred_username` (or any other OIDC-standard claim name) on access tokens with a custom API audience**. Two of the general restrictions Auth0 documents apply together:

> "OPENID standard claims and claims used internally by Auth0 cannot be customized or modified"
>
> "Access tokens with an Auth0 API audience, excluding the `/userinfo` endpoint, cannot have private, non-namespaced custom claims"
>
> — Auth0 docs: [Create Namespaced Custom Claims](https://auth0.com/docs/secure/tokens/json-web-tokens/create-namespaced-custom-claims) (under "General restrictions")

The same page closes the loop on what happens when a non-namespaced custom claim is set anyway:

> "In case of collisions, the transaction won't fail, but your custom claim won't be added to your tokens."

So an Auth0 Action that calls `api.accessToken.setCustomClaim("preferred_username", ...)` during a `credentials-exchange` trigger silently drops the claim — the Action completes with no error, but the bare claim never lands on the token. The same call with a namespaced name (`api.accessToken.setCustomClaim("https://example.com/preferred_username", ...)`) does land.

This two-rule policy is one provider's defensible implementation of the standards' guidance on attribute names in JWT access tokens:

- **RFC 9068 §2.2.2 (Identity Claims)** — "Authorization servers MAY return arbitrary attributes not defined in any existing specification, as long as the corresponding claim names are **collision resistant** or the access tokens are meant to be used only within a private subsystem. Please refer to Sections 4.2 and 4.3 of [RFC 7519] for details." [link](https://www.rfc-editor.org/rfc/rfc9068.html#section-2.2.2)
- **RFC 7519 §4.2 (Public Claim Names)** — "Claim Names can be defined at will by those using JWTs. However, in order to prevent collisions, any new Claim Name should either be registered in the IANA 'JSON Web Token Claims' registry … or be a Public Name: a value that contains a Collision-Resistant Name." [link](https://www.rfc-editor.org/rfc/rfc7519.html#section-4.2)

Together: the standards require collision-resistant names for attributes that aren't IANA-registered; Auth0 enforces that requirement strictly for access tokens with a custom API audience, with the consequence that the M2M flow cannot satisfy the bare `preferred_username` requirement on an Auth0-issued access token without either (a) using an ID token instead of the access token (not what the spec or the API server expects), or (b) patching `authenticator.py`.

I'm not asserting that Okta and AWS Cognito apply the same filtering policy — I do not have first-party documentation to back that claim, so I have withdrawn it from the patch and the docstrings. Operators on other providers with comparable collision-avoidance policies may benefit; the value-add of this PR is specifically the Auth0 path, with the optional fallback shape leaving room for similar cases without naming them.

## Reproduce on Auth0 (no code required)

In any Auth0 tenant with a custom API audience:

1. Create an Auth0 Action on the `credentials-exchange` trigger:

   ```js
   exports.onExecuteCredentialsExchange = async (event, api) => {
     api.accessToken.setCustomClaim("https://your-namespace.example/preferred_username", "test-literal");
     api.accessToken.setCustomClaim("preferred_username", "test-literal"); // non-namespaced
   };
   ```

2. Mint an access token via `client_credentials` against the custom API.
3. Decode the JWT payload (e.g. `jwt.io`). You will see:
   - `"https://your-namespace.example/preferred_username": "test-literal"` ✓
   - **No** bare `"preferred_username"` claim — silently dropped by Auth0 with no error to the caller.

## Fix

Add an optional `preferred_username_claim_namespace` config field. When set, the authenticator falls back to looking up `f"{namespace}preferred_username"` if the bare `preferred_username` claim is absent.

- The bare `preferred_username` claim remains the **first** preference — existing deployments are byte-identical in behavior.
- The namespaced lookup runs **only** when the bare claim is missing **and** the namespace config is set.
- Default value is `None` (no fallback) — so existing deployments need no configuration changes.

Example config snippet for an Auth0 deployment:

```python
config = {
    ...
    "preferred_username_claim_namespace": "https://your-namespace.example/",
    ...
}
```

The auth flow then resolves `preferred_username` from `f"https://your-namespace.example/preferred_username"` in the access-token claims.

## Tests

`packages/api-server/api_server/test_authenticator.py` covers five scenarios through the public `verify_token(token)` surface (HS256 token built with PyJWT, verified end-to-end through `jwt.decode` + claim lookup):

1. Bare `preferred_username` claim is accepted (no namespace configured).
2. Missing claim raises `AuthenticationError`.
3. Namespaced fallback is used when `preferred_username_claim_namespace` is configured and the bare claim is absent.
4. Namespaced claim is ignored when no namespace is configured (current behavior preserved).
5. Bare claim takes precedence over the namespaced variant when both are present.

## Notes / open questions for the reviewer

1. **Config-field naming.** `preferred_username_claim_namespace` is verbose but precise. If a more generic name like `jwt_claim_namespace` (paired with the existing `jwt_public_key` / `jwt_secret` family) reads better and leaves room for future namespaced-claim lookups, happy to rename — just say the word.
2. **Scope.** This only changes the `preferred_username` lookup. If `authenticator.py` starts consuming other OIDC-reserved claims later, the same fallback can be applied trivially.

## Changes since first push

- (2026-05-12) Tightened RFC citations to §2.2.2 of RFC 9068 + §4.2 of RFC 7519 after reviewer feedback. Quoted text verified character-by-character against the canonical RFC editor plain-text source.
- (2026-05-12) Reframed the Auth0 case using the two general-restrictions Auth0 documents — earlier drafts conflated Auth0's *restricted-claims* list (which contains `sub`/`aud`/`iss`/etc.) with the *general restrictions* on access tokens (which is what actually filters `preferred_username`). `preferred_username` is in Auth0's "non-restricted claims" group but is still affected by the non-namespaced-custom-claim general restriction.
- (2026-05-12) Withdrew the Okta + AWS Cognito assertions from the README and code docstrings; the directly-verified case is Auth0 only.
- (2026-05-12) Rewrote `test_authenticator.py` to exercise the public `verify_token(token)` API instead of the protected `_get_user(claims)` helper, per reviewer feedback. All five scenarios remain covered.
- (2026-05-12) Added `Generated-by: Anthropic Claude Code (Claude Opus 4.7)` trailer to all commits in compliance with [OSRF's policy on the use of generative tools in contributions](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md).

---

**AI-tool disclosure (per OSRF policy):** This contribution was drafted with assistance from Anthropic Claude Code (Claude Opus 4.7). The contributor (Ren Diao) reviewed and is responsible for the final content of every commit.