### PR TITLE
Use lyrical branch for CI

### DIFF
--- a/.github/api-server/Dockerfile
+++ b/.github/api-server/Dockerfile
@@ -5,7 +5,7 @@ FROM $BASE_IMAGE as base
 
 # fetch sources
 RUN mkdir -p /ws \
-  && BRANCH_NAME=$ROS_DISTRO && if [ "$ROS_DISTRO" = "rolling" ] || [ "$ROS_DISTRO" = "lyrical" ]; then BRANCH_NAME=main; fi \
+  && BRANCH_NAME=$ROS_DISTRO && if [ "$ROS_DISTRO" = "rolling" ]; then BRANCH_NAME=main; fi \
   && curl -L https://github.com/open-rmf/rmf-web/archive/$BRANCH_NAME.tar.gz -o rmf_web.tar.gz \
   && tar zxf rmf_web.tar.gz -C /ws --strip-components=1
 

--- a/.github/demo-dashboard/Dockerfile
+++ b/.github/demo-dashboard/Dockerfile
@@ -16,7 +16,7 @@ RUN pnpm runtime set node lts -g
 
 # fetch sources
 RUN mkdir -p /ws \
-  && BRANCH_NAME=$ROS_DISTRO && if [ "$ROS_DISTRO" = "rolling" ] || [ "$ROS_DISTRO" = "lyrical" ]; then BRANCH_NAME=main; fi \
+  && BRANCH_NAME=$ROS_DISTRO && if [ "$ROS_DISTRO" = "rolling" ]; then BRANCH_NAME=main; fi \
   && curl -L https://github.com/open-rmf/rmf-web/archive/$BRANCH_NAME.tar.gz -o rmf_web.tar.gz \
   && tar zxf rmf_web.tar.gz -C /ws --strip-components=1
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,6 @@ on:
   schedule:
     # 2am SGT
     - cron: '0 18 * * *'
-  pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -31,7 +30,7 @@ jobs:
           push: true
           build-args: |
             ROS_DISTRO=${{ matrix.ros_distribution }}
-          tags: ghcr.io/${{ github.repository }}/minimal-rmf:testing-${{ matrix.ros_distribution }}-nightly
+          tags: ghcr.io/${{ github.repository }}/minimal-rmf:${{ matrix.ros_distribution }}-nightly
           context: .github/minimal-rmf
   build-dashboard-image:
     needs: build-minimal-rmf-docker-images
@@ -56,9 +55,9 @@ jobs:
         with:
           push: true
           build-args: |
-            BASE_IMAGE=ghcr.io/${{ github.repository }}/minimal-rmf:testing-${{ matrix.ros_distribution }}-nightly
+            BASE_IMAGE=ghcr.io/${{ github.repository }}/minimal-rmf:${{ matrix.ros_distribution }}-nightly
             ROS_DISTRO=${{ matrix.ros_distribution }}
-          tags: ghcr.io/${{ github.repository }}/demo-dashboard:testing-${{ matrix.ros_distribution }}-nightly
+          tags: ghcr.io/${{ github.repository }}/demo-dashboard:${{ matrix.ros_distribution }}-nightly
           context: .github/demo-dashboard
   build-api-server-image:
     needs: build-minimal-rmf-docker-images
@@ -84,9 +83,9 @@ jobs:
           push: true
           build-args: |
             ROS_DISTRO=${{ matrix.ros_distribution }}
-            BASE_IMAGE=ghcr.io/${{ github.repository }}/minimal-rmf:testing-${{ matrix.ros_distribution }}-nightly
+            BASE_IMAGE=ghcr.io/${{ github.repository }}/minimal-rmf:${{ matrix.ros_distribution }}-nightly
           tags: |
-            ghcr.io/${{ github.repository }}/api-server:testing-${{ matrix.ros_distribution }}-nightly
+            ghcr.io/${{ github.repository }}/api-server:${{ matrix.ros_distribution }}-nightly
             ${{ matrix.ros_distribution == 'rolling' && format('ghcr.io/{0}/api-server:latest', github.repository) || null}}
           context: .github/api-server
   api-client:
