### PR TITLE
Backport #1089 to jazzy

### DIFF
--- a/packages/api-server/api_server/rmf_io/rmf_service.py
+++ b/packages/api-server/api_server/rmf_io/rmf_service.py
@@ -94,6 +94,18 @@ class RmfService(contextlib.AbstractContextManager):
                 f"Received response for unknown request id: {msg.request_id}"
             )
             return
+        if fut.done():
+            # RMF's request/response is a pub/sub pseudo-service, so more than
+            # one node may answer the same request_id (see the class docstring:
+            # clients must drop duplicated response ids). Calling set_result on
+            # an already-resolved future raises asyncio.InvalidStateError inside
+            # this subscription callback, which runs in the rclpy.spin() thread
+            # (see ros.py) and would terminate it -- after which the node stops
+            # processing every subscription and all later calls time out.
+            logging.warning(
+                f"Ignoring duplicate response for request id: {msg.request_id}"
+            )
+            return
         fut.set_result(msg.json_msg)
 
 

--- a/packages/api-server/api_server/rmf_io/test_rmf_service.py
+++ b/packages/api-server/api_server/rmf_io/test_rmf_service.py
@@ -122,3 +122,26 @@ class TestRmfService(unittest.TestCase):
             self.assertListEqual(["hello", "world"], list(results))
 
         self.loop.run_until_complete(run())
+
+    def test_duplicate_response_is_ignored(self):
+        # Regression: RMF's request/response is a pub/sub pseudo-service, so
+        # more than one node may answer the same request_id. A duplicate
+        # ApiResponse for an already-resolved future used to raise
+        # asyncio.InvalidStateError inside the subscription callback, which runs
+        # in the rclpy spin thread and would terminate it -- silently breaking
+        # every later task-api call. The handler must drop the duplicate.
+        req_id = self._create_node_id()
+        fut: asyncio.Future = self.loop.create_future()
+        self.rmf_service._requests[req_id] = fut
+        try:
+            self.rmf_service._handle_response(
+                ApiResponse(request_id=req_id, json_msg="first")
+            )
+            # second, duplicate delivery of the same request_id must not raise
+            self.rmf_service._handle_response(
+                ApiResponse(request_id=req_id, json_msg="second")
+            )
+        finally:
+            self.rmf_service._requests.pop(req_id, None)
+        self.assertTrue(fut.done())
+        self.assertEqual("first", fut.result())


### PR DESCRIPTION
(cherry picked from commit 0ee349437367f9954868fde405b20253bf2b0f18)


### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI

Generated-by:
