### PR TITLE
fix(api-server): ignore duplicate task-api responses in RmfService

### DIFF
--- a/packages/api-server/api_server/rmf_io/rmf_service.py
+++ b/packages/api-server/api_server/rmf_io/rmf_service.py
@@ -94,6 +94,18 @@ class RmfService(contextlib.AbstractContextManager):
                 f"Received response for unknown request id: {msg.request_id}"
             )
             return
+        if fut.done():
+            # RMF's request/response is a pub/sub pseudo-service, so more than
+            # one node may answer the same request_id (see the class docstring:
+            # clients must drop duplicated response ids). Calling set_result on
+            # an already-resolved future raises asyncio.InvalidStateError inside
+            # this subscription callback, which runs in the rclpy.spin() thread
+            # (see ros.py) and would terminate it -- after which the node stops
+            # processing every subscription and all later calls time out.
+            logging.warning(
+                f"Ignoring duplicate response for request id: {msg.request_id}"
+            )
+            return
         fut.set_result(msg.json_msg)
 
 

--- a/packages/api-server/api_server/rmf_io/test_rmf_service.py
+++ b/packages/api-server/api_server/rmf_io/test_rmf_service.py
@@ -122,3 +122,26 @@ class TestRmfService(unittest.TestCase):
             self.assertListEqual(["hello", "world"], list(results))
 
         self.loop.run_until_complete(run())
+
+    def test_duplicate_response_is_ignored(self):
+        # Regression: RMF's request/response is a pub/sub pseudo-service, so
+        # more than one node may answer the same request_id. A duplicate
+        # ApiResponse for an already-resolved future used to raise
+        # asyncio.InvalidStateError inside the subscription callback, which runs
+        # in the rclpy spin thread and would terminate it -- silently breaking
+        # every later task-api call. The handler must drop the duplicate.
+        req_id = self._create_node_id()
+        fut: asyncio.Future = self.loop.create_future()
+        self.rmf_service._requests[req_id] = fut
+        try:
+            self.rmf_service._handle_response(
+                ApiResponse(request_id=req_id, json_msg="first")
+            )
+            # second, duplicate delivery of the same request_id must not raise
+            self.rmf_service._handle_response(
+                ApiResponse(request_id=req_id, json_msg="second")
+            )
+        finally:
+            self.rmf_service._requests.pop(req_id, None)
+        self.assertTrue(fut.done())
+        self.assertEqual("first", fut.result())


### PR DESCRIPTION
## Problem
We hit a state where **every** task-api call (`/tasks/dispatch_task`, `/tasks/robot_task`, `/tasks/cancel_task`, …) returned `HTTP 500 {"detail":"rmf service timed out"}` after ~5s — **even though the request was delivered to RMF and executed** (the robot moved / the task was cancelled). Restarting `rmf-api-server` fixed it only temporarily; it recurred within a day.

## Root cause
`RmfService.call()` publishes an `ApiRequest` and awaits a `Future` resolved by `_handle_response` when a matching `ApiResponse` arrives. RMF's request/response channel is a pub/sub pseudo-service, and **more than one node can answer the same `request_id`** — the `RmfService` docstring itself says clients "must keep track of the request ids which they published and drop … duplicated response ids".

`_handle_response` drops *unknown* ids (`if fut is None`) but, for a known id, calls `fut.set_result()` unconditionally. When a second `ApiResponse` for the same id arrives before `call()`'s `finally: del` runs, `set_result()` is invoked on an already-resolved future and raises `asyncio.InvalidStateError`. That exception is raised **inside the subscription callback, which runs in the `rclpy.spin(node)` thread started in `ros.py`**, so it propagates out of `spin()` and **terminates the spin thread permanently**. After that the api-server node processes no further subscription callbacks: requests still publish (so tasks execute) but no `ApiResponse` is ever consumed, and every call times out → `500 "rmf service timed out"`.

Captured traceback:
```
Exception in thread Thread-1 (<lambda>):
  ...
  File ".../rclpy/executors.py", line 115, in await_or_execute
    fut.set_result(msg.json_msg)
asyncio.exceptions.InvalidStateError: invalid state
```
(The dead thread is invisible to `/fleets`, whose data is ingested via a separate path — which is why "the operation executes but the synchronous call 500s".)

## Fix
Drop duplicate/late responses in `_handle_response` (`if fut.done(): return`) — exactly the contract the class docstring already states — so the spin thread survives when RMF answers a request more than once.

## Test
Adds `test_duplicate_response_is_ignored`: a duplicate `ApiResponse` for an already-resolved request must not raise and must not overwrite the result. Without the fix it raises `InvalidStateError`.