@@ -98,7 +97,7 @@ jobs:
       matrix:
         ros_distribution: [jazzy, lyrical, rolling]
     container:
-      image: ghcr.io/${{ github.repository }}/minimal-rmf:testing-${{ matrix.ros_distribution }}-nightly
+      image: ghcr.io/${{ github.repository }}/minimal-rmf:${{ matrix.ros_distribution }}-nightly
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -132,7 +131,7 @@ jobs:
       matrix:
         ros_distribution: [jazzy, lyrical, rolling]
     container:
-      image: ghcr.io/${{ github.repository }}/minimal-rmf:testing-${{ matrix.ros_distribution }}-nightly
+      image: ghcr.io/${{ github.repository }}/minimal-rmf:${{ matrix.ros_distribution }}-nightly
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -168,7 +167,7 @@ jobs:
       matrix:
         ros_distribution: [jazzy, lyrical, rolling]
     container:
-      image: ghcr.io/${{ github.repository }}/minimal-rmf:testing-${{ matrix.ros_distribution }}-nightly
+      image: ghcr.io/${{ github.repository }}/minimal-rmf:${{ matrix.ros_distribution }}-nightly
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -203,7 +202,7 @@ jobs:
       matrix:
         ros_distribution: [jazzy, lyrical, rolling]
     container:
-      image: ghcr.io/${{ github.repository }}/minimal-rmf:testing-${{ matrix.ros_distribution }}-nightly
+      image: ghcr.io/${{ github.repository }}/minimal-rmf:${{ matrix.ros_distribution }}-nightly
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -107,10 +107,10 @@ jobs:
         working-directory: packages/api-client
     steps:
       - name: Checkout main for rolling (and lyrical for now)
-        if: matrix.ros_distribution == 'rolling' || matrix.ros_distribution == 'lyrical'
+        if: matrix.ros_distribution == 'rolling'
         uses: actions/checkout@v5
       - name: Checkout ros_distribution branch
-        if: matrix.ros_distribution != 'rolling' && matrix.ros_distribution != 'lyrical'
+        if: matrix.ros_distribution != 'rolling'
         uses: actions/checkout@v5
         with:
           ref: ${{ matrix.ros_distribution }}
@@ -141,10 +141,10 @@ jobs:
         working-directory: packages/api-server
     steps:
       - name: Checkout main for rolling / lyrical
-        if: matrix.ros_distribution == 'rolling' || matrix.ros_distribution == 'lyrical'
+        if: matrix.ros_distribution == 'rolling'
         uses: actions/checkout@v5
       - name: Checkout ros_distribution branch
-        if: matrix.ros_distribution != 'rolling' && matrix.ros_distribution != 'lyrical'
+        if: matrix.ros_distribution != 'rolling'
         uses: actions/checkout@v5
         with:
           ref: ${{ matrix.ros_distribution }}
@@ -177,10 +177,10 @@ jobs:
         working-directory: packages/rmf-dashboard-framework
     steps:
       - name: Checkout main for rolling / lyrical
-        if: matrix.ros_distribution == 'rolling' || matrix.ros_distribution == 'lyrical'
+        if: matrix.ros_distribution == 'rolling'
         uses: actions/checkout@v5
       - name: Checkout ros_distribution branch
-        if: matrix.ros_distribution != 'rolling' && matrix.ros_distribution != 'lyrical'
+        if: matrix.ros_distribution != 'rolling'
         uses: actions/checkout@v5
         with:
           ref: ${{ matrix.ros_distribution }}
@@ -212,10 +212,10 @@ jobs:
         working-directory: packages/ros-translator
     steps:
       - name: Checkout main for rolling / lyrical
-        if: matrix.ros_distribution == 'rolling' || matrix.ros_distribution == 'lyrical'
+        if: matrix.ros_distribution == 'rolling'
         uses: actions/checkout@v5
       - name: Checkout ros_distribution branch
-        if: matrix.ros_distribution != 'rolling' && matrix.ros_distribution != 'lyrical'
+        if: matrix.ros_distribution != 'rolling'
         uses: actions/checkout@v5
         with:
           ref: ${{ matrix.ros_distribution }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     # 2am SGT
     - cron: '0 18 * * *'
+  pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -30,7 +31,7 @@ jobs:
           push: true
           build-args: |
             ROS_DISTRO=${{ matrix.ros_distribution }}
-          tags: ghcr.io/${{ github.repository }}/minimal-rmf:${{ matrix.ros_distribution }}-nightly
+          tags: ghcr.io/${{ github.repository }}/minimal-rmf:testing-${{ matrix.ros_distribution }}-nightly
           context: .github/minimal-rmf
   build-dashboard-image:
     needs: build-minimal-rmf-docker-images
@@ -55,9 +56,9 @@ jobs:
         with:
           push: true
           build-args: |
-            BASE_IMAGE=ghcr.io/${{ github.repository }}/minimal-rmf:${{ matrix.ros_distribution }}-nightly
+            BASE_IMAGE=ghcr.io/${{ github.repository }}/minimal-rmf:testing-${{ matrix.ros_distribution }}-nightly
             ROS_DISTRO=${{ matrix.ros_distribution }}
-          tags: ghcr.io/${{ github.repository }}/demo-dashboard:${{ matrix.ros_distribution }}-nightly
+          tags: ghcr.io/${{ github.repository }}/demo-dashboard:testing-${{ matrix.ros_distribution }}-nightly
           context: .github/demo-dashboard
   build-api-server-image:
     needs: build-minimal-rmf-docker-images
@@ -83,9 +84,9 @@ jobs:
           push: true
           build-args: |
             ROS_DISTRO=${{ matrix.ros_distribution }}
-            BASE_IMAGE=ghcr.io/${{ github.repository }}/minimal-rmf:${{ matrix.ros_distribution }}-nightly
+            BASE_IMAGE=ghcr.io/${{ github.repository }}/minimal-rmf:testing-${{ matrix.ros_distribution }}-nightly
           tags: |
-            ghcr.io/${{ github.repository }}/api-server:${{ matrix.ros_distribution }}-nightly
+            ghcr.io/${{ github.repository }}/api-server:testing-${{ matrix.ros_distribution }}-nightly
             ${{ matrix.ros_distribution == 'rolling' && format('ghcr.io/{0}/api-server:latest', github.repository) || null}}
           context: .github/api-server
   api-client:
@@ -97,7 +98,7 @@ jobs:
       matrix:
         ros_distribution: [jazzy, lyrical, rolling]
     container:
-      image: ghcr.io/${{ github.repository }}/minimal-rmf:${{ matrix.ros_distribution }}-nightly
+      image: ghcr.io/${{ github.repository }}/minimal-rmf:testing-${{ matrix.ros_distribution }}-nightly
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -131,7 +132,7 @@ jobs:
       matrix:
         ros_distribution: [jazzy, lyrical, rolling]
     container:
-      image: ghcr.io/${{ github.repository }}/minimal-rmf:${{ matrix.ros_distribution }}-nightly
+      image: ghcr.io/${{ github.repository }}/minimal-rmf:testing-${{ matrix.ros_distribution }}-nightly
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -167,7 +168,7 @@ jobs:
       matrix:
         ros_distribution: [jazzy, lyrical, rolling]
     container:
-      image: ghcr.io/${{ github.repository }}/minimal-rmf:${{ matrix.ros_distribution }}-nightly
+      image: ghcr.io/${{ github.repository }}/minimal-rmf:testing-${{ matrix.ros_distribution }}-nightly
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -202,7 +203,7 @@ jobs:
       matrix:
         ros_distribution: [jazzy, lyrical, rolling]
     container:
-      image: ghcr.io/${{ github.repository }}/minimal-rmf:${{ matrix.ros_distribution }}-nightly
+      image: ghcr.io/${{ github.repository }}/minimal-rmf:testing-${{ matrix.ros_distribution }}-nightly
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## CI for lyrical

Now that a `lyrical` branch has been created, we start running nightlies by checking out that branch

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI

Generated-by:
